### PR TITLE
Hardcode expected allocations per key in bloom macro bench

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -29,22 +29,8 @@ benchmarks: True
 -- Luckily, bloomfilter is not commonly used package, so this is good enough.
 constraints: bloomfilter <0
 
-package lsm-tree
-  -- apply this to all components
-  -- relevant mostly only for development & testing
-  ghc-options: -fno-ignore-asserts
-
--- Enable -fcheck-prim-bounds
--- https://gitlab.haskell.org/ghc/ghc/-/issues/21054
-if impl(ghc >=9.4.6 && <9.5 || >=9.6.3)
-  package lsm-tree
-    ghc-options: -fcheck-prim-bounds
-
-  package primitive
-    ghc-options: -fcheck-prim-bounds
-
-  package vector
-    ghc-options: -fcheck-prim-bounds
+-- comment me if you are benchmarking
+import: cabal.project.debug
 
 if(os(linux))
   source-repository-package

--- a/cabal.project.debug
+++ b/cabal.project.debug
@@ -1,0 +1,19 @@
+package lsm-tree
+  -- apply this to all components
+  -- relevant mostly only for development & testing
+  ghc-options: -fno-ignore-asserts
+
+  -- there are no cpp-options in cabal.project files
+  ghc-options: -optP -DNO_IGNORE_ASSERTS
+
+-- Enable -fcheck-prim-bounds
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/21054
+if impl(ghc >=9.4.6 && <9.5 || >=9.6.3)
+  package lsm-tree
+    ghc-options: -fcheck-prim-bounds
+
+  package primitive
+    ghc-options: -fcheck-prim-bounds
+
+  package vector
+    ghc-options: -fcheck-prim-bounds


### PR DESCRIPTION
Also move debug part of cabal.project into separate import, so it's easier to disable.

Add a CPP, so we know if debug stuff is on.