### PR TITLE
Remove re-export of RunFsPaths

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -33,6 +33,7 @@ import           Database.LSMTree.Internal.Lookup (BatchSize (..),
                      prepLookups)
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.RunFsPaths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Serialise
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import           Prelude hiding (getContents)
@@ -128,7 +129,7 @@ lookupsInBatchesEnv Config {..} = do
     let hasFS = FS.ioHasFS (FS.MountPoint benchTmpDir)
     hasBlockIO <- FS.ioHasBlockIO hasFS ioctxps
     let wb = WB.WB storedKeys
-        fsps = Run.RunFsPaths 0
+        fsps = RunFsPaths 0
     r <- Run.fromWriteBuffer hasFS fsps wb
     let nentriesReal = unNumEntries $ Run.runNumEntries r
     assert (nentriesReal == nentries) $ pure ()

--- a/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
@@ -17,6 +17,8 @@ import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.RunFsPaths (RunFsPaths (..),
+                     activeRunsDir)
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
@@ -133,12 +135,12 @@ benchWriteBuffer conf@Config{name} =
           writeBufferEnvCleanup
 
     -- We'll remove the files on every run, so we can re-use the same run number.
-    getPaths :: IO Run.RunFsPaths
-    getPaths = pure (Run.RunFsPaths 0)
+    getPaths :: IO RunFsPaths
+    getPaths = pure (RunFsPaths 0)
 
     -- Simply remove the whole active directory.
     cleanupPaths :: FS.HasFS IO FS.HandleIO -> IO ()
-    cleanupPaths hasFS = FS.removeDirectoryRecursive hasFS Run.activeRunsDir
+    cleanupPaths hasFS = FS.removeDirectoryRecursive hasFS activeRunsDir
 
 insert :: InputKOps -> WriteBuffer
 insert (NormalInputs kops) =
@@ -146,7 +148,7 @@ insert (NormalInputs kops) =
 insert (MonoidalInputs kops mappendVal) =
     List.foldl' (\wb (k, e) -> WB.addEntryMonoidal mappendVal k e wb) WB.empty kops
 
-flush :: FS.HasFS IO FS.HandleIO -> Run.RunFsPaths -> WriteBuffer -> IO (Run (FS.Handle (FS.HandleIO)))
+flush :: FS.HasFS IO FS.HandleIO -> RunFsPaths -> WriteBuffer -> IO (Run (FS.Handle (FS.HandleIO)))
 flush = Run.fromWriteBuffer
 
 data InputKOps

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -35,10 +35,9 @@
 -- not exhaustive.
 --
 module Database.LSMTree.Internal.Run (
-    -- * Paths
-    module FsPaths
     -- * Run
-  , Run (..)
+    Run (..)
+  , RunFsPaths
   , sizeInPages
   , addReference
   , removeReference
@@ -73,7 +72,7 @@ import qualified Database.LSMTree.Internal.IndexCompact as Index
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.RunBuilder (RunBuilder)
 import qualified Database.LSMTree.Internal.RunBuilder as Builder
-import           Database.LSMTree.Internal.RunFsPaths as FsPaths
+import           Database.LSMTree.Internal.RunFsPaths
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
@@ -206,7 +205,7 @@ openFromDisk fs runRunFsPaths = do
          =<< CRC.readChecksumsFile fs (runChecksumsPath runRunFsPaths)
 
     -- verify checksums of files we don't read yet
-    let paths = runFsPaths runRunFsPaths
+    let paths = pathsForRunFiles runRunFsPaths
     checkCRC (forRunKOps expectedChecksums) (forRunKOps paths)
     checkCRC (forRunBlob expectedChecksums) (forRunBlob paths)
 

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -82,7 +82,7 @@ new fs runBuilderFsPaths numEntries estimatedNumPages = do
     runBuilderBlobOffset <- newIORef 0
 
     FS.createDirectoryIfMissing fs False activeRunsDir
-    runBuilderHandles <- traverse (makeHandle fs) (runFsPaths runBuilderFsPaths)
+    runBuilderHandles <- traverse (makeHandle fs) (pathsForRunFiles runBuilderFsPaths)
 
     let builder = RunBuilder {..}
     writeIndexHeader fs builder
@@ -169,7 +169,7 @@ unsafeFinalise fs builder@RunBuilder {..} = do
 close :: HasFS IO h -> RunBuilder (FS.Handle h) -> IO ()
 close fs RunBuilder {..} = do
     traverse_ (closeHandle fs) runBuilderHandles
-    traverse_ (FS.removeFile fs) (runFsPaths runBuilderFsPaths)
+    traverse_ (FS.removeFile fs) (pathsForRunFiles runBuilderFsPaths)
 
 {-------------------------------------------------------------------------------
   Helpers

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -44,6 +44,7 @@ import           Database.LSMTree.Internal.RawOverflowPage
 import           Database.LSMTree.Internal.RawPage
 import qualified Database.LSMTree.Internal.Run as Run
 import           Database.LSMTree.Internal.RunAcc as Run
+import           Database.LSMTree.Internal.RunFsPaths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.Serialise.Class
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
@@ -301,7 +302,7 @@ prop_roundtripFromWriteBufferLookupIO dats =
     pure $ opaqueifyBlobs (V.fromList model) === opaqueifyBlobs (V.zip (V.fromList lookupss) real)
   where
     mkRuns hasFS = first V.fromList . unzip <$> sequence [
-          (,wb) <$> Run.fromWriteBuffer hasFS (Run.RunFsPaths i) wb
+          (,wb) <$> Run.fromWriteBuffer hasFS (RunFsPaths i) wb
         | (i, dat) <- zip [0..] (getSmallList dats)
         , let wb = WB.WB (runData dat)
         ]

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -43,6 +43,7 @@ import           Database.LSMTree.Internal.RawOverflowPage
                      (rawOverflowPageRawBytes)
 import           Database.LSMTree.Internal.RawPage
 import           Database.LSMTree.Internal.Run
+import           Database.LSMTree.Internal.RunFsPaths (RunFsPaths (..))
 import qualified Database.LSMTree.Internal.RunReader as Reader
 import           Database.LSMTree.Internal.Serialise
 import qualified Database.LSMTree.Internal.WriteBuffer as WB


### PR DESCRIPTION
I should have done this as part of #200, but just only realised it now.

There is no need for a module re-export and we don't do it anywhere else.

Also, wanting to know the file paths to where a run stores its data breaks the abstraction boundary and is only needed for tests or benchmarks. As such, it's good to be more explicit about importing them.