### PR TITLE
Fix the index-state for formatting jobs in GHA

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -132,6 +132,16 @@ jobs:
         cabal: ["3.10.2.1"]
         os: [ubuntu-latest]
 
+    # Fix the index-state so we can get proper caching effects. Change this to a
+    # more recent time if you want to use a newer version of stylish-haskell, or
+    # if you want stylish-haskell to use updated dependencies.
+    #
+    # We use this environment variable in the primary key of our caches, and as
+    # an argument to cabal install. This ensures that we never rebuild
+    # dependencies because of newly uploaded packages unless we want to.
+    env:
+      hackage-index-state: "2024-04-10T14:36:07Z"
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -161,10 +171,12 @@ jobs:
         cache-name: cache-cabal-stylish
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ env.hackage-index-state }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install stylish-haskell
-      run: cabal install --ignore-project stylish-haskell --constraint 'stylish-haskell == 0.14.6.0'
+      run: cabal install --ignore-project --index-state="${{ env.hackage-index-state }}" stylish-haskell --constraint 'stylish-haskell == 0.14.6.0'
 
     - name: Record stylish-haskell version
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -199,6 +199,11 @@ jobs:
         cabal: ["3.10.2.1"]
         os: [ubuntu-latest]
 
+    # See the comment on the hackage-index-state environment variable for the
+    # stylish-haskell job.
+    env:
+      hackage-index-state: "2024-04-10T14:36:07Z"
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -228,10 +233,12 @@ jobs:
         cache-name: cache-cabal-cabal-fmt-11
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ env.hackage-index-state }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install cabal-fmt
-      run: cabal install --ignore-project cabal-fmt --constraint 'cabal-fmt == 0.1.11'
+      run: cabal install --ignore-project cabal-fmt --index-state="${{ env.hackage-index-state }}" --constraint 'cabal-fmt == 0.1.11'
 
     - name: Record cabal-fmt version
       run: |


### PR DESCRIPTION
Without a fixed index-state and with only one unique cache name before, GHA is likely to rebuild dependencies from scratch each time we run the formatting jobs. Fixing the index-state and using the value in the primary key of the GHA caches, we won't rebuild dependencies superfluously any longer, and we have control over when we want to build newer versions of our formatting tools, or update their dependencies.