### PR TITLE
Tighten the representation of operations in the model

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
@@ -43,8 +43,7 @@ benchmarks = rawpage `deepseq` bgroup "Bench.Database.LSMTree.Internal.RawPage"
     missing = SerialisedKey $ RB.pack [1, 2, 3]
 
     keys :: [Key]
-    keys = case page of
-        PageLogical xs -> map (\(k,_,_) -> k) xs
+    keys = case page of PageLogical xs -> map fst xs
 
     existingHead :: SerialisedKey
     existingHead = SerialisedKey $ RB.fromByteString $ unKey $ head keys

--- a/src/Database/LSMTree/Internal/PageAcc.hs
+++ b/src/Database/LSMTree/Internal/PageAcc.hs
@@ -40,13 +40,13 @@ import           Database.LSMTree.Internal.Serialise
 -- A smallest page is with empty key:
 --
 -- >>> import FormatPage
--- >>> let Just page0 = pageSizeAddElem (Key "", Delete, Nothing) pageSizeEmpty
+-- >>> let Just page0 = pageSizeAddElem (Key "", Delete) pageSizeEmpty
 -- >>> page0
 -- PageSize {pageSizeElems = 1, pageSizeBlobs = 0, pageSizeBytes = 32}
 --
 -- Then we can add pages with a single byte key, e.g.
 --
--- >>> pageSizeAddElem (Key "a", Delete, Nothing) page0
+-- >>> pageSizeAddElem (Key "a", Delete) page0
 -- Just (PageSize {pageSizeElems = 2, pageSizeBlobs = 0, pageSizeBytes = 35})
 --
 -- i.e. roughly 3-4 bytes (when we get to 32/64 elements we add more bytes for bitmaps).
@@ -54,14 +54,14 @@ import           Database.LSMTree.Internal.Serialise
 --
 -- If we write as small program, adding single byte keys to a page size:
 --
--- >>> let calc s ps = case pageSizeAddElem (Key "x", Delete, Nothing) ps of { Nothing -> s; Just ps' -> calc (s + 1) ps' }
+-- >>> let calc s ps = case pageSizeAddElem (Key "x", Delete) ps of { Nothing -> s; Just ps' -> calc (s + 1) ps' }
 -- >>> calc 1 page0
 -- 759
 --
 -- I.e. we can have a 4096 byte page with at most 759 keys, actually less,
 -- as there are only 256 single byte keys.
 --
--- >>> let calc2 s ps = case pageSizeAddElem (Key $ if s < 257 then "x" else "xx", Delete, Nothing) ps of { Nothing -> s; Just ps' -> calc2 (s + 1) ps' }
+-- >>> let calc2 s ps = case pageSizeAddElem (Key $ if s < 257 then "x" else "xx", Delete) ps of { Nothing -> s; Just ps' -> calc2 (s + 1) ps' }
 -- >>> calc2 1 page0
 -- 680
 --

--- a/test/Test/Database/LSMTree/Internal/PageAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/PageAcc.hs
@@ -26,34 +26,33 @@ tests = testGroup "Database.LSMTree.Internal.PageAcc"
     [ testProperty "prototype" prototype
 
     , testProperty "example-00" $ prototype []
-    , testProperty "example-01" $ prototype [(Proto.Key "foobar", Proto.Delete, Nothing)]
-    , testProperty "example-02" $ prototype [(Proto.Key "foobar", Proto.Insert (Proto.Value "value"), Just (Proto.BlobRef 111 333))]
-    , testProperty "example-03" $ prototype [(Proto.Key "\NUL",Proto.Delete,Nothing),(Proto.Key "\SOH",Proto.Delete,Nothing)]
+    , testProperty "example-01" $ prototype [(Proto.Key "foobar", Proto.Delete)]
+    , testProperty "example-02" $ prototype [(Proto.Key "foobar", Proto.Insert (Proto.Value "value") (Just (Proto.BlobRef 111 333)))]
+    , testProperty "example-03" $ prototype [(Proto.Key "\NUL",Proto.Delete),(Proto.Key "\SOH",Proto.Delete)]
 
     -- entries around maximal size
-    , testProperty "example-04a" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4063 120))),Nothing)]
-    , testProperty "example-04b" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4064 120))),Nothing)]
-    , testProperty "example-04c" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4065 120))),Nothing)]
+    , testProperty "example-04a" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4063 120))) Nothing)]
+    , testProperty "example-04b" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4064 120))) Nothing)]
+    , testProperty "example-04c" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4065 120))) Nothing)]
 
-    , testProperty "example-05a" $ prototype [(Proto.Key "",Proto.Delete,Nothing),(Proto.Key "k",Proto.Insert (Proto.Value (BS.pack (replicate 4060 120))),Nothing)]
-    , testProperty "example-05b" $ prototype [(Proto.Key "",Proto.Delete,Nothing),(Proto.Key "k",Proto.Insert (Proto.Value (BS.pack (replicate 4061 120))),Nothing)]
-    , testProperty "example-05c" $ prototype [(Proto.Key "",Proto.Delete,Nothing),(Proto.Key "k",Proto.Insert (Proto.Value (BS.pack (replicate 4062 120))),Nothing)]
+    , testProperty "example-05a" $ prototype [(Proto.Key "",Proto.Delete),(Proto.Key "k",Proto.Insert (Proto.Value (BS.pack (replicate 4060 120))) Nothing)]
+    , testProperty "example-05b" $ prototype [(Proto.Key "",Proto.Delete),(Proto.Key "k",Proto.Insert (Proto.Value (BS.pack (replicate 4061 120))) Nothing)]
+    , testProperty "example-05c" $ prototype [(Proto.Key "",Proto.Delete),(Proto.Key "k",Proto.Insert (Proto.Value (BS.pack (replicate 4062 120))) Nothing)]
 
-    , testProperty "example-06a" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4051 120))),Just (Proto.BlobRef 111 333))]
-    , testProperty "example-06b" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4052 120))),Just (Proto.BlobRef 111 333))]
-    , testProperty "example-06c" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4053 120))),Just (Proto.BlobRef 111 333))]
+    , testProperty "example-06a" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4051 120))) (Just (Proto.BlobRef 111 333)))]
+    , testProperty "example-06b" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4052 120))) (Just (Proto.BlobRef 111 333)))]
+    , testProperty "example-06c" $ prototype [(Proto.Key "",Proto.Insert (Proto.Value (BS.pack (replicate 4053 120))) (Just (Proto.BlobRef 111 333)))]
     ]
 
 -- | Strict 'pageSizeAddElem', doesn't allow for page to overflow
-pageSizeAddElem' :: (Proto.Key, Proto.Operation, Maybe Proto.BlobRef) -> Proto.PageSize -> Maybe Proto.PageSize
+pageSizeAddElem' :: (Proto.Key, Proto.Operation)
+                 -> Proto.PageSize -> Maybe Proto.PageSize
 pageSizeAddElem' e sz = do
     sz' <- Proto.pageSizeAddElem e sz
     guard (Proto.pageSizeBytes sz' <= 4096)
     return sz'
 
-prototype
-    :: [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)]
-    -> Property
+prototype :: [(Proto.Key, Proto.Operation)] -> Property
 prototype inputs' =
     case invariant inputs' of
         es -> runST $ do
@@ -62,36 +61,30 @@ prototype inputs' =
   where
     -- inputs should be ordered and unique to produce valid page.
     invariant xs =
-        nubBy ((==) `on` fstOf3) $
-        sortBy (compare `on` fstOf3) $
-        map cleanOp xs
+        nubBy ((==) `on` fst) $
+        sortBy (compare `on` fst) $
+        xs
 
-    -- only insert op has blob references
-    -- TODO: make values small.
-    -- If the value will overflow page, we'll need a special page anyway.
-    cleanOp :: (k, Proto.Operation, Maybe bref) -> (k, Proto.Operation, Maybe bref)
-    cleanOp (k, Proto.Delete,    _)  = (k, Proto.Delete, Nothing)
-    cleanOp (k, Proto.Mupsert v, _)  = (k, Proto.Mupsert v, Nothing)
-    cleanOp (k, Proto.Insert v,  br) = (k, Proto.Insert v, br)
-
-    fstOf3 (k,_,_) = k
-
-    go :: PageAcc s -> Proto.PageSize -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> ST s Property
-    go acc _ps acc2 []                 = finish acc acc2
-    go acc  ps acc2 (e@(k,op,bref):es) = case pageSizeAddElem' e ps of
+    go :: PageAcc s
+       -> Proto.PageSize
+       -> [(Proto.Key, Proto.Operation)]
+       -> [(Proto.Key, Proto.Operation)]
+       -> ST s Property
+    go acc _ps acc2 []            = finish acc acc2
+    go acc  ps acc2 (e@(k,op):es) = case pageSizeAddElem' e ps of
         Nothing -> do
-            added <- pageAccAddElem acc (convKey k) (convOp op bref)
+            added <- pageAccAddElem acc (convKey k) (convOp op)
             if added
             then return $ counterexample "PageAcc addition succeeded, prototype's doesn't." False
             else finish acc acc2
 
         Just ps' -> do
-            added <- pageAccAddElem acc (convKey k) (convOp op bref)
+            added <- pageAccAddElem acc (convKey k) (convOp op)
             if added
             then go acc ps' (e:acc2) es
             else return $ counterexample "PageAcc addition failed, prototype's doesn't." False
 
-    finish :: PageAcc s -> [(Proto.Key, Proto.Operation, Maybe Proto.BlobRef)] -> ST s Property
+    finish :: PageAcc s -> [(Proto.Key, Proto.Operation)] -> ST s Property
     finish acc acc2 = do
         let (lhs, _) = toRawPage $ Proto.PageLogical $ reverse acc2
         rawpage <- serialisePageAcc acc
@@ -107,8 +100,8 @@ prototype inputs' =
     convBlobSpan :: Proto.BlobRef -> BlobSpan
     convBlobSpan (Proto.BlobRef x y) = BlobSpan x y
 
-    convOp :: Proto.Operation -> Maybe Proto.BlobRef -> Entry SerialisedValue BlobSpan
-    convOp Proto.Delete      _            = Delete
-    convOp (Proto.Mupsert v) _            = Mupdate (convValue v)
-    convOp (Proto.Insert v)  Nothing      = Insert (convValue v)
-    convOp (Proto.Insert v)  (Just bspan) = InsertWithBlob (convValue v) (convBlobSpan bspan)
+    convOp :: Proto.Operation -> Entry SerialisedValue BlobSpan
+    convOp Proto.Delete                  = Delete
+    convOp (Proto.Mupsert v)             = Mupdate (convValue v)
+    convOp (Proto.Insert v Nothing)      = Insert (convValue v)
+    convOp (Proto.Insert v (Just bspan)) = InsertWithBlob (convValue v) (convBlobSpan bspan)

--- a/test/Test/Database/LSMTree/Internal/PageAcc1.hs
+++ b/test/Test/Database/LSMTree/Internal/PageAcc1.hs
@@ -45,8 +45,8 @@ prototype k v br =
     .&&. counterexample "overflow pages do not match"
            (loverflow === roverflow)
   where
-    (lhs, loverflow) = toRawPage $ Proto.PageLogical [(k, Proto.Insert v, br)]
-    (rhs, roverflow) = singletonPage (convKey k) (convOp (Proto.Insert v) br)
+    (lhs, loverflow) = toRawPage $ Proto.PageLogical [(k, Proto.Insert v br)]
+    (rhs, roverflow) = singletonPage (convKey k) (convOp (Proto.Insert v br))
 
 prototypeU
     :: Proto.Key
@@ -58,8 +58,8 @@ prototypeU k v =
     .&&. counterexample "overflow pages do not match"
            (loverflow === roverflow)
   where
-    (lhs, loverflow) = toRawPage $ Proto.PageLogical [(k, Proto.Mupsert v, Nothing)]
-    (rhs, roverflow) = singletonPage (convKey k) (convOp (Proto.Mupsert v) Nothing)
+    (lhs, loverflow) = toRawPage $ Proto.PageLogical [(k, Proto.Mupsert v)]
+    (rhs, roverflow) = singletonPage (convKey k) (convOp (Proto.Mupsert v))
 
 convKey :: Proto.Key -> SerialisedKey
 convKey (Proto.Key k) = SerialisedKey $ RB.fromByteString k
@@ -70,8 +70,9 @@ convValue (Proto.Value v) = SerialisedValue $ RB.fromByteString v
 convBlobSpan :: Proto.BlobRef -> BlobSpan
 convBlobSpan (Proto.BlobRef x y) = BlobSpan x y
 
-convOp :: Proto.Operation -> Maybe Proto.BlobRef -> Entry SerialisedValue BlobSpan
-convOp Proto.Delete      _            = Delete
-convOp (Proto.Mupsert v) _            = Mupdate (convValue v)
-convOp (Proto.Insert v)  Nothing      = Insert (convValue v)
-convOp (Proto.Insert v)  (Just bspan) = InsertWithBlob (convValue v) (convBlobSpan bspan)
+convOp :: Proto.Operation -> Entry SerialisedValue BlobSpan
+convOp Proto.Delete                  = Delete
+convOp (Proto.Mupsert v)             = Mupdate (convValue v)
+convOp (Proto.Insert v  Nothing)     = Insert (convValue v)
+convOp (Proto.Insert v (Just bspan)) = InsertWithBlob (convValue v)
+                                                     (convBlobSpan bspan)

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -140,7 +140,8 @@ testSingleInsert sessionRoot key val mblob = do
              (Proto.PageLogical
                [ ( Proto.Key (coerce RB.toByteString key)
                  , Proto.Insert (Proto.Value (coerce RB.toByteString val))
-                 , Nothing ) ])
+                                Nothing
+                 ) ])
         suffix, prefix :: Int
         suffix = max 0 (pagesize - 4096)
         prefix = coerce RB.size val - suffix


### PR DESCRIPTION
We use the reference implementation as a source of truth in tests of our implementation of code that works with the page format. The changes here are intended to reduce the difference between the reference implementation and real implementation, to make the tests simpler and better.

Previously, the model/prototype allowed an optional blob ref with every operation. Our real implementation however only allows a blob to be associated with an insert. We now think the latter makes more sense, so we now tighten the model to do the same:
```    
    data Operation = Insert  Value (Maybe BlobRef)
                   | Mupsert Value
                   | Delete
```
This also makes some of the tests simpler, since they match up more directly.
