### PR TITLE
improve Arbitrary instances for serialised keys and values

### DIFF
--- a/src-extras/Database/LSMTree/Extras.hs
+++ b/src-extras/Database/LSMTree/Extras.hs
@@ -1,15 +1,21 @@
 module Database.LSMTree.Extras (
     showPowersOf10
+  , showPowersOf
   ) where
 
+import           Data.List (find)
+import           Data.Maybe (fromJust)
 import           Text.Printf
 
 showPowersOf10 :: Int -> String
-showPowersOf10 n0
-  | n0 <= 0   = "n == 0"
-  | n0 == 1   = "n == 1"
-  | otherwise = go n0 1
+showPowersOf10 = showPowersOf 10
+
+showPowersOf :: Int -> Int -> String
+showPowersOf factor n
+  | factor <= 1 = error "showPowersOf: factor must be larger than 1"
+  | n < 0       = "n < 0"
+  | n == 0      = "n == 0"
+  | otherwise   = printf "%d <= n < %d" lb ub
   where
-    go n m | n < m'    = printf "%d < n < %d" m m'
-            | otherwise = go n m'
-            where m' = 10*m
+    ub = fromJust (find (n <) (iterate (* factor) factor))
+    lb = ub `div` factor

--- a/src/Database/LSMTree/Internal/PageAcc.hs
+++ b/src/Database/LSMTree/Internal/PageAcc.hs
@@ -15,6 +15,7 @@ module Database.LSMTree.Internal.PageAcc (
     indexKeyPageAcc,
     -- ** Entry sizes
     entryWouldFitInPage,
+    sizeofEntry,
 ) where
 
 import           Control.Monad.ST.Strict (ST)
@@ -111,9 +112,8 @@ pageSize = 4096
 
 -- | Calculate the total byte size of key, value and optional blobspan.
 --
--- To fit into single page this has to be at most 4052 with a blobspan (the
--- same as the max key size) or 4064 without a blobspan, if the entry is larger,
--- the 'pageAccAddElem' will return 'Nothing'.
+-- To fit into single page this has to be at most 4064. If the entry is larger,
+-- the 'pageAccAddElem' is guaranteed to return 'False'.
 --
 -- In other words, if you have a large entry (i.e. Insert with big value),
 -- don't use the 'PageAcc', but construct the single value page directly,

--- a/test/Test/Database/LSMTree/Generators.hs
+++ b/test/Test/Database/LSMTree/Generators.hs
@@ -9,14 +9,23 @@ module Test.Database.LSMTree.Generators (
   ) where
 
 import           Control.DeepSeq (NFData, deepseq)
+import           Data.Bifoldable (bifoldMap)
+import           Data.Coerce (coerce)
+import qualified Data.Map.Strict as Map
 import qualified Data.Vector.Primitive as PV
 import           Data.Word (Word64, Word8)
 
+import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators
+import           Database.LSMTree.Internal.BlobRef (BlobSpan)
+import           Database.LSMTree.Internal.Entry
+import           Database.LSMTree.Internal.PageAcc (entryWouldFitInPage,
+                     sizeofEntry)
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
+import           Database.LSMTree.Internal.Serialise
 
-import           Test.QuickCheck (Arbitrary (..), Gen, Testable (..),
-                     forAllShrink)
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck (Arbitrary (..), Gen, Property, Testable (..))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
@@ -35,6 +44,10 @@ tests = testGroup "Test.Database.LSMTree.Generators" [
      ++ prop_arbitraryAndShrinkPreserveInvariant (deepseqInvariant @RawBytes)
     , testGroup "KeyForIndexCompact" $
         prop_arbitraryAndShrinkPreserveInvariant keyForIndexCompactInvariant
+    , testGroup "lists of key/op pairs" $
+        [ testProperty "prop_distributionKOps" $
+            prop_distributionKOps
+        ]
     ]
 
 prop_arbitraryAndShrinkPreserveInvariant ::
@@ -46,9 +59,9 @@ prop_forAllArbitraryAndShrinkPreserveInvariant ::
     forall a. Show a => Gen a -> (a -> [a]) -> (a -> Bool) -> [TestTree]
 prop_forAllArbitraryAndShrinkPreserveInvariant gen shr inv =
     [ testProperty "Arbitrary satisfies invariant" $
-            property $ forAllShrink gen shr inv
+            property $ QC.forAllShrink gen shr inv
     , testProperty "Shrinking satisfies invariant" $
-            property $ forAllShrink gen shr (all inv . shr)
+            property $ QC.forAllShrink gen shr (all inv . shr)
     ]
 
 -- | Trivial invariant, but checks that the value is finite
@@ -58,3 +71,28 @@ deepseqInvariant x = x `deepseq` True
 prop_packRawBytesPinnedOrUnpinned :: Bool -> [Word8] -> Bool
 prop_packRawBytesPinnedOrUnpinned pinned ws =
     packRawBytesPinnedOrUnpinned pinned ws == RawBytes (PV.fromList ws)
+
+type TestEntry = Entry SerialisedValue BlobSpan
+type TestKOp = (KeyForIndexCompact, TestEntry)
+
+prop_distributionKOps :: [TestKOp] -> Property
+prop_distributionKOps kops' =
+    QC.tabulate "key occurrences (>1 is collision)" (map (show . snd) (Map.assocs keyCounts)) $
+    QC.tabulate "key sizes" (map (showPowersOf 4 . sizeofKey) keys) $
+    QC.tabulate "value sizes" (map (showPowersOf 4 . sizeofValue) values) $
+    QC.tabulate "k/op sizes" (map (showPowersOf 4 . uncurry sizeofEntry) kops) $
+    QC.tabulate "k/op is large" (map (show . isLarge) kops) $
+    QC.checkCoverage $
+    QC.cover 50 (any isLarge kops) "any k/op is large" $
+    QC.cover  1 (ratioUniqueKeys < (0.9 :: Double)) ">10% of keys collide" $
+    QC.cover  5 (any (> 2) keyCounts) "has key with >2 collisions" $
+      True
+  where
+    kops = coerce kops' :: [(SerialisedKey, Entry SerialisedValue BlobSpan)]
+    keys = map fst kops
+    keyCounts = Map.fromListWith (+) [(k, (1 :: Int)) | k <- keys]
+    uniqueKeys = Map.keys keyCounts
+    ratioUniqueKeys = fromIntegral (length uniqueKeys) / fromIntegral (length keys)
+    values = foldMap (bifoldMap pure mempty . snd) kops
+
+    isLarge = not . uncurry entryWouldFitInPage


### PR DESCRIPTION
Not particularly elegant, but improves the chance of hitting interesting cases until we have a more principled approach.

Output:

```
  Test.Database.LSMTree.Generators
    key/op pairs
      prop_distributionKOps: OK (2.19s)
        +++ OK, passed 800 tests:
        57.2% any k/op is large
        32.5% has key with >2 collisions
        23.4% >10% of keys collide
        
        k/op is large (19686 in total):
        95.205% False
         4.795% True
        
        k/op sizes (19686 in total):
        38.535% 16 <= n < 64
        22.803% 64 <= n < 256
        13.629% 256 <= n < 1024
        10.556% 4 <= n < 16
         9.728% 1024 <= n < 4096
         4.750% 4096 <= n < 16384
        
        key counts (18044 in total):
        95.140% 1
         2.455% 2
         1.313% 3
         0.643% 4
         0.255% 5
         0.127% 6
         0.044% 7
         0.017% 8
         0.006% 10
        
        key sizes (19686 in total):
        52.845% 16 <= n < 64
        32.871% 4 <= n < 16
        14.284% 64 <= n < 256
        
        value sizes (18128 in total):
        25.359% 16 <= n < 64
        23.003% 4 <= n < 16
        14.447% 256 <= n < 1024
        11.557% 1 <= n < 4
        10.255% 1024 <= n < 4096
         5.787% n == 0
         5.136% 4096 <= n < 16384
         4.457% 64 <= n < 256
```