### PR TITLE
Rename MPageAcc to PageAcc

### DIFF
--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -140,7 +140,7 @@ closeSession :: IOLike m => Session m -> m ()
 closeSession = undefined
 
 {-------------------------------------------------------------------------------
-  Serialization constraints
+  Serialisation constraints
 -------------------------------------------------------------------------------}
 
 -- | A placeholder class for (de)serialisation constraints.

--- a/src/Database/LSMTree/Internal/BloomFilter.hs
+++ b/src/Database/LSMTree/Internal/BloomFilter.hs
@@ -20,7 +20,7 @@ import           Database.LSMTree.Internal.BitMath (ceilDiv64, mul8)
 import           Database.LSMTree.Internal.ByteString (byteArrayFromTo)
 import           Database.LSMTree.Internal.Vector
 
--- serializing
+-- serialising
 -----------------------------------------------------------
 
 -- | By writing out the version in host endianness, we also indicate endianness.
@@ -39,7 +39,7 @@ toBuilder' :: BF.Bloom a -> B.Builder
 toBuilder' (BF.Bloom _hfN _len (BV64.BV64 (PV.Vector off len v))) =
     byteArrayFromTo (mul8 off) (mul8 off + mul8 len) v
 
--- deserializing
+-- deserialising
 -----------------------------------------------------------
 
 -- | Read 'BF.Bloom' from a 'ShortByteString'.

--- a/src/Database/LSMTree/Internal/PageAcc.hs
+++ b/src/Database/LSMTree/Internal/PageAcc.hs
@@ -9,7 +9,7 @@ module Database.LSMTree.Internal.PageAcc (
     newPageAcc,
     resetPageAcc,
     pageAccAddElem,
-    serializePageAcc,
+    serialisePageAcc,
     -- ** Inspection
     keysCountPageAcc,
     indexKeyPageAcc,
@@ -69,7 +69,7 @@ import           Database.LSMTree.Internal.Serialise
 -- 'PageAcc' can hold up to 704 elements, but most likely 'pageAccAddElem' will make it overflow sooner.
 -- Having an upper bound allows us to allocate all memory for the accumulator in advance.
 --
--- We don't store or calculate individual key nor value offsets in 'PageAcc', as these will be naturally calculated during serialization ('serializePageAcc').
+-- We don't store or calculate individual key nor value offsets in 'PageAcc', as these will be naturally calculated during serialisation ('serialisePageAcc').
 --
 data PageAcc s = PageAcc
     { paDir         :: !(P.MutablePrimArray s Int)      -- ^ various counters (directory + extra counters). It is convenient to have counters as 'Int', as all indexing uses 'Int's.
@@ -275,16 +275,16 @@ setOperation arr i crumb = do
 --
 -- After this operation 'PageAcc' argument can be reset with 'resetPageAcc',
 -- and reused.
-serializePageAcc :: PageAcc s -> ST s RawPage
-serializePageAcc page@PageAcc {..} = do
+serialisePageAcc :: PageAcc s -> ST s RawPage
+serialisePageAcc page@PageAcc {..} = do
     size <- P.readPrimArray paDir keysCountIdx
     case size of
         0 -> return emptyRawPage
-        _ -> serializePageAccN size page
+        _ -> serialisePageAccN size page
 
--- | Serialize non-empty page.
-serializePageAccN :: forall s. Int -> PageAcc s -> ST s RawPage
-serializePageAccN size PageAcc {..} = do
+-- | Serialise non-empty page.
+serialisePageAccN :: forall s. Int -> PageAcc s -> ST s RawPage
+serialisePageAccN size PageAcc {..} = do
     b  <- P.readPrimArray paDir blobRefCountIdx
     ks <- P.readPrimArray paDir keysSizeIdx
 

--- a/src/Database/LSMTree/Internal/RunAcc.hs
+++ b/src/Database/LSMTree/Internal/RunAcc.hs
@@ -51,7 +51,7 @@ import           Database.LSMTree.Internal.IndexCompact (IndexCompact, NumPages)
 import qualified Database.LSMTree.Internal.IndexCompact as Index
 import           Database.LSMTree.Internal.IndexCompactAcc (IndexCompactAcc)
 import qualified Database.LSMTree.Internal.IndexCompactAcc as Index
-import           Database.LSMTree.Internal.PageAcc (MPageAcc)
+import           Database.LSMTree.Internal.PageAcc (PageAcc)
 import qualified Database.LSMTree.Internal.PageAcc as PageAcc
 import qualified Database.LSMTree.Internal.PageAcc1 as PageAcc
 import           Database.LSMTree.Internal.RawOverflowPage
@@ -74,7 +74,7 @@ import           Database.LSMTree.Internal.Serialise (SerialisedKey,
 data RunAcc s = RunAcc {
       mbloom               :: !(MBloom s SerialisedKey)
     , mindex               :: !(IndexCompactAcc s)
-    , mpageacc             :: !(MPageAcc s)
+    , mpageacc             :: !(PageAcc s)
     , entryCount           :: !(PrimVar s Int)
     , rangeFinderCurVal    :: !(PrimVar s Word16)
     , rangeFinderPrecision :: !RangeFinderPrecision

--- a/src/Database/LSMTree/Internal/RunAcc.hs
+++ b/src/Database/LSMTree/Internal/RunAcc.hs
@@ -319,7 +319,7 @@ flushPageIfNonEmpty RunAcc{mpageacc, mindex} = do
         mchunk <- Index.appendSingle (minKey, maxKey) mindex
 
         -- Now serialise the page and reset the accumulator
-        page <- PageAcc.serializePageAcc mpageacc
+        page <- PageAcc.serialisePageAcc mpageacc
         PageAcc.resetPageAcc mpageacc
         return (Just (page, mchunk))
 

--- a/test/Test/Database/LSMTree/Common.hs
+++ b/test/Test/Database/LSMTree/Common.hs
@@ -49,7 +49,7 @@ decodeEncodeRoundtrip _ = testProperty "decode-encode roundtrip" prop where
 totalDeserialiseProp :: forall a.
     (NFData a, SomeSerialisationConstraint a)
     => Proxy a -> TestTree
-totalDeserialiseProp _ = testProperty "deserialize total" prop where
+totalDeserialiseProp _ = testProperty "deserialise total" prop where
     prop bs = property $ deserialise @a bs `deepseq` True
 
 -- | Serialisation MUST preserve order.

--- a/test/Test/Database/LSMTree/Internal/PageAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/PageAcc.hs
@@ -76,22 +76,22 @@ prototype inputs' =
 
     fstOf3 (k,_,_) = k
 
-    go :: MPageAcc s -> Proto.PageSize -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> ST s Property
+    go :: PageAcc s -> Proto.PageSize -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> ST s Property
     go acc _ps acc2 []                 = finish acc acc2
     go acc  ps acc2 (e@(k,op,bref):es) = case pageSizeAddElem' e ps of
         Nothing -> do
             added <- pageAccAddElem acc (convKey k) (convOp op bref)
             if added
-            then return $ counterexample "MPageAcc addition succeeded, prototype's doesn't." False
+            then return $ counterexample "PageAcc addition succeeded, prototype's doesn't." False
             else finish acc acc2
 
         Just ps' -> do
             added <- pageAccAddElem acc (convKey k) (convOp op bref)
             if added
             then go acc ps' (e:acc2) es
-            else return $ counterexample "MPageAcc addition failed, prototype's doesn't." False
+            else return $ counterexample "PageAcc addition failed, prototype's doesn't." False
 
-    finish :: MPageAcc s -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> ST s Property
+    finish :: PageAcc s -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> ST s Property
     finish acc acc2 = do
         let (lhs, _) = toRawPage $ Proto.PageLogical $ reverse acc2
         rawpage <- serializePageAcc acc

--- a/test/Test/Database/LSMTree/Internal/PageAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/PageAcc.hs
@@ -94,7 +94,7 @@ prototype inputs' =
     finish :: PageAcc s -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> ST s Property
     finish acc acc2 = do
         let (lhs, _) = toRawPage $ Proto.PageLogical $ reverse acc2
-        rawpage <- serializePageAcc acc
+        rawpage <- serialisePageAcc acc
         let rhs = rawpage :: RawPage
         return $ propEqualRawPages lhs rhs
 

--- a/test/Test/Database/LSMTree/Internal/RunAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/RunAcc.hs
@@ -112,7 +112,7 @@ fromListPageAcc kops =
              -- we expect the kops to all fit in one page
              assert added $ return ()
         | (k,e) <- kops ]
-      page <- PageAcc.serializePageAcc pacc
+      page <- PageAcc.serialisePageAcc pacc
       return (page, []))
 
 pagesToByteString :: RawPage -> [RawOverflowPage] -> BS.ByteString


### PR DESCRIPTION
For consistency. The Acc suffix already indicates mutability, so no need to have a prefix.