### PR TITLE
Mk prim vector

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,52 @@
+- ignore: {name: "Avoid lambda"} # 2 hints
+- ignore: {name: "Avoid lambda using `infix`"} # 1 hint
+- ignore: {name: "Eta reduce"} # 1 hint
+- ignore: {name: "Functor law"} # 5 hints
+- ignore: {name: "Redundant $"} # 7 hints
+- ignore: {name: "Redundant bracket"} # 2 hints
+- ignore: {name: "Redundant guard"} # 1 hint
+- ignore: {name: "Redundant lambda"} # 4 hints
+- ignore: {name: "Unused LANGUAGE pragma"} # 14 hints
+- ignore: {name: "Use <$>"} # 1 hint
+- ignore: {name: "Use camelCase"} # 8 hints
+- ignore: {name: "Use isAsciiLower"} # 1 hint
+- ignore: {name: "Use isDigit"} # 2 hints
+- ignore: {name: "Use newtype instead of data"} # 3 hints
+- ignore: {name: "Use uncurry"} # 1 hint
+- ignore: {name: "Use underscore"} # 2 hints
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+- modules:
+  - { name: "Data.Vector.Primitive", as: "PV" } # if you import Data.Vector.Primitive qualified, it must be as 'PV'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+- error: 
+    name: "Use mkPrimVector"
+    lhs: "Data.Vector.Primitive.Vector"
+    rhs: "mkPrimVector"
+
+- ignore: { name: "Use mkPrimVector", within: "Database.LSMTree.Internal.Vector" }
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -38,6 +38,7 @@ library
   exposed-modules:
     Data.Map.Range
     Database.LSMTree.Common
+    Database.LSMTree.Internal.Assertions
     Database.LSMTree.Internal.BitMath
     Database.LSMTree.Internal.BlobRef
     Database.LSMTree.Internal.BloomFilter
@@ -61,6 +62,7 @@ library
     Database.LSMTree.Internal.Serialise
     Database.LSMTree.Internal.Serialise.Class
     Database.LSMTree.Internal.Serialise.RawBytes
+    Database.LSMTree.Internal.Vector
     Database.LSMTree.Internal.WriteBuffer
     Database.LSMTree.Monoidal
     Database.LSMTree.Normal

--- a/src/Database/LSMTree/Internal/Assertions.hs
+++ b/src/Database/LSMTree/Internal/Assertions.hs
@@ -1,0 +1,14 @@
+module Database.LSMTree.Internal.Assertions (
+    assert,
+    isValidSlice,
+) where
+
+import           Control.Exception (assert)
+import           Data.Primitive.ByteArray (ByteArray, sizeofByteArray)
+
+isValidSlice :: Int -> Int -> ByteArray -> Bool
+isValidSlice off len ba =
+    off >= 0 &&
+    len >= 0 &&
+    (off + len) >= 0 && -- sum doesn't overflow
+    (off + len) <= sizeofByteArray ba

--- a/src/Database/LSMTree/Internal/BloomFilter.hs
+++ b/src/Database/LSMTree/Internal/BloomFilter.hs
@@ -16,8 +16,9 @@ import qualified Data.Primitive as P
 import           Data.Primitive.ByteArray (ByteArray (ByteArray))
 import qualified Data.Vector.Primitive as PV
 import           Data.Word (Word32, Word64, byteSwap32)
-import           Database.LSMTree.Internal.BitMath
+import           Database.LSMTree.Internal.BitMath (ceilDiv64, mul8)
 import           Database.LSMTree.Internal.ByteString (byteArrayFromTo)
+import           Database.LSMTree.Internal.Vector
 
 -- serializing
 -----------------------------------------------------------
@@ -76,7 +77,7 @@ bloomFilterFromSBS (SBS ba') = do
       Left "Byte array is too large for components"
 
     let vec64 :: PV.Vector Word64
-        vec64 = PV.Vector 2 len64 ba
+        vec64 = mkPrimVector 2 len64 ba
 
     let bloom = BF.Bloom (fromIntegral hsn) len (BV64.BV64 vec64)
     assert (BF.bloomInvariant bloom) $ return bloom

--- a/src/Database/LSMTree/Internal/PageAcc1.hs
+++ b/src/Database/LSMTree/Internal/PageAcc1.hs
@@ -14,6 +14,7 @@ import           Database.LSMTree.Internal.Entry (Entry (..))
 import           Database.LSMTree.Internal.RawPage
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.Serialise.RawBytes (RawBytes (..))
+import           Database.LSMTree.Internal.Vector
 
 pageSize :: Int
 pageSize = 4096
@@ -52,7 +53,7 @@ singletonPage k (Insert v) = runST $ do
     P.copyByteArray ba (32 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    return (makeRawPage ba' 0, RawBytes (PV.Vector (voff+vlen') (vlen-vlen') vba))
+    return (makeRawPage ba' 0, RawBytes (mkPrimVector (voff+vlen') (vlen-vlen') vba))
   where
     SerialisedKey   (RawBytes (PV.Vector koff klen kba)) = k
     SerialisedValue (RawBytes (PV.Vector voff vlen vba)) = v
@@ -87,7 +88,7 @@ singletonPage k (InsertWithBlob v (BlobSpan w64 w32)) = runST $ do
     P.copyByteArray ba (44 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    return (makeRawPage ba' 0, RawBytes (PV.Vector (voff+vlen') (vlen-vlen') vba))
+    return (makeRawPage ba' 0, RawBytes (mkPrimVector (voff+vlen') (vlen-vlen') vba))
   where
     SerialisedKey   (RawBytes (PV.Vector koff klen kba)) = k
     SerialisedValue (RawBytes (PV.Vector voff vlen vba)) = v
@@ -120,7 +121,7 @@ singletonPage k (Mupdate v) = runST $ do
     P.copyByteArray ba (32 + klen) vba voff vlen'
 
     ba' <- P.unsafeFreezeByteArray ba
-    return (makeRawPage ba' 0, RawBytes (PV.Vector (voff+vlen') (vlen-vlen') vba))
+    return (makeRawPage ba' 0, RawBytes (mkPrimVector (voff+vlen') (vlen-vlen') vba))
   where
     SerialisedKey   (RawBytes (PV.Vector koff klen kba)) = k
     SerialisedValue (RawBytes (PV.Vector voff vlen vba)) = v

--- a/src/Database/LSMTree/Internal/Serialise.hs
+++ b/src/Database/LSMTree/Internal/Serialise.hs
@@ -37,7 +37,7 @@ module Database.LSMTree.Internal.Serialise (
   ) where
 
 import qualified Data.ByteString.Builder as BB
-import qualified Data.Vector.Primitive as P
+import qualified Data.Vector.Primitive as PV
 import           Data.Word
 import           Database.LSMTree.Internal.Run.BloomFilter (Hashable (..))
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey,
@@ -59,7 +59,7 @@ newtype SerialisedKey = SerialisedKey RawBytes
   deriving newtype (Eq, Ord, Hashable)
 
 {-# COMPLETE SerialisedKey' #-}
-pattern SerialisedKey' :: P.Vector Word8 -> SerialisedKey
+pattern SerialisedKey' :: PV.Vector Word8 -> SerialisedKey
 pattern SerialisedKey' pvec = SerialisedKey (RawBytes pvec)
 
 {-# INLINE serialiseKey #-}
@@ -114,7 +114,7 @@ newtype SerialisedValue = SerialisedValue RawBytes
   deriving newtype (Eq, Ord)
 
 {-# COMPLETE SerialisedValue' #-}
-pattern SerialisedValue' :: P.Vector Word8 -> SerialisedValue
+pattern SerialisedValue' :: PV.Vector Word8 -> SerialisedValue
 pattern SerialisedValue' pvec = (SerialisedValue (RawBytes pvec))
 
 {-# INLINE serialiseValue #-}
@@ -158,7 +158,7 @@ newtype SerialisedBlob = SerialisedBlob RawBytes
   deriving newtype (Eq, Ord)
 
 {-# COMPLETE SerialisedBlob' #-}
-pattern SerialisedBlob' :: P.Vector Word8 -> SerialisedBlob
+pattern SerialisedBlob' :: PV.Vector Word8 -> SerialisedBlob
 pattern SerialisedBlob' pvec = (SerialisedBlob (RawBytes pvec))
 
 {-# INLINE serialiseBlob #-}

--- a/src/Database/LSMTree/Internal/Vector.hs
+++ b/src/Database/LSMTree/Internal/Vector.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+module Database.LSMTree.Internal.Vector (
+    mkPrimVector,
+) where
+
+import           Data.Primitive.ByteArray (ByteArray)
+import           Data.Primitive.Types (Prim (sizeOfType#))
+import           Data.Proxy (Proxy (..))
+import qualified Data.Vector.Primitive as PV
+import           Database.LSMTree.Internal.Assertions
+import           GHC.Exts (Int (..))
+
+mkPrimVector :: forall a. Prim a => Int -> Int -> ByteArray -> PV.Vector a
+mkPrimVector off len ba =
+    assert (isValidSlice (off * sizeof) (len * sizeof) ba) $
+    PV.Vector off len ba
+  where
+    sizeof = I# (sizeOfType# (Proxy @a))
+{-# INLINE mkPrimVector #-}

--- a/src/utils/Database/LSMTree/Generators.hs
+++ b/src/utils/Database/LSMTree/Generators.hs
@@ -63,7 +63,7 @@ import           Data.Coerce (coerce)
 import           Data.Containers.ListUtils (nubOrd)
 import           Data.List (sort)
 import qualified Data.Map as Map
-import qualified Data.Vector.Primitive as P
+import qualified Data.Vector.Primitive as PV
 import           Data.WideWord.Word256 (Word256 (..))
 import           Data.Word
 import           Database.LSMTree.Common (Range (..))
@@ -541,29 +541,29 @@ instance Arbitrary RawBytes where
   shrink rb = shrinkRawBytes rb ++ shrinkSlice rb
 
 genRawBytesN :: Int -> Gen RawBytes
-genRawBytesN n = RawBytes . P.fromList <$> QC.vectorOf n arbitrary
+genRawBytesN n = RawBytes . PV.fromList <$> QC.vectorOf n arbitrary
 
 genRawBytes :: Gen RawBytes
-genRawBytes = RawBytes . P.fromList <$> QC.listOf arbitrary
+genRawBytes = RawBytes . PV.fromList <$> QC.listOf arbitrary
 
 genRawBytesSized :: Int -> Gen RawBytes
 genRawBytesSized n = QC.resize n genRawBytes
 
 shrinkRawBytes :: RawBytes -> [RawBytes]
-shrinkRawBytes (RawBytes pvec) = [ RawBytes (P.fromList ws)
-                                 | ws <- QC.shrink (P.toList pvec) ]
+shrinkRawBytes (RawBytes pvec) = [ RawBytes (PV.fromList ws)
+                                 | ws <- QC.shrink (PV.toList pvec) ]
 
 genSlice :: RawBytes -> Gen RawBytes
 genSlice (RawBytes pvec) = do
-    n <- QC.chooseInt (0, P.length pvec)
-    m <- QC.chooseInt (0, P.length pvec - n)
-    pure $ RawBytes (P.slice m n pvec)
+    n <- QC.chooseInt (0, PV.length pvec)
+    m <- QC.chooseInt (0, PV.length pvec - n)
+    pure $ RawBytes (PV.slice m n pvec)
 
 shrinkSlice :: RawBytes -> [RawBytes]
 shrinkSlice (RawBytes pvec) =
-    [ RawBytes (P.slice m n pvec)
-    | n <- QC.shrink (P.length pvec)
-    , m <- QC.shrink (P.length pvec - n)
+    [ RawBytes (PV.slice m n pvec)
+    | n <- QC.shrink (PV.length pvec)
+    , m <- QC.shrink (PV.length pvec - n)
     ]
 
 deriving newtype instance Arbitrary SerialisedKey

--- a/src/utils/Database/LSMTree/Util/Orphans.hs
+++ b/src/utils/Database/LSMTree/Util/Orphans.hs
@@ -8,6 +8,7 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
+-- TODO: rename to Database.LSMTree.Orphans
 module Database.LSMTree.Util.Orphans () where
 
 import           Control.DeepSeq (NFData (..))
@@ -16,7 +17,6 @@ import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short.Internal as SBS
 import qualified Data.Primitive as P
-import qualified Data.Vector.Primitive as PV
 import           Data.WideWord.Word256 (Word256 (..))
 import           Data.Word (Word64, byteSwap64)
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
@@ -28,6 +28,7 @@ import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..),
                      SerialisedKey (..), SerialisedValue (..))
 import           Database.LSMTree.Internal.Serialise.Class
 import qualified Database.LSMTree.Internal.Serialise.RawBytes as RB
+import           Database.LSMTree.Internal.Vector
 import           GHC.Generics (Generic)
 import           System.Random (Uniform)
 
@@ -58,7 +59,7 @@ deriving anyclass instance Uniform Word256
 
 instance SerialiseKey Word256 where
   serialiseKey (Word256{word256hi, word256m1, word256m0, word256lo}) =
-    RB.RawBytes $ PV.Vector 0 32 $ P.runByteArray $ do
+    RB.RawBytes $ mkPrimVector 0 32 $ P.runByteArray $ do
       ba <- P.newByteArray 32
       P.writeByteArray ba 0 $ byteSwap64 word256hi
       P.writeByteArray ba 1 $ byteSwap64 word256m1
@@ -74,7 +75,7 @@ instance SerialiseKey Word256 where
 
 instance SerialiseKey Word64 where
   serialiseKey x =
-    RB.RawBytes $ PV.Vector 0 8 $ P.runByteArray $ do
+    RB.RawBytes $ mkPrimVector 0 8 $ P.runByteArray $ do
       ba <- P.newByteArray 8
       P.writeByteArray ba 0 $ byteSwap64 x
       return ba


### PR DESCRIPTION
- Add `mkPrimVector` smart constructor.
- Use hlint to prohibit `Vector` constructor usage, but it's fine to use it in pattern matches

If this is good approach, we probably should add HLint job to CI. (It doesn't complain about anything in `src/` atm).