### PR TITLE
Add property tests for instances of SerialiseKey and SerialiseValue

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -220,6 +220,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Run
     Test.Database.LSMTree.Internal.RunAcc
     Test.Database.LSMTree.Internal.Serialise
+    Test.Database.LSMTree.Internal.Serialise.Class
     Test.Database.LSMTree.Model.Monoidal
     Test.Database.LSMTree.Model.Normal
     Test.Database.LSMTree.ModelIO.Class

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -156,10 +156,9 @@ instance SerialiseValue SBS.ShortByteString where
  ByteArray
 -------------------------------------------------------------------------------}
 
-instance SerialiseKey P.ByteArray where
-  serialiseKey ba = RB.fromByteArray 0 (P.sizeofByteArray ba) ba
-  deserialiseKey = RB.force
-
+-- | The 'Ord' instance of 'ByteArray' is not lexicographic, so there cannot be
+-- an order-preserving instance of 'SerialiseKey'.
+-- Use 'ShortByteString' instead.
 instance SerialiseValue P.ByteArray where
   serialiseValue ba = RB.fromByteArray 0 (P.sizeofByteArray ba) ba
   deserialiseValue = RB.force

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -38,6 +38,9 @@ import           GHC.Word (Word64 (..))
 --
 -- Raw bytes are lexicographically ordered, so in particular this means that
 -- values should be serialised into big-endian formats.
+-- This constraint mainly exists for range queries, where the range is specified
+-- in terms of unserialised values, but the internal implementation works on the
+-- serialised representation.
 --
 -- === IndexCompact constraints
 --

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -97,6 +97,19 @@ instance SerialiseKey Word64 where
     | len >= 8  = byteSwap64 (W64# (indexWord8ArrayAsWord64# ba# off# ))
     | otherwise = error "deserialiseKey: not enough bytes for Word64"
 
+instance SerialiseValue Word64 where
+  serialiseValue x =
+    RB.RawBytes $ mkPrimVector 0 8 $ P.runByteArray $ do
+      ba <- P.newByteArray 8
+      P.writeByteArray ba 0 x
+      return ba
+
+  deserialiseValue (RawBytes (PV.Vector (I# off#) len (P.ByteArray ba#)))
+    | len >= 8  = W64# (indexWord8ArrayAsWord64# ba# off# )
+    | otherwise = error "deserialiseValue: not enough bytes for Word64"
+
+  deserialiseValueN = deserialiseValue . mconcat
+
 {-------------------------------------------------------------------------------
   ByteString
 -------------------------------------------------------------------------------}

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -94,7 +94,7 @@ instance SerialiseKey Word64 where
       return ba
 
   deserialiseKey (RawBytes (PV.Vector (I# off#) len (P.ByteArray ba#)))
-    | len >= 8  = W64# (indexWord8ArrayAsWord64# ba# off# )
+    | len >= 8  = byteSwap64 (W64# (indexWord8ArrayAsWord64# ba# off# ))
     | otherwise = error "deserialiseKey: not enough bytes for Word64"
 
 {-------------------------------------------------------------------------------

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Test.Database.LSMTree.Internal.RawPage
 import qualified Test.Database.LSMTree.Internal.Run
 import qualified Test.Database.LSMTree.Internal.RunAcc
 import qualified Test.Database.LSMTree.Internal.Serialise
+import qualified Test.Database.LSMTree.Internal.Serialise.Class
 import qualified Test.Database.LSMTree.Model.Monoidal
 import qualified Test.Database.LSMTree.Model.Normal
 import qualified Test.Database.LSMTree.ModelIO.Monoidal
@@ -41,6 +42,7 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Internal.RunAcc.tests
     , Test.Database.LSMTree.Internal.IndexCompact.tests
     , Test.Database.LSMTree.Internal.Serialise.tests
+    , Test.Database.LSMTree.Internal.Serialise.Class.tests
     , Test.Database.LSMTree.Model.Normal.tests
     , Test.Database.LSMTree.Model.Monoidal.tests
     , Test.Database.LSMTree.ModelIO.Normal.tests

--- a/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
@@ -7,38 +8,40 @@ import           Data.ByteString (ByteString)
 import           Data.ByteString.Lazy (LazyByteString)
 import           Data.ByteString.Short (ShortByteString)
 import           Data.Primitive (ByteArray)
+import           Data.Proxy (Proxy (Proxy))
 import           Data.Word
 import           Database.LSMTree.Extras.Generators ()
+import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Serialise.Class
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 tests :: TestTree
-tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class" [
-      testProperty "prop_roundtripSerialiseKey @Word64" $
-        prop_roundtripSerialiseKey @Word64
-    , testProperty "prop_roundtripSerialiseValue @Word64" $
-        prop_roundtripSerialiseValue @Word64
+tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class"
+    [ testGroup "Word64"          (allProperties @Word64)
+    , testGroup "ByteString"      (allProperties @ByteString)
+    , testGroup "LazyByteString"  (allProperties @LazyByteString)
+    , testGroup "ShortByteString" (allProperties @ShortByteString)
+    , testGroup "ByteArray"       (allProperties @ByteArray)
+    ]
 
-    , testProperty "prop_roundtripSerialiseKey @ByteString" $
-        prop_roundtripSerialiseKey @ByteString
-    , testProperty "prop_roundtripSerialiseValue @ByteString" $
-        prop_roundtripSerialiseValue @ByteString
+allProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a, SerialiseValue a) => [TestTree]
+allProperties = keyProperties @a <> valueProperties @a
 
-    , testProperty "prop_roundtripSerialiseKey @LazyByteString" $
-        prop_roundtripSerialiseKey @LazyByteString
-    , testProperty "prop_roundtripSerialiseValue @LazyByteString" $
-        prop_roundtripSerialiseValue @LazyByteString
+keyProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a) => [TestTree]
+keyProperties =
+    [ testProperty "prop_roundtripSerialiseKey" $
+        prop_roundtripSerialiseKey @a
+    , testProperty "prop_orderPreservationSerialiseKey" $
+        prop_orderPreservationSerialiseKey @a
+    ]
 
-    , testProperty "prop_roundtripSerialiseKey @ShortByteString" $
-        prop_roundtripSerialiseKey @ShortByteString
-    , testProperty "prop_roundtripSerialiseValue @ShortByteString" $
-        prop_roundtripSerialiseValue @ShortByteString
-
-    , testProperty "prop_roundtripSerialiseKey @ByteArray" $
-        prop_roundtripSerialiseKey @ByteArray
-    , testProperty "prop_roundtripSerialiseValue @ByteArray" $
-        prop_roundtripSerialiseValue @ByteArray
+valueProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseValue a) => [TestTree]
+valueProperties =
+    [ testProperty "prop_roundtripSerialiseValue" $
+        prop_roundtripSerialiseValue @a
+    , testProperty "prop_concatDistributesSerialiseValue" $
+        prop_concatDistributesSerialiseValue @a
     ]
 
 prop_roundtripSerialiseKey :: forall k. (Eq k, Show k, SerialiseKey k) => k -> Property
@@ -47,8 +50,39 @@ prop_roundtripSerialiseKey k =
     counterexample ("deserialised: " <> show @k (deserialiseKey (serialiseKey k))) $
       serialiseKeyIdentity k
 
+prop_orderPreservationSerialiseKey :: forall k. (Ord k, SerialiseKey k) => k -> k -> Property
+prop_orderPreservationSerialiseKey x y =
+    counterexample ("serialised: " <> show (serialiseKey x, serialiseKey y)) $
+    counterexample ("compare: " <> show (compare x y)) $
+    counterexample ("compare serialised: " <> show (compare (serialiseKey x) (serialiseKey y))) $
+      serialiseKeyPreservesOrdering x y
+
 prop_roundtripSerialiseValue :: forall v. (Eq v, Show v, SerialiseValue v) => v -> Property
 prop_roundtripSerialiseValue v =
     counterexample ("serialised: " <> show (serialiseValue v)) $
     counterexample ("deserialised: " <> show @v (deserialiseValue (serialiseValue v))) $
       serialiseValueIdentity v
+
+prop_concatDistributesSerialiseValue :: forall v. (Ord v, Show v, SerialiseValue v) => v -> Property
+prop_concatDistributesSerialiseValue v =
+    forAllShrink (genChunks bytes) shrinkChunks $ (. map (RB.pack)) $ \chs ->
+      counterexample ("from chunks: " <> show (deserialiseValueN @v chs)) $
+      counterexample ("from whole: " <> show (deserialiseValue @v (mconcat chs))) $
+        serialiseValueConcatDistributes (Proxy @v) chs
+  where
+    bytes = RB.unpack (serialiseValue v)
+
+-- | Randomly splits the input list into non-empty chunks.
+genChunks :: [a] -> Gen [[a]]
+genChunks [] = pure []
+genChunks xs = do
+    n <- chooseInt (1, length xs)
+    let (pre, post) = splitAt n xs
+    (pre :) <$> genChunks post
+
+-- | Shrinks by appending chunks where possible
+shrinkChunks :: [[a]] -> [[[a]]]
+shrinkChunks (x : y : ys) =
+      ((x <> y) : ys)
+    : map (x :) (shrinkChunks (y : ys))
+shrinkChunks _ = []

--- a/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Database.LSMTree.Internal.Serialise.Class (tests) where
+
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Lazy (LazyByteString)
+import           Data.ByteString.Short (ShortByteString)
+import           Data.Primitive (ByteArray)
+import           Data.Word
+import           Database.LSMTree.Extras.Generators ()
+import           Database.LSMTree.Internal.Serialise.Class
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class" [
+      testProperty "prop_roundtripSerialiseKey @Word64" $
+        prop_roundtripSerialiseKey @Word64
+
+    , testProperty "prop_roundtripSerialiseKey @ByteString" $
+        prop_roundtripSerialiseKey @ByteString
+    , testProperty "prop_roundtripSerialiseValue @ByteString" $
+        prop_roundtripSerialiseValue @ByteString
+
+    , testProperty "prop_roundtripSerialiseKey @LazyByteString" $
+        prop_roundtripSerialiseKey @LazyByteString
+    , testProperty "prop_roundtripSerialiseValue @LazyByteString" $
+        prop_roundtripSerialiseValue @LazyByteString
+
+    , testProperty "prop_roundtripSerialiseKey @ShortByteString" $
+        prop_roundtripSerialiseKey @ShortByteString
+    , testProperty "prop_roundtripSerialiseValue @ShortByteString" $
+        prop_roundtripSerialiseValue @ShortByteString
+
+    , testProperty "prop_roundtripSerialiseKey @ByteArray" $
+        prop_roundtripSerialiseKey @ByteArray
+    , testProperty "prop_roundtripSerialiseValue @ByteArray" $
+        prop_roundtripSerialiseValue @ByteArray
+    ]
+
+prop_roundtripSerialiseKey :: forall k. (Eq k, Show k, SerialiseKey k) => k -> Property
+prop_roundtripSerialiseKey k =
+    counterexample ("serialised: " <> show (serialiseKey k)) $
+    counterexample ("deserialised: " <> show @k (deserialiseKey (serialiseKey k))) $
+      serialiseKeyIdentity k
+
+prop_roundtripSerialiseValue :: forall v. (Eq v, Show v, SerialiseValue v) => v -> Property
+prop_roundtripSerialiseValue v =
+    counterexample ("serialised: " <> show (serialiseValue v)) $
+    counterexample ("deserialised: " <> show @v (deserialiseValue (serialiseValue v))) $
+      serialiseValueIdentity v

--- a/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
@@ -17,6 +17,8 @@ tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class" [
       testProperty "prop_roundtripSerialiseKey @Word64" $
         prop_roundtripSerialiseKey @Word64
+    , testProperty "prop_roundtripSerialiseValue @Word64" $
+        prop_roundtripSerialiseValue @Word64
 
     , testProperty "prop_roundtripSerialiseKey @ByteString" $
         prop_roundtripSerialiseKey @ByteString

--- a/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
@@ -22,7 +22,7 @@ tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class"
     , testGroup "ByteString"      (allProperties @ByteString)
     , testGroup "LazyByteString"  (allProperties @LazyByteString)
     , testGroup "ShortByteString" (allProperties @ShortByteString)
-    , testGroup "ByteArray"       (allProperties @ByteArray)
+    , testGroup "ByteArray"       (valueProperties @ByteArray)
     ]
 
 allProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a, SerialiseValue a) => [TestTree]


### PR DESCRIPTION
There was one bug in the instance for Word64. Now there is just one issue left: We require that instances should preserve the ordering of their un-serialised representation, but [`ByteArray` doesn't use lexicographic ordering](https://www.stackage.org/haddock/lts-22.7/base-4.18.2.0/src/Data.Array.Byte.html#line-212). So either:

1. the instance shouldn't exist (one could use a newtype wrapper or `RawBytes` directly, if we want to expose that)
2. ~~we do some hack with serialising the length as the first byte, but that's ugly and slow~~
3. we drop the requirement on instances

I feel like option 3 might be possible, in which case it seems preferable. I think the original reasoning was about the ordering in the write buffer, but we already use `SerialisedKey` there, so I think we're good?