### PR TITLE
Micro benchmark for run merging

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -25,8 +25,8 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import           Database.LSMTree.Extras.Orphans ()
-import           Database.LSMTree.Extras.Random (sampleUniformWithReplacement,
-                     uniformWithoutReplacement)
+import           Database.LSMTree.Extras.Random (frequency,
+                     sampleUniformWithReplacement, uniformWithoutReplacement)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
 import           Database.LSMTree.Internal.Lookup (BatchSize (..),
@@ -184,21 +184,6 @@ lookupsEnv g nentries npos nneg = do
     assert (Map.size entries' == nentries) $ pure ()
     assert (length lookups' == npos + nneg) $ pure ()
     pure (entries', lookups')
-
-frequency :: [(Int, StdGen -> (a, StdGen))] -> StdGen -> (a, StdGen)
-frequency xs0 g
-  | any ((< 0) . fst) xs0 = error "frequency: frequencies must be non-negative"
-  | tot == 0              = error "frequency: at least one frequency should be non-zero"
-  | otherwise = pick i xs0
- where
-  (i, g') = uniformR (1, tot) g
-
-  tot = sum (map fst xs0)
-
-  pick n ((k,x):xs)
-    | n <= k    = x g'
-    | otherwise = pick (n-k) xs
-  pick _ _  = error "QuickCheck.pick used with empty list"
 
 -- TODO: tweak distribution
 randomEntry :: StdGen -> (Entry UTxOValue UTxOBlob, StdGen)

--- a/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
@@ -1,0 +1,412 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Bench.Database.LSMTree.Internal.Merge (benchmarks) where
+
+import           Control.Monad (when, zipWithM)
+import           Criterion.Main (Benchmark, bench, bgroup)
+import qualified Criterion.Main as Cr
+import           Data.Bifunctor (first)
+import qualified Data.BloomFilter.Hash as Hash
+import           Data.Foldable (traverse_)
+import qualified Data.List as List
+import           Data.Maybe (fromMaybe)
+import           Data.Word (Word64)
+import           Database.LSMTree.Extras.Orphans ()
+import qualified Database.LSMTree.Extras.Random as R
+import           Database.LSMTree.Extras.UTxO
+import           Database.LSMTree.Internal.Entry
+import qualified Database.LSMTree.Internal.Merge as Merge
+import           Database.LSMTree.Internal.Run (Run)
+import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.RunFsPaths (RunFsPaths (..),
+                     pathsForRunFiles, runChecksumsPath)
+import           Database.LSMTree.Internal.Serialise
+import qualified Database.LSMTree.Internal.WriteBuffer as WB
+import           Prelude hiding (getContents)
+import           System.Directory (removeDirectoryRecursive)
+import qualified System.FS.API as FS
+import qualified System.FS.IO as FS
+import           System.IO.Temp
+import qualified System.Random as R
+import           System.Random (StdGen, mkStdGen, uniform, uniformR)
+
+benchmarks :: Benchmark
+benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
+      -- various numbers of runs
+      benchMerge configWord64
+        { name         = "word64-insert-x2"
+        , nentries     = totalEntries `splitInto` 2
+        , finserts     = 1
+        }
+    , benchMerge configWord64
+        { name         = "word64-insert-x4"
+        , nentries     = totalEntries `splitInto` 4
+        , finserts     = 1
+        }
+    , benchMerge configWord64
+        { name         = "word64-insert-x7"
+        , nentries     = totalEntries `splitInto` 7
+        , finserts     = 1
+        }
+    , benchMerge configWord64
+        { name         = "word64-insert-x13"
+        , nentries     = totalEntries `splitInto` 13
+        , finserts     = 1
+        }
+      -- different operations
+    , benchMerge configWord64
+        { name         = "word64-delete-x4"
+        , nentries     = totalEntries `splitInto` 4
+        , fdeletes     = 1
+        }
+    , benchMerge configWord64
+        { name         = "word64-blob-x4"
+        , nentries     = totalEntries `splitInto` 4
+        , fblobinserts = 1
+        }
+    , benchMerge configWord64
+        { name         = "word64-mupsert-x4"  -- basically no collisions
+        , nentries     = totalEntries `splitInto` 4
+        , fmupserts    = 1
+        , mergeMappend = Just (onDeserialisedValues ((+) @Word64))
+        }
+    , benchMerge configWord64
+        { name         = "word64-mupsert-collisions-x4"
+        , nentries     = totalEntries `splitInto` 4
+        , fmupserts    = 1
+        , randomKey    = -- each run uses half of the possible keys
+                         randomWord64OutOf (totalEntries `div` 2)
+        , mergeMappend = Just (onDeserialisedValues ((+) @Word64))
+        }
+    , benchMerge configWord64
+        { name         = "word64-mix-x4"
+        , nentries     = totalEntries `splitInto` 4
+        , finserts     = 1
+        , fdeletes     = 1
+        , fmupserts    = 1
+        , mergeMappend = Just (onDeserialisedValues ((+) @Word64))
+        }
+    , benchMerge configWord64
+        { name         = "word64-mix-collisions-x4"
+        , nentries     = totalEntries `splitInto` 4
+        , finserts     = 1
+        , fdeletes     = 1
+        , fmupserts    = 1
+        , randomKey    = -- each run uses half of the possible keys
+                         randomWord64OutOf (totalEntries `div` 2)
+        , mergeMappend = Just (onDeserialisedValues ((+) @Word64))
+        }
+      -- not writing anything at all
+    , benchMerge configWord64
+        { name         = "word64-delete-x4-lastlevel"
+        , nentries     = totalEntries `splitInto` 4
+        , fdeletes     = 1
+        , mergeLevel   = Merge.LastLevel
+        }
+      -- different key and value sizes
+    , benchMerge configWord64
+        { name         = "insert-large-keys-x4"  -- potentially long keys
+        , nentries     = (totalEntries `div` 10) `splitInto` 4
+        , finserts     = 1
+        , randomKey    = first serialiseKey . R.randomByteStringR (6, 4000)
+        }
+    , benchMerge configWord64
+        { name         = "insert-mixed-vals-x4"  -- potentially long values
+        , nentries     = (totalEntries `div` 10) `splitInto` 4
+        , finserts     = 1
+        , randomValue  = first serialiseValue . R.randomByteStringR (0, 4000)
+        }
+    , benchMerge configWord64
+        { name         = "insert-page-x4"  -- 1 page
+        , nentries     = (totalEntries `div` 10) `splitInto` 4
+        , finserts     = 1
+        , randomValue  = first serialiseValue . R.randomByteStringR (4056, 4056)
+        }
+    , benchMerge configWord64
+        { name         = "insert-page-plus-byte-x4"  -- 1 page + 1 byte
+        , nentries     = (totalEntries `div` 10) `splitInto` 4
+        , finserts     = 1
+        , randomValue  = first serialiseValue . R.randomByteStringR (4057, 4057)
+        }
+    , benchMerge configWord64
+        { name         = "insert-huge-vals-x4"  -- 1-5 pages
+        , nentries     = (totalEntries `div` 10) `splitInto` 4
+        , finserts     = 1
+        , randomValue  = first serialiseValue . R.randomByteStringR (10_000, 20_000)
+        }
+      -- common UTxO scenarios
+    , benchMerge configUTxO
+        { name         = "utxo-x4"  -- like tiering merge
+        , nentries     = totalEntries `splitInto` 4
+        , finserts     = 1
+        , fdeletes     = 1
+        }
+    , benchMerge configUTxO
+        { name         = "utxo-x4-uneven"
+        , nentries     = totalEntries `distributed` [1, 3, 1.5, 2.5]
+        , finserts     = 1
+        , fdeletes     = 1
+        }
+    , benchMerge configUTxO
+        { name         = "utxo-x4-lastlevel"
+        , nentries     = totalEntries `splitInto` 4
+        , finserts     = 1
+        , fdeletes     = 1
+        , mergeLevel   = Merge.LastLevel
+        }
+    , benchMerge configUTxO
+        { name         = "utxo-x4+1-min-skewed-lastlevel"  -- live levelling merge
+        , nentries     = totalEntries `distributed` [1, 1, 1, 1, 4]
+        , finserts     = 1
+        , fdeletes     = 1
+        , mergeLevel   = Merge.LastLevel
+        }
+    , benchMerge configUTxO
+        { name         = "utxo-x4+1-max-skewed-lastlevel"  -- live levelling merge
+        , nentries     = totalEntries `distributed` [1, 1, 1, 1, 16]
+        , finserts     = 1
+        , fdeletes     = 1
+        , mergeLevel   = Merge.LastLevel
+        }
+    ]
+  where
+    totalEntries = 50_000
+
+    splitInto :: Int -> Int -> [Int]
+    n `splitInto` k = n `distributed` replicate k 1
+
+    distributed :: Int -> [Double] -> [Int]
+    n `distributed` weights =
+      let total = sum weights
+      in [ round (fromIntegral n * w / total)
+         | w <- weights
+         ]
+
+benchMerge :: Config -> Benchmark
+benchMerge conf@Config{name} =
+    withEnv $ \ ~(_dir, hasFS, runs) ->
+      bgroup name [
+          bench "merge" $
+            -- We'd like to do: `whnfAppIO (runs' -> ...) runs`.
+            -- However, we also need per-run cleanup to avoid running out of
+            -- disk space. We use `perRunEnvWithCleanup`, which has two issues:
+            -- 1. Just as `whnfAppIO` etc., it takes an IO action and returns
+            --    `Benchmarkable`, which does not compose. As a workaround, we
+            --    thread `runs` through the environment, too.
+            -- 2. It forces the result to normal form, which would traverse the
+            --    whole run, so we force to WHNF ourselves and just return `()`.
+            Cr.perRunEnvWithCleanup
+              (pure (runs, outputRunPaths))
+              (const (removeOutputRunFiles hasFS)) $ \(runs', p) -> do
+                !run <- merge hasFS conf p runs'
+                -- Make sure to immediately close resulting runs so we don't run
+                -- out of file handles. Ideally this would not be measured, but at
+                -- least it's pretty cheap.
+                Run.removeReference hasFS run
+        ]
+  where
+    withEnv =
+        Cr.envWithCleanup
+          (mergeEnv conf)
+          mergeEnvCleanup
+
+    -- We need to keep the input runs, but remove the freshly created one.
+    removeOutputRunFiles :: FS.HasFS IO FS.HandleIO -> IO ()
+    removeOutputRunFiles hasFS = do
+        traverse_ (FS.removeFile hasFS) (pathsForRunFiles outputRunPaths)
+        exists <- FS.doesFileExist hasFS (runChecksumsPath outputRunPaths)
+        when exists $
+          FS.removeFile hasFS (runChecksumsPath outputRunPaths)
+
+merge ::
+     FS.HasFS IO FS.HandleIO
+  -> Config
+  -> Run.RunFsPaths
+  -> InputRuns
+  -> IO (Run (FS.Handle (FS.HandleIO)))
+merge fs Config {..} targetPaths runs = do
+    let f = fromMaybe const mergeMappend
+    m <- fromMaybe (error "empty inputs, no merge created") <$>
+      Merge.new fs mergeLevel f targetPaths runs
+    go m
+  where
+    go m =
+        Merge.steps fs m stepSize >>= \case
+          Merge.MergeComplete run -> return run
+          Merge.MergeInProgress -> go m
+
+outputRunPaths :: Run.RunFsPaths
+outputRunPaths = RunFsPaths 0
+
+inputRunPaths :: [Run.RunFsPaths]
+inputRunPaths = RunFsPaths <$> [1..]
+
+type InputRuns = [Run (FS.Handle FS.HandleIO)]
+
+type Mappend = SerialisedValue -> SerialisedValue -> SerialisedValue
+
+onDeserialisedValues :: SerialiseValue v => (v -> v -> v) -> Mappend
+onDeserialisedValues f x y =
+    serialiseValue (f (deserialiseValue x) (deserialiseValue y))
+
+type SerialisedKOp = (SerialisedKey, SerialisedEntry)
+type SerialisedEntry = Entry SerialisedValue SerialisedBlob
+
+{-------------------------------------------------------------------------------
+  Environments
+-------------------------------------------------------------------------------}
+
+-- | Config options describing a benchmarking scenario
+data Config = Config {
+    -- | Name for the benchmark scenario described by this config.
+    name         :: !String
+    -- | Number of key\/operation pairs, one for each run.
+  , nentries     :: ![Int]
+    -- | Frequency of inserts within the key\/op pairs.
+  , finserts     :: !Int
+    -- | Frequency of inserts with blobs within the key\/op pairs.
+  , fblobinserts :: !Int
+    -- | Frequency of deletes within the key\/op pairs.
+  , fdeletes     :: !Int
+    -- | Frequency of mupserts within the key\/op pairs.
+  , fmupserts    :: !Int
+  , randomKey    :: Rnd SerialisedKey
+  , randomValue  :: Rnd SerialisedValue
+  , randomBlob   :: Rnd SerialisedBlob
+  , mergeLevel   :: !Merge.Level
+    -- | Needs to be defined when generating mupserts.
+  , mergeMappend :: !(Maybe Mappend)
+    -- | Merging is done in chunks of @stepSize@ entries.
+  , stepSize     :: !Int
+  }
+
+type Rnd a = StdGen -> (a, StdGen)
+
+defaultConfig :: Config
+defaultConfig = Config {
+    name         = "default"
+  , nentries     = []
+  , finserts     = 0
+  , fblobinserts = 0
+  , fdeletes     = 0
+  , fmupserts    = 0
+  , randomKey    = error "randomKey not implemented"
+  , randomValue  = error "randomValue not implemented"
+  , randomBlob   = error "randomBlob not implemented"
+  , mergeLevel   = Merge.MidLevel
+  , mergeMappend = Nothing
+  , stepSize     = maxBound  -- by default, just do in one go
+  }
+
+configWord64 :: Config
+configWord64 = defaultConfig {
+    randomKey    = first serialiseKey . uniform @_ @Word64
+  , randomValue  = first serialiseValue . uniform @_ @Word64
+  , randomBlob   = first serialiseBlob . R.randomByteStringR (0, 0x2000)  -- up to 8 kB
+  }
+
+configUTxO :: Config
+configUTxO = defaultConfig {
+    randomKey    = first serialiseKey . uniform @_ @UTxOKey
+  , randomValue  = first serialiseValue . uniform @_ @UTxOValue
+  }
+
+mergeEnv ::
+     Config
+  -> IO ( FilePath -- ^ Temporary directory
+        , FS.HasFS IO FS.HandleIO
+        , InputRuns
+        )
+mergeEnv config = do
+    sysTmpDir <- getCanonicalTemporaryDirectory
+    benchTmpDir <- createTempDirectory sysTmpDir "mergeEnv"
+    let hasFS = FS.ioHasFS (FS.MountPoint benchTmpDir)
+    runs <- randomRuns hasFS config (mkStdGen 17)
+    pure (benchTmpDir, hasFS, runs)
+
+mergeEnvCleanup ::
+     ( FilePath -- ^ Temporary directory
+     , FS.HasFS IO FS.HandleIO
+     , InputRuns
+     )
+  -> IO ()
+mergeEnvCleanup (tmpDir, hasFS, runs) = do
+    traverse_ (Run.removeReference hasFS) runs
+    removeDirectoryRecursive tmpDir
+
+-- | Generate keys and entries to insert into the write buffer.
+-- They are already serialised to exclude the cost from the benchmark.
+randomRuns ::
+     FS.HasFS IO FS.HandleIO
+  -> Config
+  -> StdGen
+  -> IO InputRuns
+randomRuns hasFS config@Config {..} =
+      zipWithM (createRun hasFS mergeMappend) inputRunPaths
+    . zipWith (randomKOps config) nentries
+    . List.unfoldr (Just . R.split)
+
+createRun ::
+     FS.HasFS IO h
+  -> Maybe Mappend
+  -> Run.RunFsPaths
+  -> [SerialisedKOp]
+  -> IO (Run (FS.Handle h))
+createRun hasFS mMappend targetPath =
+      Run.fromWriteBuffer hasFS targetPath
+    . List.foldl insert WB.empty
+  where
+    insert wb (k, e) = case mMappend of
+      Nothing -> WB.addEntryNormal k (expectNormal e) wb
+      Just f  -> WB.addEntryMonoidal f k (expectMonoidal e) wb
+
+    expectNormal e = fromMaybe (error ("invalid normal update: " <> show e))
+                       (entryToUpdateNormal e)
+    expectMonoidal e = fromMaybe (error ("invalid monoidal update: " <> show e))
+                       (entryToUpdateMonoidal e)
+
+-- | Generate keys and entries to insert into the write buffer.
+-- They are already serialised to exclude the cost from the benchmark.
+randomKOps ::
+     Config
+  -> Int  -- ^ number of entries
+  -> StdGen -- ^ RNG
+  -> [SerialisedKOp]
+randomKOps Config {..} runentries g0 =
+    zip
+      (R.withoutReplacement g1 runentries randomKey)
+      (R.withReplacement g2 runentries randomEntry)
+  where
+    (g1, g2) = R.split g0
+
+    randomEntry :: Rnd SerialisedEntry
+    randomEntry = R.frequency
+        [ ( finserts
+          , \g -> let (!v, !g') = randomValue g
+                  in  (Insert v, g')
+          )
+        , ( fblobinserts
+          , \g -> let (!v, !g') = randomValue g
+                      (!b, !g'') = randomBlob g'
+                  in  (InsertWithBlob v b, g'')
+          )
+        , ( fdeletes
+          , \g -> (Delete, g)
+          )
+        , ( fmupserts
+          , \g -> let (!v, !g') = randomValue g
+                  in  (Mupdate v, g')
+          )
+        ]
+
+-- | @randomWord64OutOf n@ generates one out of @n@ distinct keys, which are
+-- uniformly distributed.
+-- This can be used to make collisions more likely.
+--
+-- Make sure to pick an @n@ that is significantly larger than the size of a run!
+-- Each run entry needs a distinct key.
+randomWord64OutOf :: Int -> Rnd SerialisedKey
+randomWord64OutOf possibleKeys =
+      first (serialiseKey . Hash.hash64)
+    . uniformR (0, fromIntegral possibleKeys :: Word64)

--- a/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
@@ -8,11 +8,11 @@ import           Control.DeepSeq (NFData (..))
 import           Criterion.Main (Benchmark, bench, bgroup)
 import qualified Criterion.Main as Cr
 import           Data.Bifunctor (first)
-import qualified Data.ByteString as BS
 import qualified Data.List as List
 import           Data.Maybe (fromMaybe)
 import           Data.Word (Word64)
 import           Database.LSMTree.Extras.Orphans ()
+import           Database.LSMTree.Extras.Random (frequency, randomByteStringR)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Run (Run)
@@ -30,8 +30,7 @@ import           System.Directory (removeDirectoryRecursive)
 import qualified System.FS.API as FS
 import qualified System.FS.IO as FS
 import           System.IO.Temp
-import qualified System.Random as R
-import           System.Random (StdGen, mkStdGen, uniform, uniformR)
+import           System.Random (StdGen, mkStdGen, uniform)
 
 benchmarks :: Benchmark
 benchmarks = bgroup "Bench.Database.LSMTree.Internal.WriteBuffer" [
@@ -280,23 +279,3 @@ lookupsEnv Config {..} = take nentries . List.unfoldr (Just . randomKOp)
                   in  (Mupdate v, g')
           )
         ]
-
-frequency :: [(Int, Rnd a)] -> Rnd a
-frequency xs0 g
-  | any ((< 0) . fst) xs0 = error "frequency: frequencies must be non-negative"
-  | tot == 0              = error "frequency: at least one frequency should be non-zero"
-  | otherwise = pick i xs0
- where
-  (i, g') = uniformR (1, tot) g
-
-  tot = sum (map fst xs0)
-
-  pick n ((k,x):xs)
-    | n <= k    = x g'
-    | otherwise = pick (n-k) xs
-  pick _ _  = error "frequency: pick used with empty list"
-
-randomByteStringR :: (Int, Int) -> Rnd BS.ByteString
-randomByteStringR range g =
-    let (!l, !g')  = uniformR range g
-    in  R.genByteString l g'

--- a/bench/micro/Main.hs
+++ b/bench/micro/Main.hs
@@ -12,6 +12,7 @@ module Main (main) where
 import qualified Bench.Database.LSMTree.Internal.BloomFilter
 import qualified Bench.Database.LSMTree.Internal.IndexCompact
 import qualified Bench.Database.LSMTree.Internal.Lookup
+import qualified Bench.Database.LSMTree.Internal.Merge
 import qualified Bench.Database.LSMTree.Internal.RawPage
 import qualified Bench.Database.LSMTree.Internal.WriteBuffer
 import           Criterion.Main (defaultMain)
@@ -21,6 +22,7 @@ main = defaultMain [
       Bench.Database.LSMTree.Internal.BloomFilter.benchmarks
     , Bench.Database.LSMTree.Internal.IndexCompact.benchmarks
     , Bench.Database.LSMTree.Internal.Lookup.benchmarks
+    , Bench.Database.LSMTree.Internal.Merge.benchmarks
     , Bench.Database.LSMTree.Internal.RawPage.benchmarks
     , Bench.Database.LSMTree.Internal.WriteBuffer.benchmarks
     ]

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -291,6 +291,7 @@ benchmark lsm-tree-micro-bench
     Bench.Database.LSMTree.Internal.BloomFilter
     Bench.Database.LSMTree.Internal.IndexCompact
     Bench.Database.LSMTree.Internal.Lookup
+    Bench.Database.LSMTree.Internal.Merge
     Bench.Database.LSMTree.Internal.RawPage
     Bench.Database.LSMTree.Internal.WriteBuffer
     Database.LSMTree.Extras

--- a/src-extras/Database/LSMTree/Extras/Random.hs
+++ b/src-extras/Database/LSMTree/Extras/Random.hs
@@ -6,10 +6,16 @@ module Database.LSMTree.Extras.Random (
   , uniformWithReplacement
   , sampleUniformWithoutReplacement
   , sampleUniformWithReplacement
+    -- * Sampling from multiple distributions
+  , frequency
+    -- * Generators for specific data types
+  , randomByteStringR
   ) where
 
+import qualified Data.ByteString as BS
 import           Data.List (unfoldr)
 import qualified Data.Set as Set
+import qualified System.Random as R
 import           System.Random (StdGen, Uniform, uniform, uniformR)
 import           Text.Printf (printf)
 
@@ -57,3 +63,38 @@ sampleUniformWithReplacement rng0 n xs0 = take n $
       where
         (i, rng') = uniformR (0, Set.size xs - 1) rng
         !x        = Set.elemAt i xs
+
+{-------------------------------------------------------------------------------
+  Sampling from multiple distributions
+-------------------------------------------------------------------------------}
+
+-- | Chooses one of the given generators, with a weighted random distribution.
+-- The input list must be non-empty, weights should be non-negative, and the sum
+-- of weights should be non-zero (i.e., at least one weight should be positive).
+--
+-- Based on the implementation in @QuickCheck@.
+frequency :: [(Int, StdGen -> (a, StdGen))] -> StdGen -> (a, StdGen)
+frequency xs0 g
+  | any ((< 0) . fst) xs0 = error "frequency: frequencies must be non-negative"
+  | tot == 0              = error "frequency: at least one frequency should be non-zero"
+  | otherwise = pick i xs0
+ where
+  (i, g') = uniformR (1, tot) g
+
+  tot = sum (map fst xs0)
+
+  pick n ((k,x):xs)
+    | n <= k    = x g'
+    | otherwise = pick (n-k) xs
+  pick _ _  = error "frequency: pick used with empty list"
+
+{-------------------------------------------------------------------------------
+  Generators for specific data types
+-------------------------------------------------------------------------------}
+
+-- | Generates a random bytestring. Its length is uniformly distributed within
+-- the provided range.
+randomByteStringR :: (Int, Int) -> StdGen -> (BS.ByteString, StdGen)
+randomByteStringR range g =
+    let (!l, !g')  = uniformR range g
+    in  R.genByteString l g'


### PR DESCRIPTION
Output:

<details>

```
benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x2/merge
time                 12.58 ms   (12.50 ms .. 12.66 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 12.52 ms   (12.48 ms .. 12.58 ms)
std dev              128.4 μs   (88.78 μs .. 215.9 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.496e7    (4.496e7 .. 4.496e7)
  y                  -28.758    (-1143.358 .. 1049.724)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x4/merge
time                 14.25 ms   (14.20 ms .. 14.29 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 14.21 ms   (14.18 ms .. 14.25 ms)
std dev              78.37 μs   (58.54 μs .. 113.9 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.499e7    (4.499e7 .. 4.499e7)
  y                  -136.455   (-1323.932 .. 1207.667)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x7/merge
time                 15.77 ms   (15.71 ms .. 15.82 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 15.75 ms   (15.72 ms .. 15.86 ms)
std dev              133.0 μs   (54.35 μs .. 263.1 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.504e7    (4.504e7 .. 4.504e7)
  y                  3.148      (-60.479 .. 63.803)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x13/merge
time                 17.36 ms   (17.31 ms .. 17.41 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 17.41 ms   (17.37 ms .. 17.52 ms)
std dev              152.7 μs   (67.17 μs .. 292.4 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.517e7    (4.517e7 .. 4.517e7)
  y                  -112.569   (-1013.016 .. 788.339)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-delete-x4/merge
time                 13.63 ms   (13.60 ms .. 13.66 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 13.64 ms   (13.61 ms .. 13.69 ms)
std dev              89.54 μs   (38.76 μs .. 178.3 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.754e7    (3.754e7 .. 3.754e7)
  y                  110.844    (-933.824 .. 1054.549)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-blob-x4/merge
time                 350.7 ms   (350.1 ms .. 351.9 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 352.3 ms   (351.6 ms .. 353.4 ms)
std dev              1.112 ms   (58.81 μs .. 1.388 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.567e9    (1.567e9 .. 1.567e9)
  y                  -752.000   (-1504.000 .. 6.898e-6)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-mupsert-collisions-x4/merge
time                 11.36 ms   (11.33 ms .. 11.39 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 11.40 ms   (11.37 ms .. 11.50 ms)
std dev              128.1 μs   (33.62 μs .. 254.4 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.615e7    (3.614e7 .. 3.615e7)
  y                  -3.538     (-903.746 .. 840.478)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-mix-x4/merge
time                 15.83 ms   (15.80 ms .. 15.86 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 15.88 ms   (15.84 ms .. 15.95 ms)
std dev              117.6 μs   (27.07 μs .. 224.0 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.248e7    (4.248e7 .. 4.248e7)
  y                  -296.735   (-1376.169 .. 950.580)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-mix-collisions-x4/merge
time                 11.88 ms   (11.86 ms .. 11.90 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 11.92 ms   (11.89 ms .. 11.98 ms)
std dev              97.85 μs   (35.90 μs .. 187.2 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.262e7    (3.262e7 .. 3.262e7)
  y                  454.457    (-842.262 .. 1606.995)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-large-keys-x4/merge
time                 27.80 ms   (27.68 ms .. 27.91 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.71 ms   (27.65 ms .. 27.76 ms)
std dev              117.7 μs   (88.09 μs .. 162.6 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.707e8    (1.707e8 .. 1.707e8)
  y                  87.111     (-1.524e-6 .. 229.760)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-mixed-vals-x4/merge
time                 28.15 ms   (28.00 ms .. 28.35 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.59 ms   (27.33 ms .. 27.79 ms)
std dev              504.4 μs   (376.2 μs .. 619.8 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.719e8    (1.719e8 .. 1.719e8)
  y                  40.784     (-1400.984 .. 1500.370)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-page-x4/merge
time                 40.84 ms   (40.52 ms .. 41.17 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 41.58 ms   (41.11 ms .. 42.79 ms)
std dev              1.517 ms   (289.7 μs .. 2.678 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2.557e8    (2.557e8 .. 2.557e8)
  y                  91.429     (-2.632e-6 .. 240.000)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-page-plus-byte-x4/merge
time                 75.62 ms   (74.94 ms .. 76.21 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 76.29 ms   (76.02 ms .. 76.62 ms)
std dev              481.6 μs   (346.7 μs .. 682.4 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.914e8    (4.914e8 .. 4.914e8)
  y                  -936.533   (-3067.488 .. 3223.921)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-huge-vals-x4/merge
time                 136.3 ms   (136.0 ms .. 136.8 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 137.2 ms   (136.9 ms .. 138.2 ms)
std dev              860.2 μs   (231.7 μs .. 1.325 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              9.708e8    (9.708e8 .. 9.708e8)
  y                  -155.429   (-310.857 .. 8.762e-6)
variance introduced by outliers: 12% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4/merge
time                 21.11 ms   (21.07 ms .. 21.14 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 21.20 ms   (21.16 ms .. 21.28 ms)
std dev              136.8 μs   (82.43 μs .. 226.4 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              7.367e7    (7.367e7 .. 7.367e7)
  y                  -14.400    (-136.699 .. 92.296)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4-uneven/merge
time                 21.13 ms   (21.09 ms .. 21.16 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 21.22 ms   (21.18 ms .. 21.27 ms)
std dev              97.75 μs   (63.69 μs .. 159.2 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              7.378e7    (7.378e7 .. 7.378e7)
  y                  -276.838   (-1252.356 .. 792.753)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4-lastlevel/merge
time                 15.75 ms   (15.68 ms .. 15.82 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 15.84 ms   (15.80 ms .. 15.92 ms)
std dev              140.5 μs   (89.71 μs .. 215.7 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              5.889e7    (5.889e7 .. 5.889e7)
  y                  211.105    (-7.078 .. 412.992)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4+1-min-skewed-lastlevel/merge
time                 16.18 ms   (16.11 ms .. 16.26 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.28 ms   (16.24 ms .. 16.34 ms)
std dev              133.8 μs   (81.17 μs .. 197.3 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              5.906e7    (5.906e7 .. 5.906e7)
  y                  174.265    (-1134.176 .. 1484.813)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4+1-max-skewed-lastlevel/merge
time                 15.55 ms   (15.50 ms .. 15.60 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 15.46 ms   (15.39 ms .. 15.50 ms)
std dev              133.4 μs   (89.37 μs .. 194.7 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              5.913e7    (5.913e7 .. 5.913e7)
  y                  154.180    (-1232.263 .. 1605.893)
```

</details>