### PR TITLE
Use -fcheck-prim-bounds in lsm-tree, primitive & vector

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -39,6 +39,18 @@ package lsm-tree
   -- relevant mostly only for development & testing
   ghc-options: -fno-ignore-asserts
 
+  -- For extra testing of low-level operations use bounds checks on bytearray
+  -- primitives.
+  ghc-options: -fcheck-prim-bounds
+
+-- For extra testing of low-level operations use bounds checks on bytearray
+-- primitives from select dependencies.
+package primitive
+  ghc-options: -fcheck-prim-bounds
+
+package vector
+  ghc-options: -fcheck-prim-bounds
+
 if(os(linux))
   source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -39,17 +39,17 @@ package lsm-tree
   -- relevant mostly only for development & testing
   ghc-options: -fno-ignore-asserts
 
-  -- For extra testing of low-level operations use bounds checks on bytearray
-  -- primitives.
-  ghc-options: -fcheck-prim-bounds
+-- Enable -fcheck-prim-bounds
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/21054
+if impl(ghc >=9.4.6 && <9.5 || >=9.6.3)
+  package lsm-tree
+    ghc-options: -fcheck-prim-bounds
 
--- For extra testing of low-level operations use bounds checks on bytearray
--- primitives from select dependencies.
-package primitive
-  ghc-options: -fcheck-prim-bounds
+  package primitive
+    ghc-options: -fcheck-prim-bounds
 
-package vector
-  ghc-options: -fcheck-prim-bounds
+  package vector
+    ghc-options: -fcheck-prim-bounds
 
 if(os(linux))
   source-repository-package

--- a/src/Database/LSMTree/Internal/Run/Index/Compact.hs
+++ b/src/Database/LSMTree/Internal/Run/Index/Compact.hs
@@ -698,7 +698,7 @@ fromSBS (SBS ba') = do
     let ba = ByteArray ba'
     let len8 = sizeofByteArray ba
     when (mod8 len8 /= 0) $ Left "Length is not multiple of 64 bit"
-    when (len8 < 36) $ Left "Doesn't contain header and footer"
+    when (len8 < 32) $ Left "Doesn't contain header and footer"
 
     -- check version
     let version = indexByteArray ba 0 :: Word32
@@ -767,7 +767,7 @@ getTieBreaker ::
      ByteArray -> Offset64
   -> Either String (Offset64, Map SerialisedKey PageNo)
 getTieBreaker ba = \off -> do
-    when (off >= sizeofByteArray ba) $
+    when (mul8 off >= sizeofByteArray ba) $
       Left "Tie breaker is out of bounds"
     let size = fromIntegral (indexByteArray ba off :: Word64)
     (off', pairs) <- go size (off + 1) []


### PR DESCRIPTION
At least in CI, so we get better error checking of low level operations.

Yes currently this exposes some failures that we ought to fix.