### PR TITLE
Add a RawOverflowPage type and start to use it

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -51,6 +51,7 @@ library
     Database.LSMTree.Internal.Normal
     Database.LSMTree.Internal.PageAcc
     Database.LSMTree.Internal.PageAcc1
+    Database.LSMTree.Internal.RawOverflowPage
     Database.LSMTree.Internal.RawPage
     Database.LSMTree.Internal.Run
     Database.LSMTree.Internal.Run.BloomFilter
@@ -228,6 +229,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Lookup
     Test.Database.LSMTree.Internal.PageAcc
     Test.Database.LSMTree.Internal.PageAcc1
+    Test.Database.LSMTree.Internal.RawOverflowPage
     Test.Database.LSMTree.Internal.RawPage
     Test.Database.LSMTree.Internal.Run
     Test.Database.LSMTree.Internal.Run.BloomFilter

--- a/prototypes/FormatPage.hs
+++ b/prototypes/FormatPage.hs
@@ -536,7 +536,7 @@ instance Arbitrary PageLogical where
   arbitrary =
     frequency
       [ (1, (PageLogical . (:[])) <$>
-               scale (\n' -> ceiling (fromIntegral n' ** 1.8 :: Float)) arbitrary)
+               scale (\n' -> ceiling (fromIntegral n' ** 2.2 :: Float)) arbitrary)
       , (4, do n <- getSize
                scale (\n' -> ceiling (sqrt (fromIntegral n' :: Float))) $
                  go [] n pageSizeEmpty)

--- a/src/Database/LSMTree/Internal/Assertions.hs
+++ b/src/Database/LSMTree/Internal/Assertions.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE MagicHash #-}
 module Database.LSMTree.Internal.Assertions (
     assert,
     isValidSlice,
+    sameByteArray,
 ) where
 
 import           Control.Exception (assert)
-import           Data.Primitive.ByteArray (ByteArray, sizeofByteArray)
+import           Data.Primitive.ByteArray (ByteArray (..), sizeofByteArray)
+import           GHC.Exts (isTrue#, sameByteArray#)
 
 isValidSlice :: Int -> Int -> ByteArray -> Bool
 isValidSlice off len ba =
@@ -12,3 +15,7 @@ isValidSlice off len ba =
     len >= 0 &&
     (off + len) >= 0 && -- sum doesn't overflow
     (off + len) <= sizeofByteArray ba
+
+sameByteArray :: ByteArray -> ByteArray -> Bool
+sameByteArray (ByteArray ba1) (ByteArray ba2) =
+    isTrue# (sameByteArray# ba1 ba2)

--- a/src/Database/LSMTree/Internal/Assertions.hs
+++ b/src/Database/LSMTree/Internal/Assertions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP       #-}
 {-# LANGUAGE MagicHash #-}
 module Database.LSMTree.Internal.Assertions (
     assert,
@@ -7,7 +8,12 @@ module Database.LSMTree.Internal.Assertions (
 
 import           Control.Exception (assert)
 import           Data.Primitive.ByteArray (ByteArray (..), sizeofByteArray)
+#if MIN_VERSION_base(4,17,0)
 import           GHC.Exts (isTrue#, sameByteArray#)
+#else
+import           GHC.Exts (ByteArray#, MutableByteArray#, isTrue#,
+                     sameMutableByteArray#, unsafeCoerce#)
+#endif
 
 isValidSlice :: Int -> Int -> ByteArray -> Bool
 isValidSlice off len ba =
@@ -17,5 +23,13 @@ isValidSlice off len ba =
     (off + len) <= sizeofByteArray ba
 
 sameByteArray :: ByteArray -> ByteArray -> Bool
-sameByteArray (ByteArray ba1) (ByteArray ba2) =
-    isTrue# (sameByteArray# ba1 ba2)
+sameByteArray (ByteArray ba1#) (ByteArray ba2#) =
+#if MIN_VERSION_base(4,17,0)
+    isTrue# (sameByteArray# ba1# ba2#)
+#else
+    isTrue# (sameMutableByteArray# (unsafeCoerceByteArray# ba1#)
+                                   (unsafeCoerceByteArray# ba2#))
+  where
+    unsafeCoerceByteArray# :: ByteArray# -> MutableByteArray# s
+    unsafeCoerceByteArray# = unsafeCoerce#
+#endif

--- a/src/Database/LSMTree/Internal/BitMath.hs
+++ b/src/Database/LSMTree/Internal/BitMath.hs
@@ -28,6 +28,8 @@ module Database.LSMTree.Internal.BitMath (
     mod64,
     mul64,
     ceilDiv64,
+    -- * 4096, page size
+    roundUpToPageSize,
 ) where
 
 import           Data.Bits
@@ -150,3 +152,12 @@ mul64 x = unsafeShiftL x 6
 ceilDiv64 :: (Bits a, Num a) => a -> a
 ceilDiv64 i = unsafeShiftR (i + 63) 6
 {-# INLINE ceilDiv64 #-}
+
+-------------------------------------------------------------------------------
+-- 4096
+-------------------------------------------------------------------------------
+
+-- | assumes pageSize = 4096:
+roundUpToPageSize :: (Bits a, Num a) => a -> a
+roundUpToPageSize n =
+    ((n + 0x0fff) .&. complement 0x0fff)

--- a/src/Database/LSMTree/Internal/PageAcc1.hs
+++ b/src/Database/LSMTree/Internal/PageAcc1.hs
@@ -12,10 +12,11 @@ import qualified Data.Vector.Primitive as PV
 import           Data.Word (Word16, Word32, Word64)
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry (Entry (..))
+import           Database.LSMTree.Internal.RawOverflowPage
 import           Database.LSMTree.Internal.RawPage
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.Serialise.RawBytes (RawBytes (..))
-import           Database.LSMTree.Internal.Vector
+import qualified Database.LSMTree.Internal.Serialise.RawBytes as RawBytes
 
 pageSize :: Int
 pageSize = 4096
@@ -25,7 +26,7 @@ pageSize = 4096
 singletonPage
     :: SerialisedKey
     -> Entry SerialisedValue BlobSpan
-    -> (RawPage, RawBytes)
+    -> (RawPage, [RawOverflowPage])
 singletonPage k (Insert v) = runST $ do
     -- allocate bytearray
     ba <- P.newByteArray pageSize :: ST s (P.MutableByteArray s)
@@ -54,10 +55,12 @@ singletonPage k (Insert v) = runST $ do
     P.copyByteArray ba (32 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    return (makeRawPage ba' 0, RawBytes (mkPrimVector (voff+vlen') (vlen-vlen') vba))
+    let !page          = makeRawPage ba' 0
+        !overflowPages = rawBytesToOverflowPages (RawBytes.drop vlen' v')
+    return (page, overflowPages)
   where
-    SerialisedKey   (RawBytes (PV.Vector koff klen kba)) = k
-    SerialisedValue (RawBytes (PV.Vector voff vlen vba)) = v
+    SerialisedKey      (RawBytes (PV.Vector koff klen kba)) = k
+    SerialisedValue v'@(RawBytes (PV.Vector voff vlen vba)) = v
 
 singletonPage k (InsertWithBlob v (BlobSpan w64 w32)) = runST $ do
     -- allocate bytearray
@@ -89,10 +92,12 @@ singletonPage k (InsertWithBlob v (BlobSpan w64 w32)) = runST $ do
     P.copyByteArray ba (44 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    return (makeRawPage ba' 0, RawBytes (mkPrimVector (voff+vlen') (vlen-vlen') vba))
+    let !page          = makeRawPage ba' 0
+        !overflowPages = rawBytesToOverflowPages (RawBytes.drop vlen' v')
+    return (page, overflowPages)
   where
-    SerialisedKey   (RawBytes (PV.Vector koff klen kba)) = k
-    SerialisedValue (RawBytes (PV.Vector voff vlen vba)) = v
+    SerialisedKey      (RawBytes (PV.Vector koff klen kba)) = k
+    SerialisedValue v'@(RawBytes (PV.Vector voff vlen vba)) = v
 
 singletonPage k (Mupdate v) = runST $ do
     -- allocate bytearray
@@ -122,9 +127,11 @@ singletonPage k (Mupdate v) = runST $ do
     P.copyByteArray ba (32 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    return (makeRawPage ba' 0, RawBytes (mkPrimVector (voff+vlen') (vlen-vlen') vba))
+    let !page          = makeRawPage ba' 0
+        !overflowPages = rawBytesToOverflowPages (RawBytes.drop vlen' v')
+    return (page, overflowPages)
   where
-    SerialisedKey   (RawBytes (PV.Vector koff klen kba)) = k
-    SerialisedValue (RawBytes (PV.Vector voff vlen vba)) = v
+    SerialisedKey      (RawBytes (PV.Vector koff klen kba)) = k
+    SerialisedValue v'@(RawBytes (PV.Vector voff vlen vba)) = v
 
 singletonPage _ Delete = error "singletonPage: unexpected Delete entry"

--- a/src/Database/LSMTree/Internal/PageAcc1.hs
+++ b/src/Database/LSMTree/Internal/PageAcc1.hs
@@ -29,7 +29,7 @@ singletonPage
     -> (RawPage, [RawOverflowPage])
 singletonPage k (Insert v) = runST $ do
     -- allocate bytearray
-    ba <- P.newByteArray pageSize :: ST s (P.MutableByteArray s)
+    ba <- P.newPinnedByteArray pageSize :: ST s (P.MutableByteArray s)
     P.fillByteArray ba 0 pageSize 0
 
     -- directory: 64 bytes
@@ -55,7 +55,7 @@ singletonPage k (Insert v) = runST $ do
     P.copyByteArray ba (32 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    let !page          = makeRawPage ba' 0
+    let !page          = unsafeMakeRawPage ba' 0
         !overflowPages = rawBytesToOverflowPages (RawBytes.drop vlen' v')
     return (page, overflowPages)
   where
@@ -64,7 +64,7 @@ singletonPage k (Insert v) = runST $ do
 
 singletonPage k (InsertWithBlob v (BlobSpan w64 w32)) = runST $ do
     -- allocate bytearray
-    ba <- P.newByteArray pageSize :: ST s (P.MutableByteArray s)
+    ba <- P.newPinnedByteArray pageSize :: ST s (P.MutableByteArray s)
     P.fillByteArray ba 0 pageSize 0
 
     -- directory: 64 bytes
@@ -92,7 +92,7 @@ singletonPage k (InsertWithBlob v (BlobSpan w64 w32)) = runST $ do
     P.copyByteArray ba (44 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    let !page          = makeRawPage ba' 0
+    let !page          = unsafeMakeRawPage ba' 0
         !overflowPages = rawBytesToOverflowPages (RawBytes.drop vlen' v')
     return (page, overflowPages)
   where
@@ -101,7 +101,7 @@ singletonPage k (InsertWithBlob v (BlobSpan w64 w32)) = runST $ do
 
 singletonPage k (Mupdate v) = runST $ do
     -- allocate bytearray
-    ba <- P.newByteArray pageSize :: ST s (P.MutableByteArray s)
+    ba <- P.newPinnedByteArray pageSize :: ST s (P.MutableByteArray s)
     P.fillByteArray ba 0 pageSize 0
 
     -- directory: 64 bytes
@@ -127,7 +127,7 @@ singletonPage k (Mupdate v) = runST $ do
     P.copyByteArray ba (32 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    let !page          = makeRawPage ba' 0
+    let !page          = unsafeMakeRawPage ba' 0
         !overflowPages = rawBytesToOverflowPages (RawBytes.drop vlen' v')
     return (page, overflowPages)
   where

--- a/src/Database/LSMTree/Internal/PageAcc1.hs
+++ b/src/Database/LSMTree/Internal/PageAcc1.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Create a single value page

--- a/src/Database/LSMTree/Internal/RawOverflowPage.hs
+++ b/src/Database/LSMTree/Internal/RawOverflowPage.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE BangPatterns   #-}
+{-# LANGUAGE DeriveFunctor  #-}
+{-# LANGUAGE NamedFieldPuns #-}
+module Database.LSMTree.Internal.RawOverflowPage (
+    RawOverflowPage,
+    makeRawOverflowPage,
+    unsafeMakeRawOverflowPage,
+    rawOverflowPageRawBytes,
+    rawBytesToOverflowPages,
+) where
+
+import           Control.DeepSeq (NFData (rnf))
+import           Control.Monad (when)
+import           Data.Primitive.ByteArray (ByteArray (..), copyByteArray,
+                     fillByteArray, isByteArrayPinned, newPinnedByteArray,
+                     runByteArray)
+import qualified Data.Vector.Primitive as P
+import           Database.LSMTree.Internal.Assertions
+import           Database.LSMTree.Internal.BitMath (roundUpToPageSize)
+import           Database.LSMTree.Internal.Serialise.RawBytes (RawBytes (..))
+import qualified Database.LSMTree.Internal.Serialise.RawBytes as RB
+
+-------------------------------------------------------------------------------
+-- RawOverflowPage type
+-------------------------------------------------------------------------------
+
+-- | When a key\/op pair is too large to fit in a single disk page, the
+-- representation is split into a normal page, and one or more overflow pages.
+-- The normal 'RawPage' follows the run page format, and contains the key,
+-- optional blob reference and a prefix of the value, while the overflow pages
+-- contain the suffix of a large value that didn't fit in the normal page.
+--
+-- Each overflow page is the same size as normal pages (currently 4096 only).
+--
+data RawOverflowPage = RawOverflowPage
+                         !Int        -- ^ offset in Word8s.
+                         !ByteArray
+  deriving (Show)
+
+-- | This invariant is the same as for 'RawPage', but there is no alignment
+-- constraint. This is for two reasons: 1. we don't need alignment, because
+-- the page has no structure that we need to read with aligned memory
+-- operations; 2. we don't want alignment because we want to convert the suffix
+-- of serialised values (as 'RawBytes') into a 'RawOverflowPage' without
+-- copying, and a suffix can start at an arbitrary offset.
+--
+invariant :: RawOverflowPage -> Bool
+invariant (RawOverflowPage off ba) = and
+    [ isValidSlice off 4096 ba    -- valid bytearray slice for length 4096
+    , isByteArrayPinned ba        -- bytearray must be pinned (for I/O)
+    ]
+
+instance NFData RawOverflowPage where
+  rnf (RawOverflowPage _ _) = ()
+
+-- | This instance assumes pages are 4096 bytes in size
+instance Eq RawOverflowPage where
+    r1 == r2 = rawOverflowPageRawBytes r1 == rawOverflowPageRawBytes r2
+
+rawOverflowPageRawBytes :: RawOverflowPage -> RawBytes
+rawOverflowPageRawBytes (RawOverflowPage off ba) =
+    RB.fromByteArray off 4096 ba
+
+-- | Create a 'RawOverflowPage'.
+--
+-- The length must be 4096 or less.
+--
+-- This function will copy data if the byte array is not pinned, or the length
+-- is strictly less than 4096.
+--
+makeRawOverflowPage
+    :: ByteArray  -- ^ bytearray
+    -> Int        -- ^ offset in bytes into the bytearray
+    -> Int        -- ^ length in bytes, must be @>= 0 && <= 4096@
+    -> RawOverflowPage
+makeRawOverflowPage ba off len
+    | len == 4096
+    , let page = RawOverflowPage off ba
+    , invariant page
+    = page
+
+    | otherwise
+    = makeRawOverflowPageCopy ba off len
+
+makeRawOverflowPageCopy
+    :: ByteArray  -- ^ bytearray
+    -> Int        -- ^ offset in bytes into the bytearray
+    -> Int        -- ^ length in bytes
+    -> RawOverflowPage
+makeRawOverflowPageCopy ba off len =
+    assert (isValidSlice off len ba && len <= 4096) $
+    (\page -> assert (invariant page) page) $
+    RawOverflowPage 0 $ runByteArray $ do
+      mba <- newPinnedByteArray 4096
+      let suffixlen = min 4096 len -- would only do anything with assertions off
+      copyByteArray mba 0 ba off suffixlen
+      when (suffixlen < 4096) $ fillByteArray mba suffixlen (4096-suffixlen) 0
+      return mba
+
+-- | Create a 'RawOverflowPage' without copying. The byte array and offset must
+-- satisfy the invariant for 'RawOverflowPage'.
+--
+unsafeMakeRawOverflowPage
+    :: ByteArray  -- ^ bytearray, must be pinned and contain 4096 bytes (after offset)
+    -> Int        -- ^ offset in bytes
+    -> RawOverflowPage
+unsafeMakeRawOverflowPage ba off =
+    assert (invariant page) page
+  where
+    page = RawOverflowPage off ba
+
+-- | Convert 'RawBytes' representing the \"overflow\" part of a value into one
+-- or more 'RawOverflowPage's.
+--
+-- This will avoid copying where possible.
+--
+rawBytesToOverflowPages :: RawBytes -> [RawOverflowPage]
+rawBytesToOverflowPages (RawBytes (P.Vector off len ba))
+  | isByteArrayPinned ba
+  = rawBytesToOverflowPagesPinned off len ba
+  | otherwise
+  = rawBytesToOverflowPagesUnpinned off len ba
+
+rawBytesToOverflowPagesPinned :: Int -> Int -> ByteArray -> [RawOverflowPage]
+rawBytesToOverflowPagesPinned !off !len !ba
+      | len >= 4096
+      , let !page = unsafeMakeRawOverflowPage ba off
+      = page : rawBytesToOverflowPagesPinned (off+4096) (len-4096) ba
+
+      | len <= 0
+      = []
+
+      | otherwise -- > 0 && < 4096
+                  -- have to copy the partial last page
+      , let !page = makeRawOverflowPageCopy ba off len
+      = page : []
+
+-- | Not pinned, in principle shouldn't happen much because if the value
+-- is big enough to overflow then it's big enough to be pinned.
+-- It is possible however if a page has a huge key and a small value.
+--
+-- Unfortunately, with GHC versions 9.6.x we also get this because the meaning
+-- of pinned has changed. Sigh.
+-- See <https://gitlab.haskell.org/ghc/ghc/-/issues/22255>
+--
+rawBytesToOverflowPagesUnpinned :: Int -> Int -> ByteArray -> [RawOverflowPage]
+rawBytesToOverflowPagesUnpinned !off !len !ba =
+    let !lenPages = roundUpToPageSize len
+        ba'       = runByteArray $ do
+                      mba <- newPinnedByteArray lenPages
+                      copyByteArray mba 0 ba off len
+                      fillByteArray mba len (lenPages-len) 0
+                      return mba
+        pages     = rawBytesToOverflowPagesPinned 0 lenPages ba'
+        -- We've arranged to do the conversion without any extra copying,
+        -- so assert that we got that right:
+     in assert (all (isSliceNotCopy ba') pages)
+        pages
+  where
+    isSliceNotCopy :: ByteArray -> RawOverflowPage -> Bool
+    isSliceNotCopy ba1 (RawOverflowPage _ ba2) = sameByteArray ba1 ba2
+

--- a/src/Database/LSMTree/Internal/Serialise/RawBytes.hs
+++ b/src/Database/LSMTree/Internal/Serialise/RawBytes.hs
@@ -30,11 +30,13 @@ module Database.LSMTree.Internal.Serialise.RawBytes (
   , size
     -- ** Extracting subvectors (slicing)
   , take
+  , drop
   , topBits16
   , sliceBits32
     -- * Construction
     -- | Use 'Semigroup' and 'Monoid' operations
     -- * Conversions
+  , fromVector
   , fromByteArray
     -- ** Lists
   , pack
@@ -61,7 +63,7 @@ import           Database.LSMTree.Internal.ByteString (shortByteStringFromTo,
                      tryGetByteArray)
 import           Database.LSMTree.Internal.Run.BloomFilter (Hashable (..))
 import           Database.LSMTree.Internal.Vector
-import           Prelude hiding (take)
+import           Prelude hiding (drop, take)
 
 import           GHC.Exts
 import           GHC.Stack
@@ -130,6 +132,10 @@ size = coerce PV.length
 -- | \( O(1) \)
 take :: Int -> RawBytes -> RawBytes
 take = coerce PV.take
+
+-- | \( O(1) \)
+drop :: Int -> RawBytes -> RawBytes
+drop = coerce PV.drop
 
 -- | @'topBits16' n rb@ slices the first @n@ bits from the /top/ of the raw
 -- bytes @rb@. Returns the string of bits as a 'Word16'.
@@ -208,6 +214,10 @@ instance Monoid RawBytes where
 {-------------------------------------------------------------------------------
   Conversions
 -------------------------------------------------------------------------------}
+
+-- | \( O(1) \)
+fromVector :: PV.Vector Word8 -> RawBytes
+fromVector v = RawBytes v
 
 -- | \( O(1) \)
 fromByteArray :: Int -> Int -> ByteArray -> RawBytes

--- a/src/utils/Database/LSMTree/Generators.hs
+++ b/src/utils/Database/LSMTree/Generators.hs
@@ -542,7 +542,7 @@ chunkSizeInvariant (ChunkSize csize) = chunkSizeLB <= csize && csize <= chunkSiz
 
 instance Arbitrary RawBytes where
   arbitrary = genRawBytes >>= genSlice
-  shrink rb = shrinkRawBytes rb ++ shrinkSlice rb
+  shrink rb = shrinkSlice rb ++ shrinkRawBytes rb
 
 genRawBytesN :: Int -> Gen RawBytes
 genRawBytesN n =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -9,6 +9,7 @@ import qualified Test.Database.LSMTree.Internal.Entry
 import qualified Test.Database.LSMTree.Internal.Lookup
 import qualified Test.Database.LSMTree.Internal.PageAcc
 import qualified Test.Database.LSMTree.Internal.PageAcc1
+import qualified Test.Database.LSMTree.Internal.RawOverflowPage
 import qualified Test.Database.LSMTree.Internal.RawPage
 import qualified Test.Database.LSMTree.Internal.Run
 import qualified Test.Database.LSMTree.Internal.Run.BloomFilter
@@ -32,6 +33,7 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Internal.PageAcc.tests
     , Test.Database.LSMTree.Internal.PageAcc1.tests
     , Test.Database.LSMTree.Internal.RawPage.tests
+    , Test.Database.LSMTree.Internal.RawOverflowPage.tests
     , Test.Database.LSMTree.Internal.Run.tests
     , Test.Database.LSMTree.Internal.Run.BloomFilter.tests
     , Test.Database.LSMTree.Internal.Run.Construction.tests

--- a/test/Test/Database/LSMTree/Internal/PageAcc1.hs
+++ b/test/Test/Database/LSMTree/Internal/PageAcc1.hs
@@ -40,22 +40,26 @@ prototype
     -> Maybe Proto.BlobRef
     -> Property
 prototype k v br =
-    label (show (BS.length lbytes)) $
-    propEqualRawPages lhs rhs .&&. lbytes === RB.toByteString rbytes
+    label (show (length loverflow) ++ " overflow pages") $
+         propEqualRawPages lhs rhs
+    .&&. counterexample "overflow pages do not match"
+           (loverflow === roverflow)
   where
-    (lhs, lbytes) = toRawPage $ Proto.PageLogical [(k, Proto.Insert v, br)]
-    (rhs, rbytes) = singletonPage (convKey k) (convOp (Proto.Insert v) br)
+    (lhs, loverflow) = toRawPage $ Proto.PageLogical [(k, Proto.Insert v, br)]
+    (rhs, roverflow) = singletonPage (convKey k) (convOp (Proto.Insert v) br)
 
 prototypeU
     :: Proto.Key
     -> Proto.Value
     -> Property
 prototypeU k v =
-    label (show (BS.length lbytes)) $
-    propEqualRawPages lhs rhs .&&. lbytes === RB.toByteString rbytes
+    label (show (length loverflow) ++ " overflow pages") $
+         propEqualRawPages lhs rhs
+    .&&. counterexample "overflow pages do not match"
+           (loverflow === roverflow)
   where
-    (lhs, lbytes) = toRawPage $ Proto.PageLogical [(k, Proto.Mupsert v, Nothing)]
-    (rhs, rbytes) = singletonPage (convKey k) (convOp (Proto.Mupsert v) Nothing)
+    (lhs, loverflow) = toRawPage $ Proto.PageLogical [(k, Proto.Mupsert v, Nothing)]
+    (rhs, roverflow) = singletonPage (convKey k) (convOp (Proto.Mupsert v) Nothing)
 
 convKey :: Proto.Key -> SerialisedKey
 convKey (Proto.Key k) = SerialisedKey $ RB.fromByteString k

--- a/test/Test/Database/LSMTree/Internal/RawOverflowPage.hs
+++ b/test/Test/Database/LSMTree/Internal/RawOverflowPage.hs
@@ -1,0 +1,56 @@
+module Test.Database.LSMTree.Internal.RawOverflowPage (
+    -- * Main test tree
+    tests,
+) where
+
+import qualified Data.Primitive.ByteArray as BA
+import qualified Data.Vector.Primitive as PV
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck
+
+import           Database.LSMTree.Generators (LargeRawBytes (..))
+import           Database.LSMTree.Internal.RawOverflowPage
+import           Database.LSMTree.Internal.Serialise.RawBytes (RawBytes (..))
+import qualified Database.LSMTree.Internal.Serialise.RawBytes as RawBytes
+
+tests :: TestTree
+tests =
+  testGroup "Database.LSMTree.Internal.RawOverflowPage"
+    [ testProperty "RawBytes prefix to RawOverflowPage"
+                   prop_rawBytesToRawOverflowPage
+    , testProperty "RawBytes to [RawOverflowPage]"
+                   prop_rawBytesToRawOverflowPages
+    ]
+
+-- | Converting up to the first 4096 bytes of a 'RawBytes' to an
+-- 'RawOverflowPage' and back gives us the original, padded with zeros to a
+-- multiple of the page size.
+prop_rawBytesToRawOverflowPage :: LargeRawBytes -> Property
+prop_rawBytesToRawOverflowPage
+  (LargeRawBytes bytes@(RawBytes (PV.Vector off len ba))) =
+    label (if RawBytes.size bytes >= 4096 then "large" else "small") $
+    label (if BA.isByteArrayPinned ba then "pinned" else "unpinned") $
+    label (if off == 0 then "offset 0" else "offset non-0") $
+
+        rawOverflowPageRawBytes (makeRawOverflowPage ba off (min len 4096))
+    === RawBytes.take 4096 bytes <> padding
+  where
+    padding    = RawBytes.fromVector (PV.replicate paddinglen 0)
+    paddinglen = 4096 - (min len 4096)
+
+
+-- | Converting the bytes to @[RawOverflowPage]@ and back gives us the original
+-- bytes, padded with zeros to a multiple of the page size.
+--
+prop_rawBytesToRawOverflowPages :: LargeRawBytes -> Property
+prop_rawBytesToRawOverflowPages (LargeRawBytes bytes) =
+    mconcat (map rawOverflowPageRawBytes pages) === bytes <> padding
+  where
+    pages      = rawBytesToOverflowPages bytes
+    padding    = RawBytes.fromVector (PV.replicate paddinglen 0)
+    paddinglen = let trailing = RawBytes.size bytes `mod` 4096 in
+                 if trailing == 0 then 0 else 4096 - trailing
+

--- a/test/Test/Database/LSMTree/Internal/RawPage.hs
+++ b/test/Test/Database/LSMTree/Internal/RawPage.hs
@@ -5,13 +5,13 @@ module Test.Database.LSMTree.Internal.RawPage (
     tests,
 ) where
 
+import           Control.DeepSeq (deepseq)
 import qualified Data.ByteString as BS
 import           Data.Maybe (isJust)
 import           Data.Primitive.ByteArray (byteArrayFromList)
 import qualified Data.Vector as V
 import qualified Data.Vector.Primitive as P
 import           Data.Word (Word16, Word64)
-import           Control.DeepSeq (deepseq)
 import           GHC.Word (byteSwap16)
 import           Test.QuickCheck.Instances ()
 import           Test.Tasty (TestTree, testGroup)

--- a/test/Test/Database/LSMTree/Internal/RawPage.hs
+++ b/test/Test/Database/LSMTree/Internal/RawPage.hs
@@ -21,6 +21,7 @@ import           Test.Util.RawPage
 
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import qualified Database.LSMTree.Internal.Entry as Entry
+import           Database.LSMTree.Internal.RawOverflowPage
 import           Database.LSMTree.Internal.RawPage
 import           Database.LSMTree.Internal.Serialise
 import qualified Database.LSMTree.Internal.Serialise.RawBytes as RB
@@ -43,7 +44,7 @@ tests = testGroup "Database.LSMTree.Internal.RawPage"
 
         let page = makeRawPage (byteArrayFromList bytes) 0
 
-        page @=? fst (toRawPage (PageLogical []))
+        (page, []) @=? toRawPage (PageLogical [])
         rawPageNumKeys page @=? 0
         rawPageNumBlobs page @=? 0
         rawPageKeyOffsets page @=? P.fromList [10]
@@ -91,7 +92,7 @@ tests = testGroup "Database.LSMTree.Internal.RawPage"
 
         let page = makeRawPage (byteArrayFromList bytes) 0
 
-        page @=? fst (toRawPage (PageLogical [(Key "\x42\x43", Insert (Value "\x88\x99"), Just (BlobRef 0xff 0xfe))]))
+        (page, []) @=? toRawPage (PageLogical [(Key "\x42\x43", Insert (Value "\x88\x99"), Just (BlobRef 0xff 0xfe))])
         rawPageNumKeys page @=? 1
         rawPageNumBlobs page @=? 1
         rawPageKeyOffsets page @=? P.fromList [44, 46]
@@ -116,7 +117,7 @@ tests = testGroup "Database.LSMTree.Internal.RawPage"
 
         let page = makeRawPage (byteArrayFromList bytes) 0
 
-        page @=? fst (toRawPage (PageLogical [(Key "\x42\x43", Delete, Nothing)]))
+        (page, []) @=? toRawPage (PageLogical [(Key "\x42\x43", Delete, Nothing)])
         rawPageNumKeys page @=? 1
         rawPageNumBlobs page @=? 0
         rawPageKeyOffsets page @=? P.fromList [32, 34]
@@ -142,7 +143,7 @@ tests = testGroup "Database.LSMTree.Internal.RawPage"
 
         let page = makeRawPage (byteArrayFromList bytes) 0
 
-        page @=? fst (toRawPage (PageLogical [(Key "\x42\x43", Mupsert (Value "\x44\x45"), Nothing), (Key "\x52\x53", Mupsert (Value "\x54\x55"), Nothing)]))
+        (page, []) @=? toRawPage (PageLogical [(Key "\x42\x43", Mupsert (Value "\x44\x45"), Nothing), (Key "\x52\x53", Mupsert (Value "\x54\x55"), Nothing)])
         rawPageNumKeys page @=? 2
         rawPageNumBlobs page @=? 0
         rawPageKeyOffsets page @=? P.fromList [34, 36, 38]
@@ -262,43 +263,84 @@ prop_entries_all page@(PageLogical xs) bs =
         Just (Delete, _)                            -> LookupEntry Entry.Delete
 
 prop_big_insert :: Key -> Maybe BlobRef -> Property
-prop_big_insert k blobref =
-    rawPageLookup rawpage k' === case blobref of
-        Nothing            -> LookupEntryOverflow (Entry.Insert (SerialisedValue $ RB.fromByteString (BS.take size v))) (fromIntegral sfxSize)
-        Just (BlobRef x y) -> LookupEntryOverflow (Entry.InsertWithBlob (SerialisedValue $ RB.fromByteString (BS.take size v)) (BlobSpan x y)) (fromIntegral sfxSize)
+prop_big_insert k mblobref =
+    case rawPageLookup rawpage k' of
+      LookupEntryOverflow entry suffixlen ->
+        equivalentOpEntry (Insert v) mblobref
+                          entry overflowPagesBS (fromIntegral suffixlen)
+
+      other -> counterexample (show other) False
   where
-    page = PageLogical [(k, Insert (Value v), blobref)]
-    (rawpage, sfx) = toRawPage page
+    page = PageLogical [(k, Insert v, mblobref)]
+    (rawpage, overflowPages) = toRawPage page
+    overflowPagesBS = overflowPagesToByteString overflowPages
     k' = SerialisedKey $ RB.fromByteString (unKey k)
 
     -- original value
-    v = BS.replicate 5000 42
-
-    size :: Int
-    size = 5000 - sfxSize
-
-    sfxSize :: Int
-    sfxSize = BS.length sfx
+    v = Value (BS.replicate 5000 42)
 
 prop_single_entry :: Key -> Operation -> Maybe BlobRef -> Property
-prop_single_entry k op blobref = label (show $ BS.null sfx) $
-    rawPageLookup rawpage k' === mkLookupEntry case op of
-        Insert (Value v)       -> case blobref of
-            Nothing            -> Entry.Insert (SerialisedValue $ RB.fromByteString (trim v))
-            Just (BlobRef x y) -> Entry.InsertWithBlob (SerialisedValue $ RB.fromByteString (trim v)) (BlobSpan x y)
-        Mupsert (Value v)      -> Entry.Mupdate (SerialisedValue $ RB.fromByteString (trim v))
-        Delete                 -> Entry.Delete
+prop_single_entry k op mblobref = label (show $ null overflowPages) $
+    case rawPageLookup rawpage k' of
+      LookupEntryNotPresent ->
+        counterexample "LookupEntryNotPresent" False
+
+      LookupEntry e ->
+        equivalentOpEntry op mblobref
+                          e overflowPagesBS 0
+
+      LookupEntryOverflow e suffixlen ->
+        equivalentOpEntry op mblobref
+                          e overflowPagesBS (fromIntegral suffixlen)
   where
-    page = PageLogical [(k, op, blobref)]
-    (rawpage, sfx) = toRawPage page
+    page = PageLogical [(k, op, mblobref)]
+    (rawpage, overflowPages) = toRawPage page
+    overflowPagesBS = overflowPagesToByteString overflowPages
     k' = SerialisedKey $ RB.fromByteString (unKey k)
 
-    trim :: BS.ByteString -> BS.ByteString
-    trim = BS.dropEnd sfxSize
+-- | Check that an 'Operation' and optional 'Blobref' (from the reference
+-- implementation) is equivalent to (from the real implementation) the
+-- combination of an 'Entry', containing the prefix of a value, plus a given
+-- length suffix from the overflow pages.
+equivalentOpEntry :: Operation -> Maybe BlobRef
+                  -> Entry.Entry SerialisedValue BlobSpan
+                  -> BS.ByteString
+                  -> Int
+                  -> Property
+equivalentOpEntry (Insert v) Nothing
+                  (Entry.Insert v') overflowPagesBS suffixlen =
+    equivalentValue v v' overflowPagesBS suffixlen
 
-    sfxSize :: Int
-    sfxSize = BS.length sfx
+equivalentOpEntry (Insert v) (Just blobref)
+                  (Entry.InsertWithBlob v' blobspan) overflowPagesBS suffixlen =
+    equivalentValue v v' overflowPagesBS suffixlen .&&.
+    equivalentBlobRefSpan blobref blobspan
 
-    mkLookupEntry entry
-      | sfxSize > 0 = LookupEntryOverflow entry (fromIntegral sfxSize)
-      | otherwise   = LookupEntry         entry
+equivalentOpEntry (Mupsert v) _
+                  (Entry.Mupdate v') overflowPagesBS suffixlen =
+    equivalentValue v v' overflowPagesBS suffixlen
+
+equivalentOpEntry Delete _ Entry.Delete _ 0 =
+    property True
+
+equivalentOpEntry op mblobref e _overflowPagesBS suffixlen =
+    counterexample (show (op, mblobref) ++ " not equivalent to "
+                                        ++ show (e, suffixlen))
+                   False
+
+-- | Check that a value is equality to the combination of a 'SerialisedValue'
+-- prefix, plus a given length of suffix from the overflow pages.
+--
+equivalentValue :: Value -> SerialisedValue -> BS.ByteString -> Int -> Property
+equivalentValue (Value v) (SerialisedValue v') overflowPagesBS suffixlen =
+    v === RB.toByteString v' <> BS.take suffixlen overflowPagesBS
+
+equivalentBlobRefSpan :: BlobRef -> BlobSpan -> Property
+equivalentBlobRefSpan (BlobRef x y) (BlobSpan x' y') =
+    (x, y) === (x', y')
+
+overflowPagesToByteString :: [RawOverflowPage] -> BS.ByteString
+overflowPagesToByteString =
+    RB.toByteString
+  . mconcat
+  . map rawOverflowPageRawBytes


### PR DESCRIPTION
This is preparation for integrating the `MPageAcc` type in run construction.

We add a `RawOverflowPage` type and tests, and we change `PageAcc1.singletonPage` to return `(RawPage, [RawOverflowPage])` rather than `(RawPage, RawBytes)`.