### PR TITLE
Add micro benchmark for write buffer

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
@@ -1,0 +1,255 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards    #-}
+
+module Bench.Database.LSMTree.Internal.WriteBuffer (benchmarks) where
+
+import           Criterion.Main (Benchmark, bench, bgroup)
+import qualified Criterion.Main as Cr
+import           Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import qualified Data.List as List
+import           Data.Word (Word64)
+import           Database.LSMTree.Extras.Orphans ()
+import           Database.LSMTree.Extras.UTxO
+import           Database.LSMTree.Internal.Run (Run)
+import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
+import qualified Database.LSMTree.Internal.WriteBuffer as WB
+import qualified Database.LSMTree.Normal as Normal
+import           Prelude hiding (getContents)
+import           System.Directory (removeDirectoryRecursive)
+import qualified System.FS.API as FS
+import qualified System.FS.IO as FS
+import           System.IO.Temp
+import qualified System.Random as R
+import           System.Random (StdGen, mkStdGen, uniform, uniformR)
+
+benchmarks :: Benchmark
+benchmarks = bgroup "Bench.Database.LSMTree.Internal.WriteBuffer" [
+      benchWriteBuffer configWord64
+        { name         = "word64-insert-10k"
+        , ninserts     = 10_000
+        }
+    , benchWriteBuffer configWord64
+        { name         = "word64-delete-10k"
+        , ndeletes     = 10_000
+        }
+    , benchWriteBuffer configWord64
+        { name         = "word64-blob-10k"
+        , nblobinserts = 10_000
+        }
+      -- different key and value sizes
+    , benchWriteBuffer configWord64
+        { name         = "insert-large-keys-2k"  -- large keys
+        , ninserts     = 2_000
+        , randomKey    = first serialiseKey . randomByteStringR (0, 4000)
+        }
+    , benchWriteBuffer configWord64
+        { name         = "insert-mix-2k"  -- small and large values
+        , ninserts     = 2_000
+        , randomValue  = first serialiseValue . randomByteStringR (0, 8000)
+        }
+    , benchWriteBuffer configWord64
+        { name         = "insert-page-2k"  -- 1 page
+        , ninserts     = 2_000
+        , randomValue  = first serialiseValue . randomByteStringR (4056, 4056)
+        }
+    , benchWriteBuffer configWord64
+        { name         = "insert-page-plus-byte-2k"  -- 1 page + 1 byte
+        , ninserts     = 2_000
+        , randomValue  = first serialiseValue . randomByteStringR (4057, 4057)
+        }
+    , benchWriteBuffer configWord64
+        { name         = "insert-huge-2k"  -- 3-5 pages
+        , ninserts     = 2_000
+        , randomValue  = first serialiseValue . randomByteStringR (10_000, 20_000)
+        }
+      -- UTxO workload
+      -- compare different buffer sizes to see superlinear cost of map insertion
+    , benchWriteBuffer configUTxO
+        { name         = "utxo-2k"
+        , ninserts     = 1_000
+        , ndeletes     = 1_000
+        }
+    , benchWriteBuffer configUTxO
+        { name         = "utxo-10k"
+        , ninserts     = 5_000
+        , ndeletes     = 5_000
+        }
+    , benchWriteBuffer configUTxO
+        { name         = "utxo-50k"
+        , ninserts     = 25_000
+        , ndeletes     = 25_000
+        }
+    ]
+
+benchWriteBuffer :: Config -> Benchmark
+benchWriteBuffer conf@Config{name} =
+    withEnv $ \ ~(_dir, hasFS, kops) ->
+      bgroup name [
+          bench "insert" $
+            Cr.whnf (\kops' -> insert kops') kops
+        , Cr.env (pure $ insert kops) $ \wb ->
+            bench "flush" $
+              Cr.perRunEnvWithCleanup getPaths (const (cleanupPaths hasFS)) $ \p -> do
+                !run <- flush hasFS p wb
+                Run.removeReference hasFS run
+        , bench "insert+flush" $
+            -- To make sure the WriteBuffer really gets recomputed on every run,
+            -- we'd like to do: `whnfAppIO (kops' -> ...) kops`.
+            -- However, we also need per-run cleanup to avoid running out of
+            -- disk space. We use `perRunEnvWithCleanup`, which has two issues:
+            -- 1. Just as `whnfAppIO` etc., it takes an IO action and returns
+            --    `Benchmarkable`, which does not compose. As a workaround, we
+            --    thread `kops` through the environment, too.
+            -- 2. It forces the result to normal form, which would traverse the
+            --    whole run, so we force to WHNF ourselves and just return `()`.
+            Cr.perRunEnvWithCleanup
+              ((,) kops <$> getPaths)
+              (const (cleanupPaths hasFS)) $ \(kops', p) -> do
+                !run <- flush hasFS p (insert kops')
+                -- Make sure to immediately close runs so we don't run out of
+                -- file handles. Ideally this would not be measured, but at
+                -- least it's pretty cheap.
+                Run.removeReference hasFS run
+        ]
+  where
+    withEnv =
+        Cr.envWithCleanup
+          (writeBufferEnv conf)
+          writeBufferEnvCleanup
+
+    -- We'll remove the files on every run, so we can re-use the same run number.
+    getPaths :: IO Run.RunFsPaths
+    getPaths = pure (Run.RunFsPaths 0)
+
+    -- Simply remove the whole active directory.
+    cleanupPaths :: FS.HasFS IO FS.HandleIO -> IO ()
+    cleanupPaths hasFS = FS.removeDirectoryRecursive hasFS Run.activeRunsDir
+
+insert :: [SerialisedKOp] -> WriteBuffer
+insert = List.foldl' (\wb (k, e) -> WB.addEntryNormal k e wb) WB.empty
+
+flush :: FS.HasFS IO FS.HandleIO -> Run.RunFsPaths -> WriteBuffer -> IO (Run (FS.Handle (FS.HandleIO)))
+flush = Run.fromWriteBuffer
+
+type SerialisedKOp = (SerialisedKey, SerialisedEntry)
+type SerialisedEntry = Normal.Update SerialisedValue SerialisedBlob
+
+{-------------------------------------------------------------------------------
+  Environments
+-------------------------------------------------------------------------------}
+
+-- | Config options describing a benchmarking scenario
+data Config = Config {
+    -- | Name for the benchmark scenario described by this config.
+    name         :: !String
+    -- | Number of key\/operation pairs in the run
+  , ninserts     :: !Int
+  , nblobinserts :: !Int
+  , ndeletes     :: !Int
+  , randomKey    :: Rnd SerialisedKey
+  , randomValue  :: Rnd SerialisedValue
+  , randomBlob   :: Rnd SerialisedBlob
+  }
+
+type Rnd a = StdGen -> (a, StdGen)
+
+defaultConfig :: Config
+defaultConfig = Config {
+    name         = "default"
+  , ninserts     = 0
+  , nblobinserts = 0
+  , ndeletes     = 0
+  , randomKey    = error "randomKey not implemented"
+  , randomValue  = error "randomValue not implemented"
+  , randomBlob   = error "randomBlob not implemented"
+  }
+
+configWord64 :: Config
+configWord64 = defaultConfig {
+    randomKey    = first serialiseKey . uniform @_ @Word64
+  , randomValue  = first serialiseValue . uniform @_ @Word64
+  , randomBlob   = first serialiseBlob . randomByteStringR (0, 0x2000)  -- up to 8 kB
+  }
+
+configUTxO :: Config
+configUTxO = defaultConfig {
+    randomKey    = first serialiseKey . uniform @_ @UTxOKey
+  , randomValue  = first serialiseValue . uniform @_ @UTxOValue
+  }
+
+writeBufferEnv ::
+     Config
+  -> IO ( FilePath -- ^ Temporary directory
+        , FS.HasFS IO FS.HandleIO
+        , [SerialisedKOp]
+        )
+writeBufferEnv config = do
+    sysTmpDir <- getCanonicalTemporaryDirectory
+    benchTmpDir <- createTempDirectory sysTmpDir "writeBufferEnv"
+    let kops = lookupsEnv config (mkStdGen 17)
+    let hasFS = FS.ioHasFS (FS.MountPoint benchTmpDir)
+    pure (benchTmpDir, hasFS, kops)
+
+writeBufferEnvCleanup ::
+     ( FilePath -- ^ Temporary directory
+     , FS.HasFS IO FS.HandleIO
+     , [SerialisedKOp]
+     )
+  -> IO ()
+writeBufferEnvCleanup (tmpDir, _, _) = do
+    removeDirectoryRecursive tmpDir
+
+-- | Generate keys and entries to insert into the write buffer.
+-- They are already serialised to exclude the cost from the benchmark.
+lookupsEnv ::
+     Config
+  -> StdGen -- ^ RNG
+  -> [SerialisedKOp]
+lookupsEnv Config {..} = take nentries . List.unfoldr (Just . randomKOp)
+  where
+    nentries = ninserts + nblobinserts + ndeletes
+
+    randomKOp :: Rnd SerialisedKOp
+    randomKOp g = let (!k, !g')  = randomKey g
+                      (!e, !g'') = randomEntry g'
+                  in  ((k, e), g'')
+
+    randomEntry :: Rnd SerialisedEntry
+    randomEntry = frequency
+        [ ( ninserts
+          , \g -> let (!v, !g') = randomValue g
+                  in  (Normal.Insert v Nothing, g')
+          )
+        , ( nblobinserts
+          , \g -> let (!v, !g') = randomValue g
+                      (!b, !g'') = randomBlob g'
+                  in  (Normal.Insert v (Just b), g'')
+          )
+        , ( ndeletes
+          , \g -> (Normal.Delete, g)
+          )
+        ]
+
+frequency :: [(Int, Rnd a)] -> Rnd a
+frequency xs0 g
+  | any ((< 0) . fst) xs0 = error "frequency: frequencies must be non-negative"
+  | tot == 0              = error "frequency: at least one frequency should be non-zero"
+  | otherwise = pick i xs0
+ where
+  (i, g') = uniformR (1, tot) g
+
+  tot = sum (map fst xs0)
+
+  pick n ((k,x):xs)
+    | n <= k    = x g'
+    | otherwise = pick (n-k) xs
+  pick _ _  = error "frequency: pick used with empty list"
+
+randomByteStringR :: (Int, Int) -> Rnd BS.ByteString
+randomByteStringR range g =
+    let (!l, !g')  = uniformR range g
+    in  R.genByteString l g'

--- a/bench/micro/Main.hs
+++ b/bench/micro/Main.hs
@@ -13,12 +13,14 @@ import qualified Bench.Database.LSMTree.Internal.BloomFilter
 import qualified Bench.Database.LSMTree.Internal.IndexCompact
 import qualified Bench.Database.LSMTree.Internal.Lookup
 import qualified Bench.Database.LSMTree.Internal.RawPage
+import qualified Bench.Database.LSMTree.Internal.WriteBuffer
 import           Criterion.Main (defaultMain)
 
 main :: IO ()
 main = defaultMain [
-      Bench.Database.LSMTree.Internal.Lookup.benchmarks
-    , Bench.Database.LSMTree.Internal.BloomFilter.benchmarks
+      Bench.Database.LSMTree.Internal.BloomFilter.benchmarks
     , Bench.Database.LSMTree.Internal.IndexCompact.benchmarks
+    , Bench.Database.LSMTree.Internal.Lookup.benchmarks
     , Bench.Database.LSMTree.Internal.RawPage.benchmarks
+    , Bench.Database.LSMTree.Internal.WriteBuffer.benchmarks
     ]

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -292,6 +292,7 @@ benchmark lsm-tree-micro-bench
     Bench.Database.LSMTree.Internal.IndexCompact
     Bench.Database.LSMTree.Internal.Lookup
     Bench.Database.LSMTree.Internal.RawPage
+    Bench.Database.LSMTree.Internal.WriteBuffer
     Database.LSMTree.Extras
     Database.LSMTree.Extras.Generators
     Database.LSMTree.Extras.Orphans

--- a/src-extras/Database/LSMTree/Extras/Generators.hs
+++ b/src-extras/Database/LSMTree/Extras/Generators.hs
@@ -559,17 +559,8 @@ shrinkSlice (RawBytes pvec) =
     , m <- QC.shrink (PV.length pvec - n)
     ]
 
-instance SerialiseKey RawBytes where
-  serialiseKey = id
-  deserialiseKey = id
-
-instance SerialiseValue RawBytes where
-  serialiseValue = id
-  deserialiseValue = id
-  deserialiseValueN = mconcat
-
+-- TODO: makes collisions very unlikely
 deriving newtype instance Arbitrary SerialisedKey
-deriving newtype instance SerialiseKey SerialisedKey
 
 instance Arbitrary SerialisedValue where
   -- good mix of sizes, including larger than two pages, also some slices
@@ -584,10 +575,7 @@ instance Arbitrary SerialisedValue where
       | RB.size rb > 64 = coerce (shrink (LargeRawBytes rb))
       | otherwise       = coerce (shrink rb)
 
-deriving newtype instance SerialiseValue SerialisedValue
-
 deriving newtype instance Arbitrary SerialisedBlob
-deriving newtype instance SerialiseValue SerialisedBlob
 
 newtype LargeRawBytes = LargeRawBytes RawBytes
   deriving Show

--- a/src-extras/Database/LSMTree/Extras/Orphans.hs
+++ b/src-extras/Database/LSMTree/Extras/Orphans.hs
@@ -22,6 +22,8 @@ import           Data.WideWord.Word128 (Word128 (..), byteSwapWord128)
 import           Data.WideWord.Word256 (Word256 (..))
 import           Database.LSMTree.Internal.Primitive (indexWord8ArrayAsWord64)
 import qualified Database.LSMTree.Internal.RawBytes as RB
+import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..),
+                     SerialisedKey (..), SerialisedValue (..))
 import           Database.LSMTree.Internal.Serialise.Class
 import           Database.LSMTree.Internal.Vector
 import           GHC.Generics
@@ -137,3 +139,26 @@ deriving anyclass instance NFData FS.FsPath
 deriving instance NFData h => NFData (FS.Handle h)
 instance NFData (FS.HasFS m h) where
   rnf x = x `seq` ()
+
+{-------------------------------------------------------------------------------
+  RawBytes
+-------------------------------------------------------------------------------}
+
+instance SerialiseKey RawBytes where
+  serialiseKey = id
+  deserialiseKey = id
+
+instance SerialiseValue RawBytes where
+  serialiseValue = id
+  deserialiseValue = id
+  deserialiseValueN = mconcat
+
+{-------------------------------------------------------------------------------
+  SerialisedKey/Value/Blob
+-------------------------------------------------------------------------------}
+
+deriving newtype instance SerialiseKey SerialisedKey
+
+deriving newtype instance SerialiseValue SerialisedValue
+
+deriving newtype instance SerialiseValue SerialisedBlob

--- a/src/Database/LSMTree/Internal/Entry.hs
+++ b/src/Database/LSMTree/Internal/Entry.hs
@@ -11,6 +11,8 @@ module Database.LSMTree.Internal.Entry (
     -- * Injections/projections
   , updateToEntryNormal
   , updateToEntryMonoidal
+  , entryToUpdateNormal
+  , entryToUpdateMonoidal
     -- * Value resolution/merging
   , combine
   , combinesMonoidal

--- a/src/Database/LSMTree/Internal/Monoidal.hs
+++ b/src/Database/LSMTree/Internal/Monoidal.hs
@@ -4,6 +4,8 @@ module Database.LSMTree.Internal.Monoidal (
     Update (..),
 ) where
 
+import           Control.DeepSeq (NFData (..))
+
 -- | Result of a single point lookup.
 data LookupResult k v =
     NotFound      !k
@@ -26,3 +28,8 @@ data Update v =
     -- | TODO: should be given a more suitable name.
   | Mupsert !v
   deriving (Show, Eq)
+
+instance NFData v => NFData (Update v) where
+  rnf (Insert v)  = rnf v
+  rnf Delete      = ()
+  rnf (Mupsert v) = rnf v

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 
 -- | The in-memory LSM level 0.
 --
@@ -31,6 +32,7 @@ module Database.LSMTree.Internal.WriteBuffer (
     rangeLookups,
 ) where
 
+import           Control.DeepSeq (NFData (..))
 import qualified Data.Map.Range as Map.R
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -53,7 +55,8 @@ import           Database.LSMTree.Internal.Serialise
 -- for these constraints and (de)serialisation to the layer above.
 newtype WriteBuffer =
   WB { unWB :: Map SerialisedKey (Entry SerialisedValue SerialisedBlob) }
-  deriving Show
+  deriving stock Show
+  deriving newtype NFData
 
 empty :: WriteBuffer
 empty = WB Map.empty


### PR DESCRIPTION
First draft, I still want to:
- factor some things out of this benchmark and the `Lookup` one it is based on
- think about which input distributions we really want to measure
- properly look at the results

<details>
<summary>benchmark output</summary>

```
benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-2k/insert
time                 687.7 μs   (686.0 μs .. 689.1 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 690.1 μs   (688.9 μs .. 692.4 μs)
std dev              5.597 μs   (3.378 μs .. 9.407 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1276688.340 (1276684.791 .. 1276692.537)
  y                  2933.008   (2505.811 .. 3405.795)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-2k/flush
time                 427.0 μs   (426.1 μs .. 428.5 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 432.2 μs   (430.7 μs .. 433.6 μs)
std dev              4.642 μs   (3.964 μs .. 6.152 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1092217.501 (1092212.452 .. 1092222.261)
  y                  -63.041    (-1041.078 .. 870.866)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-2k/insert+flush
time                 1.107 ms   (1.105 ms .. 1.110 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.111 ms   (1.108 ms .. 1.115 ms)
std dev              11.53 μs   (8.084 μs .. 17.48 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2368866.393 (2368854.284 .. 2368880.693)
  y                  -96.598    (-1352.200 .. 1252.274)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-10k/insert
time                 6.173 ms   (6.137 ms .. 6.206 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 6.134 ms   (6.096 ms .. 6.168 ms)
std dev              108.0 μs   (72.79 μs .. 180.9 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              7511647.845 (7511608.364 .. 7511689.077)
  y                  3037.808   (2060.653 .. 4146.498)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-10k/flush
time                 1.850 ms   (1.839 ms .. 1.859 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.856 ms   (1.847 ms .. 1.864 ms)
std dev              30.09 μs   (24.24 μs .. 37.60 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4737936.597 (4737936.000 .. 4737937.947)
  y                  -43.614    (-138.682 .. 7.227e-8)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-10k/insert+flush
time                 7.724 ms   (7.600 ms .. 7.819 ms)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 8.197 ms   (8.046 ms .. 8.502 ms)
std dev              600.1 μs   (381.9 μs .. 859.9 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.225e7    (1.225e7 .. 1.225e7)
  y                  261.362    (-9.014e-8 .. 585.792)
variance introduced by outliers: 41% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-50k/insert
time                 67.55 ms   (65.56 ms .. 69.15 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 69.28 ms   (67.64 ms .. 70.45 ms)
std dev              2.442 ms   (1.582 ms .. 3.978 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.345e7    (4.345e7 .. 4.345e7)
  y                  3141.236   (2071.417 .. 5754.182)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-50k/flush
time                 13.75 ms   (13.58 ms .. 13.99 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 14.27 ms   (14.15 ms .. 14.43 ms)
std dev              360.9 μs   (234.9 μs .. 588.8 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2.285e7    (2.285e7 .. 2.285e7)
  y                  1419.962   (76.447 .. 3984.122)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/word64-50k/insert+flush
time                 82.09 ms   (80.96 ms .. 82.75 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 83.78 ms   (83.21 ms .. 85.16 ms)
std dev              1.396 ms   (634.2 μs .. 2.282 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              6.630e7    (6.630e7 .. 6.630e7)
  y                  2348.800   (370.649 .. 8648.276)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-2k/insert
time                 690.3 μs   (687.3 μs .. 692.5 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 687.1 μs   (685.7 μs .. 688.7 μs)
std dev              5.127 μs   (4.393 μs .. 6.093 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1262720.601 (1262716.737 .. 1262724.545)
  y                  2957.785   (2513.431 .. 3440.825)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-2k/flush
time                 556.5 μs   (555.5 μs .. 558.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 560.5 μs   (559.2 μs .. 561.8 μs)
std dev              4.278 μs   (3.606 μs .. 5.096 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2136155.977 (2136155.270 .. 2136156.779)
  y                  -5.447     (-125.127 .. 109.114)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-2k/insert+flush
time                 1.242 ms   (1.239 ms .. 1.245 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.241 ms   (1.238 ms .. 1.244 ms)
std dev              8.501 μs   (6.815 μs .. 10.64 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3398836.122 (3398833.971 .. 3398838.208)
  y                  2.203      (-140.106 .. 153.464)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-10k/insert
time                 6.351 ms   (6.304 ms .. 6.393 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 6.261 ms   (6.197 ms .. 6.299 ms)
std dev              140.1 μs   (92.06 μs .. 230.1 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              7471083.835 (7471044.093 .. 7471123.012)
  y                  2708.030   (1957.613 .. 3659.020)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-10k/flush
time                 2.623 ms   (2.605 ms .. 2.638 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 2.649 ms   (2.636 ms .. 2.672 ms)
std dev              55.44 μs   (34.42 μs .. 95.12 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.014e7    (1.014e7 .. 1.014e7)
  y                  -58.482    (-187.392 .. 1.740e-7)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-10k/insert+flush
time                 8.862 ms   (8.779 ms .. 8.932 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 9.368 ms   (9.235 ms .. 9.617 ms)
std dev              477.0 μs   (301.4 μs .. 826.5 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.761e7    (1.761e7 .. 1.761e7)
  y                  -131.193   (-409.670 .. 1.984e-7)
variance introduced by outliers: 25% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-50k/insert
time                 67.57 ms   (66.12 ms .. 69.07 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 67.52 ms   (65.81 ms .. 69.00 ms)
std dev              2.885 ms   (1.834 ms .. 4.982 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.339e7    (4.339e7 .. 4.339e7)
  y                  3141.236   (2071.080 .. 5710.181)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-50k/flush
time                 18.16 ms   (16.15 ms .. 20.50 ms)
                     0.964 R²   (0.932 R² .. 1.000 R²)
mean                 20.05 ms   (19.16 ms .. 20.46 ms)
std dev              1.315 ms   (307.3 μs .. 2.058 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              5.002e7    (5.002e7 .. 5.002e7)
  y                  788.533    (-1040.799 .. 2584.387)
variance introduced by outliers: 27% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-50k/insert+flush
time                 95.07 ms   (93.06 ms .. 96.90 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 92.81 ms   (89.90 ms .. 94.39 ms)
std dev              3.295 ms   (1.521 ms .. 5.112 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              9.342e7    (9.342e7 .. 9.342e7)
  y                  -143.778   (-2170.000 .. 3230.740)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-2k-blob/insert
time                 704.8 μs   (700.9 μs .. 711.8 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 712.7 μs   (708.1 μs .. 718.1 μs)
std dev              16.19 μs   (13.41 μs .. 24.57 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1259200.267 (1259196.760 .. 1259204.442)
  y                  2948.745   (2497.642 .. 3453.120)
variance introduced by outliers: 13% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-2k-blob/flush
time                 2.960 ms   (2.941 ms .. 2.977 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.022 ms   (3.006 ms .. 3.042 ms)
std dev              55.63 μs   (41.79 μs .. 81.38 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.462e7    (1.462e7 .. 1.462e7)
  y                  -46.497    (-140.224 .. 2.270e-7)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-2k-blob/insert+flush
time                 3.823 ms   (3.805 ms .. 3.842 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 3.858 ms   (3.845 ms .. 3.881 ms)
std dev              53.17 μs   (33.77 μs .. 95.84 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.587e7    (1.587e7 .. 1.587e7)
  y                  -54.042    (-158.980 .. 1.949e-7)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-10k-blob/insert
time                 6.197 ms   (6.151 ms .. 6.245 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 6.162 ms   (6.125 ms .. 6.243 ms)
std dev              148.3 μs   (83.10 μs .. 253.1 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              7457413.833 (7457379.054 .. 7457451.808)
  y                  2994.890   (2157.489 .. 3927.488)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-10k-blob/flush
time                 15.68 ms   (15.58 ms .. 15.77 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 15.89 ms   (15.77 ms .. 16.27 ms)
std dev              486.9 μs   (127.1 μs .. 952.5 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              7.573e7    (7.573e7 .. 7.573e7)
  y                  -189.217   (-515.412 .. 9.893e-7)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-10k-blob/insert+flush
time                 24.41 ms   (24.21 ms .. 24.55 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 24.97 ms   (24.79 ms .. 25.28 ms)
std dev              490.6 μs   (275.7 μs .. 695.1 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              8.319e7    (8.319e7 .. 8.319e7)
  y                  -229.053   (-625.737 .. 6.514e-7)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-50k-blob/insert
time                 67.65 ms   (65.97 ms .. 68.58 ms)
                     0.998 R²   (0.993 R² .. 1.000 R²)
mean                 68.08 ms   (67.13 ms .. 69.57 ms)
std dev              2.112 ms   (1.206 ms .. 3.396 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.319e7    (4.319e7 .. 4.319e7)
  y                  2712.727   (1592.179 .. 4764.752)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-50k-blob/flush
time                 87.83 ms   (83.65 ms .. 91.73 ms)
                     0.998 R²   (0.997 R² .. 1.000 R²)
mean                 92.67 ms   (90.93 ms .. 94.21 ms)
std dev              2.688 ms   (2.039 ms .. 3.580 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.726e8    (3.726e8 .. 3.726e8)
  y                  -312.889   (-692.218 .. 3.487e-6)

benchmarking Bench.Database.LSMTree.Internal.WriteBuffer/utxo-50k-blob/insert+flush
time                 162.0 ms   (159.1 ms .. 166.0 ms)
                     1.000 R²   (0.998 R² .. 1.000 R²)
mean                 163.5 ms   (162.2 ms .. 164.4 ms)
std dev              1.509 ms   (992.5 μs .. 2.236 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.158e8    (4.158e8 .. 4.158e8)
  y                  -402.286   (-807.024 .. 3.637e-6)
variance introduced by outliers: 12% (moderately inflated)
```

</details>