### PR TITLE
apt-get update workaround

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install liburing (on Linux)
       id: setup-liburing
       run: |
-        sudo apt-get update
+        sudo apt-get update || true
         sudo apt-get -y install pkg-config
         echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
         mkdir tmp

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -61,7 +61,7 @@ jobs:
       id: setup-liburing
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
-        sudo apt-get update
+        sudo apt-get update || true
         sudo apt-get -y install liburing-dev
 
     - name: Configure the build
@@ -157,7 +157,7 @@ jobs:
 
     - name: Install system dependencies (apt-get)
       run: |
-        sudo apt-get update
+        sudo apt-get update || true
         sudo apt-get -y install fd-find
 
     - name: Setup Haskell
@@ -219,7 +219,7 @@ jobs:
 
     - name: Install system dependencies (apt-get)
       run: |
-        sudo apt-get update
+        sudo apt-get update || true
         sudo apt-get -y install fd-find
 
     - name: Setup Haskell


### PR DESCRIPTION
Let's `apt-get update` fail. We really care that the `apt-get install` succeeds.