### PR TITLE
Fix hanging test suite `fs-api-blockio-test`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -39,15 +39,11 @@ package lsm-tree
   -- relevant mostly only for development & testing
   ghc-options: -fno-ignore-asserts
 
-  -- TODO: temporarily disable asynchronous HasBlockIO on Linux-based systems.
-  -- See lsm-tree#129.
-  flags: +serialblockio
-
 if(os(linux))
   source-repository-package
     type: git
     location: https://github.com/well-typed/blockio-uring
-    tag: 233aba90e86041657bb8b96b41917b34f49be7c8
+    tag: c07e1b0c61203e7fc3a944b4070522bc53464fbd
 
 -- fs-api with support for I/O using user-supplied buffers
 source-repository-package


### PR DESCRIPTION
Update the `blockio-uring` s-r-p to include the bugfix from https://github.com/well-typed/blockio-uring/pull/10, and disable the `serialblockio` flag in `cabal.project`