### PR TITLE
Dont mavx2 on OSX

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,6 +36,14 @@ jobs:
             os: macOS-latest
 
     steps:
+    - name: CPU info (macOS)
+      if: matrix.os == 'macOS-latest'
+      run: sysctl -a machdep.cpu
+
+    - name: CPU info (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: cat /proc/cpuinfo
+
     - name: Checkout repository
       uses: actions/checkout@v3
 

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -91,7 +91,7 @@ library xxhash
 
   exposed-modules:  XXH3
 
-  if arch(x86_64)
+  if (arch(x86_64) && !os(osx))
     -- Cabal doesn't pass cc-options to "ordinary" Haskell source compilation
     -- https://github.com/haskell/cabal/issues/9801
     ghc-options: -optc=-mavx2 -optc=-O3


### PR DESCRIPTION
I'm curious whether CI will pass if we dont avx2