### PR TITLE
`submitIO` using vectors

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ repository cardano-haskell-packages
 
 index-state:
   -- Bump this if you need newer packages from Hackage
-  -- current date: crc32c-0.2.0
-  , hackage.haskell.org 2024-02-24T04:59:47Z
+  -- current date: quickcheck-lockstep-0.4.1
+  , hackage.haskell.org 2024-03-20T10:26:53Z
   -- Bump this if you need newer packages from CHaP
   -- current date: fs-api-0.2.0.1, fs-sim-0.2.1.1
   , cardano-haskell-packages 2023-11-30T09:59:24Z
@@ -36,7 +36,8 @@ if(os(linux))
   source-repository-package
     type: git
     location: https://github.com/well-typed/blockio-uring
-    tag: c07e1b0c61203e7fc3a944b4070522bc53464fbd
+    -- submitIO using vectors
+    tag: fdb1a51e94ad731b1bf114ee1f8143720481a49a
 
 -- fs-api with support for I/O using user-supplied buffers
 source-repository-package

--- a/fs-api-blockio/src/System/FS/BlockIO/Serial.hs
+++ b/fs-api-blockio/src/System/FS/BlockIO/Serial.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module System.FS.BlockIO.Serial (
     serialHasBlockIO
@@ -6,6 +8,10 @@ module System.FS.BlockIO.Serial (
 import           Control.Concurrent.Class.MonadMVar
 import           Control.Monad (unless)
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Primitive (PrimMonad)
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector.Unboxed.Mutable as VUM
 import           System.FS.API
 import qualified System.FS.BlockIO.API as API
 import           System.FS.BlockIO.API (IOOp (..), IOResult (..))
@@ -13,7 +19,7 @@ import           System.FS.BlockIO.API (IOOp (..), IOResult (..))
 -- | IO instantiation of 'HasBlockIO', using an existing 'HasFS'. Thus this
 -- implementation does not take advantage of parallel I/O.
 serialHasBlockIO ::
-     (MonadThrow m, MonadMVar m, Eq h)
+     (MonadThrow m, MonadMVar m, PrimMonad m, Eq h)
   => HasFS m h
   -> HasBufFS m h
   -> m (API.HasBlockIO m h)
@@ -37,15 +43,15 @@ close :: MonadMVar m => IOCtx m -> m ()
 close ctx = modifyMVar_ (openVar ctx) $ const (pure False)
 
 submitIO ::
-     (MonadMVar m, MonadThrow m)
+     (MonadMVar m, MonadThrow m, PrimMonad m)
   => HasFS m h
   -> HasBufFS m h
   -> IOCtx m
-  -> [IOOp m h]
-  -> m [IOResult]
+  -> V.Vector (IOOp m h)
+  -> m (VU.Vector IOResult)
 submitIO hfs hbfs ctx ioops = do
-  guardIsOpen ctx
-  mapM (ioop hfs hbfs) ioops
+    guardIsOpen ctx
+    hmapM (ioop hfs hbfs) ioops
 
 -- | Perform the IOOp using synchronous I\/O.
 ioop ::
@@ -58,3 +64,26 @@ ioop hfs hbfs (IOOpRead h off buf bufOff c) =
     IOResult <$> hGetBufExactlyAt hfs hbfs h buf bufOff c (fromIntegral off)
 ioop _hfs hbfs (IOOpWrite h off buf bufOff c) =
     IOResult <$> hPutBufExactlyAt hbfs h buf bufOff c (fromIntegral off)
+
+-- | Heterogeneous blend of 'V.mapM' and 'VU.mapM'.
+--
+-- The @vector@ package does not provide functions that take distinct vector
+-- containers as arguments, so we write it by hand to prevent having to convert
+-- one vector type to the other.
+hmapM ::
+     forall m a b. (PrimMonad m, VUM.Unbox b)
+  => (a -> m b)
+  -> V.Vector a
+  -> m (VU.Vector b)
+hmapM f v = do
+    res <- VUM.unsafeNew n
+    loop res 0
+  where
+    !n = V.length v
+    loop !res !i
+      | i == n = VU.unsafeFreeze res
+      | otherwise = do
+          let !x = v `V.unsafeIndex` i
+          !z <- f x
+          VUM.unsafeWrite res i z
+          loop res (i+1)

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -471,10 +471,11 @@ library fs-api-blockio
     System.FS.BlockIO.Serial
 
   build-depends:
-    , base        >=4.16 && <4.20
+    , base        >=4.16  && <4.20
     , fs-api      ^>=0.2
     , io-classes  ^>=1.3
     , primitive   ^>=0.9
+    , vector      ^>=0.13
 
   if os(linux)
     hs-source-dirs: fs-api-blockio/src-linux
@@ -512,5 +513,6 @@ test-suite fs-api-blockio-test
     , tasty-hunit
     , tasty-quickcheck
     , temporary
+    , vector
 
   ghc-options:      -threaded -fno-ignore-asserts


### PR DESCRIPTION
Update `blockio-uring` to the latest version, and adapt the `fs-api-blockio` code to use vectors instead of lists