### PR TITLE
Make the default `IOCtxParams` explicit

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -22,6 +22,7 @@ import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.List as List
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Extras.Random (sampleUniformWithReplacement,
@@ -127,7 +128,7 @@ lookupsInBatchesEnv Config {..} = do
     benchTmpDir <- createTempDirectory sysTmpDir "lookupsInBatchesEnv"
     (storedKeys, lookupKeys) <- lookupsEnv (mkStdGen 17) nentries npos nneg
     let hasFS = FS.ioHasFS (FS.MountPoint benchTmpDir)
-    hasBlockIO <- FS.ioHasBlockIO hasFS ioctxps
+    hasBlockIO <- FS.ioHasBlockIO hasFS (fromMaybe FS.defaultIOCtxParams ioctxps)
     let wb = WB.WB storedKeys
         fsps = RunFsPaths 0
     r <- Run.fromWriteBuffer hasFS fsps wb

--- a/fs-api-blockio/src-linux/System/FS/BlockIO/Async.hs
+++ b/fs-api-blockio/src-linux/System/FS/BlockIO/Async.hs
@@ -26,9 +26,9 @@ import           System.IO.Error (ioeSetErrorString, isResourceVanishedError)
 import           System.Posix.Types
 
 -- | IO instantiation of 'HasBlockIO', using @blockio-uring@.
-asyncHasBlockIO :: HasFS IO HandleIO -> Maybe API.IOCtxParams -> IO (API.HasBlockIO IO HandleIO)
+asyncHasBlockIO :: HasFS IO HandleIO -> API.IOCtxParams -> IO (API.HasBlockIO IO HandleIO)
 asyncHasBlockIO hasFS ctxParams = do
-  ctx <- I.initIOCtx (maybe I.defaultIOCtxParams ctxParamsConv ctxParams)
+  ctx <- I.initIOCtx (ctxParamsConv ctxParams)
   pure $ API.HasBlockIO {
       API.close = I.closeIOCtx ctx
     , API.submitIO = submitIO hasFS ctx

--- a/fs-api-blockio/src-linux/System/FS/BlockIO/Internal.hs
+++ b/fs-api-blockio/src-linux/System/FS/BlockIO/Internal.hs
@@ -15,7 +15,7 @@ import           System.FS.IO (HandleIO)
 
 ioHasBlockIO ::
      HasFS IO HandleIO
-  -> Maybe IOCtxParams
+  -> IOCtxParams
   -> IO (HasBlockIO IO HandleIO)
 #if SERIALBLOCKIO
 ioHasBlockIO hasFS _ = Serial.serialHasBlockIO hasFS

--- a/fs-api-blockio/src-macos/System/FS/BlockIO/Internal.hs
+++ b/fs-api-blockio/src-macos/System/FS/BlockIO/Internal.hs
@@ -14,6 +14,6 @@ import           System.FS.IO (HandleIO)
 -- The recommended choice would be to use the POSIX AIO API.
 ioHasBlockIO ::
      HasFS IO HandleIO
-  -> Maybe IOCtxParams
+  -> IOCtxParams
   -> IO (HasBlockIO IO HandleIO)
 ioHasBlockIO hasFS _ = Serial.serialHasBlockIO hasFS

--- a/fs-api-blockio/src-windows/System/FS/BlockIO/Internal.hs
+++ b/fs-api-blockio/src-windows/System/FS/BlockIO/Internal.hs
@@ -14,6 +14,6 @@ import           System.FS.IO (HandleIO)
 -- The recommended choice would be to use the Win32 IOCP API.
 ioHasBlockIO ::
      HasFS IO HandleIO
-  -> Maybe IOCtxParams
+  -> IOCtxParams
   -> IO (HasBlockIO IO HandleIO)
 ioHasBlockIO hasFS _ = Serial.serialHasBlockIO hasFS

--- a/fs-api-blockio/src/System/FS/BlockIO/API.hs
+++ b/fs-api-blockio/src/System/FS/BlockIO/API.hs
@@ -9,6 +9,7 @@
 module System.FS.BlockIO.API (
     HasBlockIO (..)
   , IOCtxParams (..)
+  , defaultIOCtxParams
   , mkClosedError
   , IOOp (..)
   , ioopHandle
@@ -63,6 +64,12 @@ data IOCtxParams = IOCtxParams {
                      ioctxBatchSizeLimit   :: !Int,
                      ioctxConcurrencyLimit :: !Int
                    }
+
+defaultIOCtxParams :: IOCtxParams
+defaultIOCtxParams = IOCtxParams {
+      ioctxBatchSizeLimit   = 64,
+      ioctxConcurrencyLimit = 64 * 3
+    }
 
 mkClosedError :: HasCallStack => SomeHasFS m -> String -> FsError
 mkClosedError (SomeHasFS hasFS) loc = ioToFsError (mkFsErrorPath hasFS (mkFsPath [])) ioerr

--- a/fs-api-blockio/src/System/FS/BlockIO/IO.hs
+++ b/fs-api-blockio/src/System/FS/BlockIO/IO.hs
@@ -10,6 +10,6 @@ import           System.FS.IO (HandleIO)
 -- | Platform-dependent IO instantiation of 'HasBlockIO'.
 ioHasBlockIO ::
      HasFS IO HandleIO
-  -> Maybe IOCtxParams
+  -> IOCtxParams
   -> IO (HasBlockIO IO HandleIO)
 ioHasBlockIO = I.ioHasBlockIO

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -282,7 +282,7 @@ prop_roundtripFromWriteBufferLookupIO ::
 prop_roundtripFromWriteBufferLookupIO dats =
     ioProperty $ withSystemTempDirectory "prop" $ \dir -> do
     let hasFS = FS.ioHasFS (MountPoint dir)
-    hasBlockIO <- FS.ioHasBlockIO hasFS Nothing
+    hasBlockIO <- FS.ioHasBlockIO hasFS FS.defaultIOCtxParams
     (runs, wbs) <- mkRuns hasFS
     let wbAll = WB.WB (Map.unionsWith (combine resolveV) (fmap WB.unWB wbs))
     real <- lookupsInBatches


### PR DESCRIPTION
Otherwise, it's opaque to the user what values are being used. By making the default parameters explicit, the user has full control.