### PR TITLE
Move kmerge benchmarks into non-test-suite component

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -366,6 +366,26 @@ test-suite kmerge-test
     , tasty-quickcheck
     , vector
 
+benchmark kmerge-bench
+  import:           warnings, wno-x-partial
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          kmerge-test.hs
+  cpp-options:      -DKMERGE_BENCHMARKS
+  build-depends:
+    , base              >=4.16 && <4.20
+    , deepseq
+    , heaps
+    , lsm-tree:kmerge
+    , primitive
+    , splitmix
+    , tasty
+    , tasty-bench
+    , tasty-hunit
+    , tasty-quickcheck
+    , vector
+
 test-suite map-range-test
   import:           warnings, wno-x-partial
   default-language: Haskell2010

--- a/test/kmerge-test.hs
+++ b/test/kmerge-test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes                 #-}
@@ -161,6 +162,7 @@ main = do
                     ]
                 ]
             ]
+#ifdef KMERGE_BENCHMARKS
         , testGroup "bench"
             [ testGroup "eight"
                 [ B.bench "sortConcat"     $ B.nf (L.sort . concat) input8
@@ -205,6 +207,7 @@ main = do
                 , B.bench "mutHeapMerge"   $ B.nf mutHeapMerge      inputLevellingMax
                 ]
             ]
+#endif
         ]
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
benchmarks take non-deterministic time to run.

`tasty-bench` test methodology is crappy, as on noisy machine it easily uses time up to the timeout. Maybe we should only use `criterion` (which is crappy too, but at least it has strict time limits)