### PR TITLE
Move module Run.FsPaths

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -66,9 +66,9 @@ library
     Database.LSMTree.Internal.RawOverflowPage
     Database.LSMTree.Internal.RawPage
     Database.LSMTree.Internal.Run
-    Database.LSMTree.Internal.Run.FsPaths
     Database.LSMTree.Internal.RunAcc
     Database.LSMTree.Internal.RunBuilder
+    Database.LSMTree.Internal.RunFsPaths
     Database.LSMTree.Internal.RunReader
     Database.LSMTree.Internal.Serialise
     Database.LSMTree.Internal.Serialise.Class

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -71,9 +71,9 @@ import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import           Database.LSMTree.Internal.IndexCompact (IndexCompact, NumPages)
 import qualified Database.LSMTree.Internal.IndexCompact as Index
 import qualified Database.LSMTree.Internal.RawBytes as RB
-import           Database.LSMTree.Internal.Run.FsPaths as FsPaths
 import           Database.LSMTree.Internal.RunBuilder (RunBuilder)
 import qualified Database.LSMTree.Internal.RunBuilder as Builder
+import           Database.LSMTree.Internal.RunFsPaths as FsPaths
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -33,9 +33,9 @@ import           Database.LSMTree.Internal.RawOverflowPage (RawOverflowPage)
 import qualified Database.LSMTree.Internal.RawOverflowPage as RawOverflowPage
 import           Database.LSMTree.Internal.RawPage (RawPage)
 import qualified Database.LSMTree.Internal.RawPage as RawPage
-import           Database.LSMTree.Internal.Run.FsPaths
 import           Database.LSMTree.Internal.RunAcc (RunAcc)
 import qualified Database.LSMTree.Internal.RunAcc as RunAcc
+import           Database.LSMTree.Internal.RunFsPaths
 import           Database.LSMTree.Internal.Serialise
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS)

--- a/src/Database/LSMTree/Internal/RunFsPaths.hs
+++ b/src/Database/LSMTree/Internal/RunFsPaths.hs
@@ -1,4 +1,4 @@
-module Database.LSMTree.Internal.Run.FsPaths (
+module Database.LSMTree.Internal.RunFsPaths (
     RunFsPaths (..)
   , runFsPaths
   , runKOpsPath

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -29,7 +29,7 @@ import           Database.LSMTree.Internal.RawOverflowPage (RawOverflowPage,
 import           Database.LSMTree.Internal.RawPage
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
-import           Database.LSMTree.Internal.Run.FsPaths
+import           Database.LSMTree.Internal.RunFsPaths
 import           Database.LSMTree.Internal.Serialise
 import qualified System.FS.API as FS
 import           System.FS.API (HasBufFS, HasFS)


### PR DESCRIPTION
The last step of flattening the `Run` hierarchy (and thus concluding #106).