### PR TITLE
Add rocksdb wrapper, and comparison wp8-like benchmark

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         sudo apt-get update || true
         sudo apt-get -y install liburing-dev
+        sudo apt-get -y install librocksdb-dev
 
     - name: Configure the build
       run: |

--- a/bench/macro/rocksdb-bench-wp8.hs
+++ b/bench/macro/rocksdb-bench-wp8.hs
@@ -1,0 +1,418 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors      #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
+{-# LANGUAGE OverloadedStrings     #-}
+
+{- Benchmark requirements:
+
+A. The benchmark should use the external interface of the disk backend,
+   and no internal interfaces.
+B. The benchmark should use a workload ratio of 1 insert, to 1 delete,
+   to 1 lookup. This is the workload ratio for the UTxO. Thus the
+   performance is to be evaluated on the combination of the operations,
+   not on operations individually.
+C. The benchmark should use 34 byte keys, and 60 byte values. This
+   corresponds roughly to the UTxO.
+D. The benchmark should use keys that are evenly spread through the
+   key space, such as cryptographic hashes.
+E. The benchmark should start with a table of 100 million entries.
+   This corresponds to the stretch target for the UTxO size.
+   This table may be pre-generated. The time to construct the table
+   should not be included in the benchmark time.
+F. The benchmark workload should ensure that all inserts are for
+   `fresh' keys, and that all lookups and deletes are for keys that
+   are present. This is the typical workload for the UTxO.
+G. It is acceptable to pre-generate the sequence of operations for the
+   benchmark, or to take any other measure to exclude the cost of
+   generating or reading the sequence of operations.
+H. The benchmark should use the external interface of the disk backend
+   to present batches of operations: a first batch consisting of 256
+   lookups, followed by a second batch consisting of 256 inserts plus
+   256 deletes. This corresponds to the UTxO workload using 64kb
+   blocks, with 512 byte txs with 2 inputs and 2 outputs.
+I. The benchmark should be able to run in two modes, using the
+   external interface of the disk backend in two ways: serially (in
+   batches), or fully pipelined (in batches).
+
+TODO 2024-04-29 consider alternative methods of implementing key generation
+TODO 2024-04-29 pipelined mode is not implemented.
+
+-}
+module Main (main) where
+
+import           Control.Applicative ((<**>))
+import           Control.DeepSeq (force)
+import           Control.Exception (evaluate)
+import           Control.Monad (forM, forM_, void, when)
+import qualified Crypto.Hash.SHA256 as SHA256
+import qualified Data.Binary as B
+import qualified Data.ByteString as BS
+import qualified Data.IntSet as IS
+import           Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import           Data.List.Split (chunksOf)
+import           Data.Traversable (mapAccumL)
+import           Data.Tuple (swap)
+import           Data.Word (Word64)
+import qualified MCG
+import qualified Options.Applicative as O
+import qualified System.Clock as Clock
+import           System.Directory (removePathForcibly)
+import           Text.Printf (printf)
+
+import qualified RocksDB
+
+-------------------------------------------------------------------------------
+-- Keys and values
+-------------------------------------------------------------------------------
+
+type K = BS.ByteString
+type V = BS.ByteString
+
+-- We generate keys by hashing a word64 and adding two "random" bytes.
+-- This way we can ensure that keys are distinct.
+--
+-- I think this approach of generating keys should match UTxO quite well.
+-- This is purely CPU bound operation, and we should be able to push IO
+-- when doing these in between.
+makeKey :: Word64 -> K
+makeKey w64 = SHA256.hashlazy (B.encode w64) <> "=="
+
+makeValue :: K -> V
+makeValue k = k <> BS.replicate (60 - 34) 120 -- 'x'
+
+-------------------------------------------------------------------------------
+-- Options and commands
+-------------------------------------------------------------------------------
+
+data GlobalOpts = GlobalOpts
+    { rootDir     :: !FilePath  -- ^ session directory.
+    , initialSize :: !Int
+    }
+  deriving Show
+
+data SetupOpts = SetupOpts
+  deriving Show
+
+data RunOpts = RunOpts
+    { batchCount :: !Int
+    , batchSize  :: !Int
+    , check      :: !Bool
+    , seed       :: !Word64
+    }
+  deriving Show
+
+data Cmd
+    -- | Setup benchmark: generate initial LSM tree etc.
+    = CmdSetup SetupOpts
+
+    -- | Make a dry run, measure the overhead.
+    | CmdDryRun RunOpts
+
+    -- | Run the actual benchmark
+    | CmdRun RunOpts
+  deriving Show
+
+-------------------------------------------------------------------------------
+-- command line interface
+-------------------------------------------------------------------------------
+
+globalOptsP :: O.Parser GlobalOpts
+globalOptsP = pure GlobalOpts
+    <*> pure "_bench_rocksdb"
+    <*> O.option O.auto (O.long "initial-size" <> O.value 100_000_000 <> O.showDefault <> O.help "Initial LSM tree size")
+
+cmdP :: O.Parser Cmd
+cmdP = O.subparser $ mconcat
+    [ O.command "setup" $ O.info
+        (CmdSetup <$> setupOptsP <**> O.helper)
+        (O.progDesc "Setup benchmark")
+
+    , O.command "dry-run" $ O.info
+        (CmdDryRun <$> runOptsP <**> O.helper)
+        (O.progDesc "Dry run, measure overhead")
+
+    , O.command "run" $ O.info
+        (CmdRun <$> runOptsP <**> O.helper)
+        (O.progDesc "Proper run")
+    ]
+
+setupOptsP :: O.Parser SetupOpts
+setupOptsP = pure SetupOpts
+
+runOptsP :: O.Parser RunOpts
+runOptsP = pure RunOpts
+    <*> O.option O.auto (O.long "batch-count" <> O.value 1000 <> O.showDefault <> O.help "Batch count")
+    <*> O.option O.auto (O.long "batch-size" <> O.value 256 <> O.showDefault <> O.help "Batch size")
+    <*> O.switch (O.long "check" <> O.help "Check generated key distribution")
+    <*> O.option O.auto (O.long "seed" <> O.value 1337 <> O.showDefault <> O.help "Random seed")
+
+-------------------------------------------------------------------------------
+-- clock
+-------------------------------------------------------------------------------
+
+timed :: IO a -> IO (a, Double)
+timed action = do
+    t1 <- Clock.getTime Clock.Monotonic
+    x  <- action
+    t2 <- Clock.getTime Clock.Monotonic
+    let !t = fromIntegral (Clock.toNanoSecs (Clock.diffTimeSpec t2 t1)) * 1e-9
+    return (x, t)
+
+timed_ :: IO () -> IO Double
+timed_ action = do
+    t1 <- Clock.getTime Clock.Monotonic
+    action
+    t2 <- Clock.getTime Clock.Monotonic
+    return $! fromIntegral (Clock.toNanoSecs (Clock.diffTimeSpec t2 t1)) * 1e-9
+
+-------------------------------------------------------------------------------
+-- setup
+-------------------------------------------------------------------------------
+
+{-
+rocksdb::BlockBasedTableOptions table_options;
+  table_options.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
+  my_cf_options.table_factory.reset(
+      rocksdb::NewBlockBasedTableFactory(table_options));
+-}
+
+rocksDbWithOptions :: (RocksDB.Options -> IO r) -> IO r
+rocksDbWithOptions kont =
+    RocksDB.withOptions $ \options ->
+    RocksDB.withFilterPolicyBloom 10 $ \filterPolicy ->
+    RocksDB.withBlockTableOptions $ \topts -> do
+        RocksDB.blockBasedOptionsSetFilterPolicy topts filterPolicy
+
+        RocksDB.optionsSetCreateIfMissing options True
+        RocksDB.optionsIncreaseParallelism options 4 -- the benchmark spec says to use one core though.
+        RocksDB.optionsOptimizeLevelStyleCompaction options 0x200_00000 -- 32*1024*1024; default is 512*1024*1024?
+        -- RocksDB.optionsSetCompression options 0 -- no compression
+        RocksDB.optionsSetCompression options 4 -- lz4
+        -- RocksDB.optionsSetCompression options 7 -- zstd
+        RocksDB.optionsSetMaxOpenFiles options 512
+
+        RocksDB.optionsSetBlockBasedTableFactory options topts
+
+        kont options
+
+rocksDbWithWriteOptions :: (RocksDB.WriteOptions -> IO r) -> IO r
+rocksDbWithWriteOptions kont = RocksDB.withWriteOptions $ \options -> do
+    -- lsm-tree doesn't have WAL, so we don't use with RocksDB to be fair.
+    RocksDB.writeOptionsDisableWAL options True
+
+    kont options
+
+--
+--
+-- It's useful to run
+--
+-- sst_dump --file=_bench_rocksdb --command=identity --show_properties
+--
+-- after setup
+doSetup :: GlobalOpts -> SetupOpts -> IO ()
+doSetup gopts opts = do
+    time <- timed_ $ doSetup' gopts opts
+    printf "Setup %.03f sec\n" time
+
+doSetup' :: GlobalOpts -> SetupOpts -> IO ()
+doSetup' gopts _opts =
+    rocksDbWithOptions $ \options ->
+    RocksDB.withRocksDB options gopts.rootDir $ \db ->
+    rocksDbWithWriteOptions $ \wopts ->
+    forM_ (chunksOf 256 [ 0 .. gopts.initialSize ]) $ \chunk ->
+    RocksDB.withWriteBatch $ \batch -> do
+        forM_ chunk $ \ (fromIntegral -> i) -> do
+            when (mod i (fromIntegral (div gopts.initialSize 50)) == 0) $ do
+                printf "%3.0f%%\n" (100 * fromIntegral i / fromIntegral gopts.initialSize :: Double)
+            let k = makeKey i
+            let v = makeValue k
+            RocksDB.writeBatchPut batch k v
+
+        RocksDB.write db wopts batch
+
+-------------------------------------------------------------------------------
+-- dry-run
+-------------------------------------------------------------------------------
+
+doDryRun :: GlobalOpts -> RunOpts -> IO ()
+doDryRun gopts opts = do
+    time <- timed_ $ doDryRun' gopts opts
+    printf "Batch generation: %.03f sec\n" time
+
+doDryRun' :: GlobalOpts -> RunOpts -> IO ()
+doDryRun' gopts opts = do
+    keysRef <- newIORef $
+        if opts.check
+        then IS.fromList [ 0 .. gopts.initialSize - 1 ]
+        else IS.empty
+    duplicateRef <- newIORef (0 :: Int)
+
+    void $ forFoldM_ initGen [ 0 .. opts.batchCount - 1 ] $ \b g -> do
+        let lookups :: [Word64]
+            inserts :: [Word64]
+            (!nextG, lookups, inserts) = generateBatch gopts.initialSize opts.batchSize g b
+
+        when opts.check $ do
+            keys <- readIORef keysRef
+            let new  = IS.fromList $ map fromIntegral lookups
+            let diff = IS.difference new keys
+            -- when (IS.notNull diff) $ printf "missing in batch %d %s\n" b (show diff)
+            modifyIORef' duplicateRef $ \n -> n + IS.size diff
+            writeIORef keysRef $! IS.union
+                (IS.difference keys new)
+                (IS.fromList $ map fromIntegral inserts)
+
+        -- lookups
+        forM_ lookups $ \k -> evaluate (makeKey k)
+
+        -- deletes & inserts; deletes done above.
+        forM_ inserts $ \k' -> do
+            let k = makeKey k'
+            evaluate k >> evaluate (makeValue k)
+
+        return nextG
+
+    when opts.check $ do
+        duplicates <- readIORef duplicateRef
+        printf "True duplicates: %d\n" duplicates
+  where
+    initGen = MCG.make
+        (fromIntegral $ gopts.initialSize + opts.batchSize * opts.batchCount)
+        opts.seed
+
+-------------------------------------------------------------------------------
+-- Batch generation
+-------------------------------------------------------------------------------
+
+{- | Implement generation of unbounded sequence of insert/delete operations
+
+matching UTxO style from spec: interleaved batches insert and lookup
+configurable batch sizes
+1 insert, 1 delete, 1 lookup per key.
+
+Current approach is probabilistic, but uses very little state.
+We could also make it exact, but then we'll need to carry some state around
+(at least the difference).
+
+-}
+generateBatch
+    :: Int       -- ^ initial size of the collection
+    -> Int       -- ^ batch size
+    -> MCG.MCG   -- ^ generator
+    -> Int       -- ^ batch number
+    -> (MCG.MCG, [Word64], [Word64])
+generateBatch initialSize batchSize g b = (nextG, lookups, inserts)
+  where
+    maxK :: Word64
+    maxK = fromIntegral $ initialSize + batchSize * b
+
+    lookups :: [Word64]
+    (!nextG, lookups) = mapAccumL (\g' _ -> swap (MCG.reject maxK g')) g [1 .. batchSize]
+
+    inserts :: [Word64]
+    inserts = [ maxK .. maxK + fromIntegral batchSize - 1 ]
+
+-------------------------------------------------------------------------------
+-- run
+-------------------------------------------------------------------------------
+
+doRun :: GlobalOpts -> RunOpts -> IO ()
+doRun gopts opts = do
+    removePathForcibly $ gopts.rootDir ++ "_cp"
+    makeCheckpoint gopts
+
+    time <- timed_ $ doRun' gopts { rootDir = gopts.rootDir ++ "_cp" } opts
+    -- TODO: collect more statistic, save them in dry-run,
+    -- TODO: make the results human comprehensible.
+    printf "Proper run:            %7.03f sec\n" time
+    let ops = opts.batchCount * opts.batchSize
+    printf "Operations per second: %7.01f ops/sec\n" (fromIntegral ops / time)
+
+makeCheckpoint :: GlobalOpts -> IO ()
+makeCheckpoint gopts =
+    rocksDbWithOptions $ \options ->
+    RocksDB.withRocksDB options gopts.rootDir $ \db ->
+    RocksDB.checkpoint db $ gopts.rootDir ++ "_cp"
+
+doRun' :: GlobalOpts -> RunOpts -> IO ()
+doRun' gopts opts =
+    rocksDbWithOptions $ \options ->
+    RocksDB.withRocksDB options gopts.rootDir $ \db ->
+    rocksDbWithWriteOptions $ \wopts ->
+    RocksDB.withReadOptions $ \ropts ->
+        void $ forFoldM_ initGen [ 0 .. opts.batchCount - 1 ] $ \b g -> do
+            let lookups :: [Word64]
+                inserts :: [Word64]
+                (!nextG, lookups, inserts) = generateBatch gopts.initialSize opts.batchSize g b
+
+            -- lookups
+            let ks = makeKey <$> lookups
+
+            vs' <-
+                -- multi get or not.
+                if True
+                then RocksDB.multiGet db ropts ks
+                else forM ks (RocksDB.get db ropts)
+
+            vs <- evaluate (force vs')
+
+            -- check that we get values we expect
+            when opts.check $ do
+                let expected = map (Just . makeValue) ks
+                when (vs /= expected) $ do
+                    printf "Value mismatch in batch %d\n" b
+                    print vs
+                    print expected
+
+             -- deletes and inserts
+            RocksDB.withWriteBatch $ \batch -> do
+                forM_ ks $ \k -> do
+                    RocksDB.writeBatchDelete batch k
+
+                forM_ inserts $ \k' -> do
+                    let k = makeKey k'
+                    let v = makeValue k
+                    RocksDB.writeBatchPut batch k v
+
+                RocksDB.write db wopts batch
+
+            return nextG
+  where
+    initGen = MCG.make
+        (fromIntegral $ gopts.initialSize + opts.batchSize * opts.batchCount)
+        opts.seed
+
+-------------------------------------------------------------------------------
+-- main
+-------------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+    (gopts, cmd) <- O.customExecParser prefs cliP
+    print gopts
+    print cmd
+    case cmd of
+        CmdSetup opts  -> doSetup gopts opts
+        CmdDryRun opts -> doDryRun gopts opts
+        CmdRun opts    -> doRun gopts opts
+  where
+    cliP = O.info ((,) <$> globalOptsP <*> cmdP <**> O.helper) O.fullDesc
+    prefs = O.prefs $ O.showHelpOnEmpty <> O.helpShowGlobals <> O.subparserInline
+
+-------------------------------------------------------------------------------
+-- general utils
+-------------------------------------------------------------------------------
+
+forFoldM_ :: Monad m => s -> [a] -> (a -> s -> m s) -> m s
+forFoldM_ !s []     _ = return s
+forFoldM_ !s (x:xs) f = do
+    !s' <- f x s
+    forFoldM_ s' xs f
+
+-------------------------------------------------------------------------------
+-- unused for now
+-------------------------------------------------------------------------------
+
+_unused :: ()
+_unused = const ()
+    timed

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -374,6 +374,47 @@ benchmark lsm-tree-bench-wp8
 
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded
 
+benchmark rocksdb-bench-wp8
+  import:         language, warnings, wno-x-partial
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/macro src-extras
+  main-is:        rocksdb-bench-wp8.hs
+
+  if !os(linux)
+    buildable: False
+
+  build-depends:
+    , base
+    , binary
+    , bytestring
+    , clock
+    , containers
+    , cryptohash-sha256
+    , deepseq
+    , directory
+    , lsm-tree:mcg
+    , lsm-tree:rocksdb
+    , optparse-applicative
+    , split
+
+  ghc-options:    -rtsopts -with-rtsopts=-T -threaded
+
+library rocksdb
+  import:          language, warnings
+  hs-source-dirs:  src-rocksdb
+  exposed-modules: RocksDB
+  other-modules:   RocksDB.FFI
+
+  if !os(linux)
+    buildable: False
+
+  -- Ubuntu 22.04 doesn't have pkgconfig files for rocksdb
+  extra-libraries: rocksdb
+  build-depends:
+    , base
+    , bytestring
+    , indexed-traversable
+
 library kmerge
   import:          language, warnings, wno-x-partial
   hs-source-dirs:  src-kmerge

--- a/src-rocksdb/RocksDB.hs
+++ b/src-rocksdb/RocksDB.hs
@@ -1,0 +1,313 @@
+{-# LANGUAGE CPP #-}
+module RocksDB (
+    -- * Options
+    Options,
+    withOptions,
+    optionsSetCreateIfMissing,
+    optionsSetMaxOpenFiles,
+    optionsSetCompression,
+    optionsIncreaseParallelism,
+    optionsOptimizeLevelStyleCompaction,
+    -- * Read Options
+    ReadOptions,
+    withReadOptions,
+    -- * Write options
+    WriteOptions,
+    withWriteOptions,
+    writeOptionsDisableWAL,
+    -- * DB operations
+    RocksDB,
+    withRocksDB,
+    put,
+    get,
+    multiGet,
+    delete,
+    write,
+    checkpoint,
+    -- * Write batch
+    WriteBatch,
+    withWriteBatch,
+    writeBatchPut,
+    writeBatchDelete,
+    -- * Block based table options
+    BlockTableOptions,
+    withBlockTableOptions,
+    blockBasedOptionsSetFilterPolicy,
+    optionsSetBlockBasedTableFactory,
+    -- * Filter policy
+    FilterPolicy,
+    withFilterPolicyBloom,
+) where
+
+import           Control.Exception (bracket)
+import           Control.Monad (forM)
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Unsafe (unsafePackMallocCStringLen,
+                     unsafeUseAsCStringLen)
+import           Data.Foldable.WithIndex (ifor_)
+import           Data.Word (Word64)
+import           Foreign.C.String (peekCString, withCString)
+import           Foreign.C.Types (CInt, CSize)
+import           Foreign.Marshal.Alloc (alloca, free)
+import           Foreign.Marshal.Array (allocaArray)
+import           Foreign.Marshal.Utils (withMany)
+import           Foreign.Ptr (Ptr, nullPtr)
+import           Foreign.Storable (peek, peekElemOff, poke, pokeElemOff)
+
+import           RocksDB.FFI
+
+#if MIN_VERSION_base(4,18,0)
+import           Foreign.C.ConstPtr (ConstPtr (..))
+#endif
+
+-------------------------------------------------------------------------------
+-- constptr
+-------------------------------------------------------------------------------
+
+#if MIN_VERSION_base(4,18,0)
+constPtr :: Ptr a -> ConstPtr a
+constPtr = ConstPtr
+#else
+constPtr :: Ptr a -> Ptr a
+constPtr = id
+#endif
+
+-------------------------------------------------------------------------------
+-- error
+-------------------------------------------------------------------------------
+
+withErrPtr :: (ErrPtr -> IO r) -> IO r
+withErrPtr kont = alloca $ \ptr -> do
+    poke ptr nullPtr
+    x <- kont ptr
+    ptr' <- peek ptr
+    if ptr' == nullPtr
+    then return ()
+    else free ptr'
+    return x
+
+assertErrPtr :: String -> ErrPtr -> IO ()
+assertErrPtr fun ptr = do
+    ptr' <- peek ptr
+    if ptr' == nullPtr
+    then return ()
+    else do
+        msg <- peekCString ptr'
+        fail $ fun ++ ": " ++ msg
+
+-------------------------------------------------------------------------------
+-- options
+-------------------------------------------------------------------------------
+
+newtype Options = Options (Ptr OPTIONS)
+
+withOptions :: (Options -> IO r) -> IO r
+withOptions kont = bracket
+    rocksdb_options_create
+    rocksdb_options_destroy
+    (\ptr -> kont (Options ptr))
+
+optionsSetCreateIfMissing :: Options -> Bool -> IO ()
+optionsSetCreateIfMissing (Options ptr) v =
+    rocksdb_options_set_create_if_missing ptr (if v then 1 else 0)
+
+optionsIncreaseParallelism :: Options -> Int -> IO ()
+optionsIncreaseParallelism (Options ptr) v =
+    rocksdb_options_increase_parallelism ptr (intToCInt v)
+
+optionsSetMaxOpenFiles :: Options -> Int -> IO ()
+optionsSetMaxOpenFiles (Options ptr) v =
+    rocksdb_options_set_max_open_files ptr (intToCInt v)
+
+optionsOptimizeLevelStyleCompaction :: Options -> Word64 -> IO ()
+optionsOptimizeLevelStyleCompaction (Options ptr) v =
+    rocksdb_options_optimize_level_style_compaction ptr v
+
+optionsSetCompression :: Options -> Int -> IO ()
+optionsSetCompression (Options ptr) v =
+    rocksdb_options_set_compression ptr (intToCInt v)
+
+-------------------------------------------------------------------------------
+-- read options
+-------------------------------------------------------------------------------
+
+newtype ReadOptions = ReadOptions (Ptr READOPTIONS)
+
+withReadOptions :: (ReadOptions -> IO r) -> IO r
+withReadOptions kont = bracket
+    rocksdb_readoptions_create
+    rocksdb_readoptions_destroy
+    (\ptr -> kont (ReadOptions ptr))
+
+-------------------------------------------------------------------------------
+-- write options
+-------------------------------------------------------------------------------
+
+newtype WriteOptions = WriteOptions (Ptr WRITEOPTIONS)
+
+withWriteOptions :: (WriteOptions -> IO r) -> IO r
+withWriteOptions kont = bracket
+    rocksdb_writeoptions_create
+    rocksdb_writeoptions_destroy
+    (\ptr -> kont (WriteOptions ptr))
+
+writeOptionsDisableWAL :: WriteOptions -> Bool {- ^ Disable -} -> IO ()
+writeOptionsDisableWAL (WriteOptions opts) disable =
+    rocksdb_writeoptions_disable_WAL opts (if disable then 1 else 0)
+
+-------------------------------------------------------------------------------
+-- db operations
+-------------------------------------------------------------------------------
+
+data RocksDB = RocksDB (Ptr DB) ErrPtr
+
+withRocksDB :: Options -> FilePath -> (RocksDB -> IO r) -> IO r
+withRocksDB (Options opt) path kont =
+    withCString path $ \path' ->
+    withErrPtr $ \errptr ->
+    bracket (rocksdb_open' path' errptr) rocksdb_close $ \ptr ->
+    kont (RocksDB ptr errptr)
+  where
+    rocksdb_open' path' errptr = do
+        ptr <- rocksdb_open opt path' errptr
+        assertErrPtr "rocksdb_open" errptr
+        return ptr
+
+put :: RocksDB -> WriteOptions -> ByteString -> ByteString -> IO ()
+put (RocksDB dbPtr errPtr) (WriteOptions opts) key val =
+    unsafeUseAsCStringLen key $ \(kp, kl) ->
+    unsafeUseAsCStringLen val $ \(vp, vl) -> do
+        rocksdb_put dbPtr opts kp (intToCSize kl) vp (intToCSize vl) errPtr
+        assertErrPtr "rocksdb_put" errPtr
+
+get :: RocksDB -> ReadOptions -> ByteString -> IO (Maybe ByteString)
+get (RocksDB dbPtr errPtr) (ReadOptions opts) key =
+    unsafeUseAsCStringLen key $ \(kp, kl) ->
+    alloca $ \vlPtr -> do
+        vp <- rocksdb_get dbPtr opts kp (intToCSize kl) vlPtr errPtr
+        assertErrPtr "rocksdb_get" errPtr -- TODO: may leak
+        vl <- peek vlPtr
+        if vp == nullPtr
+        then return Nothing
+        else Just <$> unsafePackMallocCStringLen (vp, csizeToInt vl)
+
+multiGet :: RocksDB -> ReadOptions -> [ByteString] -> IO [Maybe ByteString]
+multiGet (RocksDB db _errPtr) (ReadOptions opts) keys =
+    allocaArray n $ \kps ->
+    allocaArray n $ \kls ->
+    allocaArray n $ \vps ->
+    allocaArray n $ \vls ->
+    allocaArray n $ \errs ->
+    withMany unsafeUseAsCStringLen keys $ \keys' -> do
+        -- populate keys
+        ifor_ keys' $ \i (kp, kl) -> do
+            pokeElemOff kps i (constPtr kp)
+            pokeElemOff kls i (intToCSize kl)
+
+        -- multi get
+        rocksdb_multi_get db opts (intToCSize n) kps kls vps vls errs
+
+        -- read keys
+        forM [ 0 .. n - 1 ] $ \i -> do
+            vp <- peekElemOff vps i
+            vl <- peekElemOff vls i
+
+            -- TODO: we don't check errs here. we should.
+
+            if vp == nullPtr
+            then return Nothing
+            else Just <$> unsafePackMallocCStringLen (vp, csizeToInt vl)
+
+  where
+    n = length keys
+
+delete :: RocksDB -> WriteOptions -> ByteString -> IO ()
+delete (RocksDB dbPtr errPtr) (WriteOptions opts) key =
+    unsafeUseAsCStringLen key $ \(kp, kl) -> do
+        rocksdb_delete dbPtr opts kp (intToCSize kl) errPtr
+        assertErrPtr "rocksdb_delete" errPtr
+
+write :: RocksDB -> WriteOptions -> WriteBatch -> IO ()
+write (RocksDB dbPtr errPtr) (WriteOptions opts) (WriteBatch batch) = do
+    rocksdb_write dbPtr opts batch errPtr
+    assertErrPtr "rocksdb_write" errPtr
+
+checkpoint :: RocksDB -> FilePath -> IO ()
+checkpoint (RocksDB dbPtr errPtr) path =
+    withCString path $ \path' ->
+    bracket rocksdb_checkpoint_object_create' rocksdb_checkpoint_object_destroy $ \cp -> do
+        rocksdb_checkpoint_create cp path' 0 errPtr
+        assertErrPtr "rocksdb_checkpoint_create" errPtr
+  where
+    rocksdb_checkpoint_object_create' = do
+        cp <- rocksdb_checkpoint_object_create dbPtr errPtr
+        assertErrPtr "rocksdb_checkpoint_object_create" errPtr
+        return cp
+
+-------------------------------------------------------------------------------
+-- write batch
+-------------------------------------------------------------------------------
+
+newtype WriteBatch = WriteBatch (Ptr WRITEBATCH)
+
+withWriteBatch :: (WriteBatch -> IO r) -> IO r
+withWriteBatch kont = bracket
+    rocksdb_writebatch_create
+    rocksdb_writebatch_destroy
+    (\ptr -> kont (WriteBatch ptr))
+
+writeBatchPut :: WriteBatch -> ByteString -> ByteString -> IO ()
+writeBatchPut (WriteBatch batch) key val =
+    unsafeUseAsCStringLen key $ \(kp, kl) ->
+    unsafeUseAsCStringLen val $ \(vp, vl) ->
+        rocksdb_writebatch_put batch kp (intToCSize kl) vp (intToCSize vl)
+
+writeBatchDelete :: WriteBatch -> ByteString -> IO ()
+writeBatchDelete (WriteBatch batch) key =
+    unsafeUseAsCStringLen key $ \(kp, kl) ->
+        rocksdb_writebatch_delete batch kp (intToCSize kl)
+
+-------------------------------------------------------------------------------
+-- block based table options
+-------------------------------------------------------------------------------
+
+newtype BlockTableOptions = BlockTableOptions (Ptr BLOCKTABLEOPTIONS)
+
+withBlockTableOptions :: (BlockTableOptions -> IO r) -> IO r
+withBlockTableOptions kont = bracket
+    rocksdb_block_based_options_create
+    rocksdb_block_based_options_destroy
+    (\ptr -> kont (BlockTableOptions ptr))
+
+blockBasedOptionsSetFilterPolicy :: BlockTableOptions -> FilterPolicy -> IO ()
+blockBasedOptionsSetFilterPolicy (BlockTableOptions opts) (FilterPolicy policy) =
+    rocksdb_block_based_options_set_filter_policy opts policy
+
+optionsSetBlockBasedTableFactory :: Options -> BlockTableOptions -> IO ()
+optionsSetBlockBasedTableFactory (Options opts) (BlockTableOptions ptr) =
+    rocksdb_options_set_block_based_table_factory opts ptr
+
+-------------------------------------------------------------------------------
+-- filter policy
+-------------------------------------------------------------------------------
+
+newtype FilterPolicy = FilterPolicy (Ptr FILTERPOLICY)
+
+withFilterPolicyBloom :: Int -> (FilterPolicy -> IO r) -> IO r
+withFilterPolicyBloom bits_per_key kont = bracket
+    (rocksdb_filterpolicy_create_bloom (intToCInt bits_per_key))
+    (\_ -> return ()) -- rocksdb_filterpolicy_destroy, causes segfault if we free it.
+    (\ptr -> kont (FilterPolicy ptr))
+
+-------------------------------------------------------------------------------
+-- utils
+-------------------------------------------------------------------------------
+
+intToCSize :: Int -> CSize
+intToCSize = fromIntegral
+
+csizeToInt :: CSize -> Int
+csizeToInt = fromIntegral
+
+intToCInt :: Int -> CInt
+intToCInt = fromIntegral

--- a/src-rocksdb/RocksDB/FFI.hs
+++ b/src-rocksdb/RocksDB/FFI.hs
@@ -1,0 +1,245 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE CPP     #-}
+module RocksDB.FFI (
+  -- * options
+  OPTIONS,
+  rocksdb_options_create,
+  rocksdb_options_destroy,
+  rocksdb_options_set_create_if_missing,
+  rocksdb_options_set_max_open_files,
+  rocksdb_options_increase_parallelism,
+  rocksdb_options_optimize_level_style_compaction,
+  rocksdb_options_set_compression,
+  -- * read options
+  READOPTIONS,
+  rocksdb_readoptions_create,
+  rocksdb_readoptions_destroy,
+  -- * write options
+  WRITEOPTIONS,
+  rocksdb_writeoptions_create,
+  rocksdb_writeoptions_destroy,
+  rocksdb_writeoptions_disable_WAL,
+  -- * db operations
+  DB,
+  rocksdb_open,
+  rocksdb_close,
+  rocksdb_get,
+  rocksdb_multi_get,
+  rocksdb_put,
+  rocksdb_delete,
+  rocksdb_write,
+  -- ** checkpoints
+  CHECKPOINT,
+  rocksdb_checkpoint_object_create,
+  rocksdb_checkpoint_object_destroy,
+  rocksdb_checkpoint_create,
+  -- * write batch
+  WRITEBATCH,
+  rocksdb_writebatch_create,
+  rocksdb_writebatch_destroy,
+  rocksdb_writebatch_put,
+  rocksdb_writebatch_delete,
+  -- * block table options
+  BLOCKTABLEOPTIONS,
+  rocksdb_block_based_options_create,
+  rocksdb_block_based_options_destroy,
+  rocksdb_block_based_options_set_filter_policy,
+  rocksdb_options_set_block_based_table_factory,
+  -- * filter policy
+  FILTERPOLICY,
+  rocksdb_filterpolicy_destroy,
+  rocksdb_filterpolicy_create_bloom,
+  -- * error
+  ErrPtr,
+) where
+
+import           Data.Word (Word64)
+import           Foreign.C.String (CString)
+import           Foreign.C.Types (CChar, CInt (..), CSize (..), CUChar (..))
+import           Foreign.Ptr (Ptr)
+
+#if MIN_VERSION_base(4,18,0)
+import           Foreign.C.ConstPtr (ConstPtr (..))
+#endif
+
+-------------------------------------------------------------------------------
+-- error
+-------------------------------------------------------------------------------
+
+type ErrPtr = Ptr CString
+
+-------------------------------------------------------------------------------
+-- options
+-------------------------------------------------------------------------------
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_options_t" #-} OPTIONS
+
+foreign import capi "rocksdb/c.h rocksdb_options_create"
+  rocksdb_options_create :: IO (Ptr OPTIONS)
+
+foreign import capi "rocksdb/c.h rocksdb_options_destroy"
+  rocksdb_options_destroy :: Ptr OPTIONS -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_options_increase_parallelism"
+  rocksdb_options_increase_parallelism :: Ptr OPTIONS -> CInt -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_options_optimize_level_style_compaction"
+  rocksdb_options_optimize_level_style_compaction :: Ptr OPTIONS -> Word64 -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_options_set_create_if_missing"
+  rocksdb_options_set_create_if_missing :: Ptr OPTIONS -> CUChar -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_options_set_max_open_files"
+  rocksdb_options_set_max_open_files :: Ptr OPTIONS -> CInt -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_options_set_compression"
+  rocksdb_options_set_compression :: Ptr OPTIONS -> CInt -> IO ()
+
+-------------------------------------------------------------------------------
+-- read options
+-------------------------------------------------------------------------------
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_readoptions_t" #-} READOPTIONS
+
+foreign import capi "rocksdb/c.h rocksdb_readoptions_create"
+  rocksdb_readoptions_create :: IO (Ptr READOPTIONS)
+
+foreign import capi "rocksdb/c.h rocksdb_readoptions_destroy"
+  rocksdb_readoptions_destroy :: Ptr READOPTIONS -> IO ()
+
+-------------------------------------------------------------------------------
+-- write options
+-------------------------------------------------------------------------------
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_writeoptions_t" #-} WRITEOPTIONS
+
+foreign import capi "rocksdb/c.h rocksdb_writeoptions_create"
+  rocksdb_writeoptions_create :: IO (Ptr WRITEOPTIONS)
+
+foreign import capi "rocksdb/c.h rocksdb_writeoptions_destroy"
+  rocksdb_writeoptions_destroy :: Ptr WRITEOPTIONS -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_writeoptions_disable_WAL"
+  rocksdb_writeoptions_disable_WAL :: Ptr WRITEOPTIONS -> CInt -> IO ()
+
+-------------------------------------------------------------------------------
+-- db operations
+-------------------------------------------------------------------------------
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_t" #-} DB
+
+foreign import capi "rocksdb/c.h rocksdb_open"
+  rocksdb_open :: Ptr OPTIONS -> CString -> ErrPtr -> IO (Ptr DB)
+
+foreign import capi "rocksdb/c.h rocksdb_close"
+  rocksdb_close :: Ptr DB -> IO ()
+
+-- | Returns NULL if not found.  A malloc()ed array otherwise.
+-- Stores the length of the array in *vallen.
+foreign import capi "rocksdb/c.h rocksdb_get"
+  rocksdb_get :: Ptr DB -> Ptr READOPTIONS
+    -> CString -> CSize
+    -> Ptr CSize
+    -> ErrPtr
+    -> IO CString
+
+#if MIN_VERSION_base(4,18,0)
+foreign import capi "rocksdb/c.h rocksdb_multi_get"
+  rocksdb_multi_get :: Ptr DB -> Ptr READOPTIONS
+    -> CSize
+    -> Ptr (ConstPtr CChar) -> Ptr CSize
+    -> Ptr CString -> Ptr CSize
+    -> Ptr CString
+    -> IO ()
+#else
+foreign import ccall "rocksdb/c.h rocksdb_multi_get"
+  rocksdb_multi_get :: Ptr DB -> Ptr READOPTIONS
+    -> CSize
+    -> Ptr (Ptr CChar) -> Ptr CSize
+    -> Ptr CString -> Ptr CSize
+    -> Ptr CString
+    -> IO ()
+#endif
+
+foreign import capi "rocksdb/c.h rocksdb_put"
+  rocksdb_put :: Ptr DB -> Ptr WRITEOPTIONS
+    -> CString -> CSize
+    -> CString -> CSize
+    -> ErrPtr
+    -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_delete"
+  rocksdb_delete :: Ptr DB -> Ptr WRITEOPTIONS
+    -> CString -> CSize
+    -> ErrPtr
+    -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_write"
+  rocksdb_write :: Ptr DB -> Ptr WRITEOPTIONS
+    -> Ptr WRITEBATCH
+    -> ErrPtr
+    -> IO ()
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_checkpoint_t" #-} CHECKPOINT
+
+foreign import capi "rocksdb/c.h rocksdb_checkpoint_object_create"
+  rocksdb_checkpoint_object_create :: Ptr DB -> ErrPtr -> IO (Ptr CHECKPOINT)
+
+foreign import capi "rocksdb/c.h rocksdb_checkpoint_object_destroy"
+  rocksdb_checkpoint_object_destroy :: Ptr CHECKPOINT -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_checkpoint_create"
+  rocksdb_checkpoint_create :: Ptr CHECKPOINT -> CString -> Word64 -> ErrPtr -> IO ()
+
+-------------------------------------------------------------------------------
+-- write batch
+-------------------------------------------------------------------------------
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_writebatch_t" #-} WRITEBATCH
+
+foreign import capi "rocksdb/c.h rocksdb_writebatch_create"
+  rocksdb_writebatch_create :: IO (Ptr WRITEBATCH)
+
+foreign import capi "rocksdb/c.h rocksdb_writebatch_destroy"
+  rocksdb_writebatch_destroy :: Ptr WRITEBATCH -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_writebatch_put"
+  rocksdb_writebatch_put :: Ptr WRITEBATCH
+    -> CString -> CSize
+    -> CString -> CSize
+    -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_writebatch_delete"
+  rocksdb_writebatch_delete :: Ptr WRITEBATCH
+    -> CString -> CSize
+    -> IO ()
+
+-------------------------------------------------------------------------------
+-- block based table options
+-------------------------------------------------------------------------------
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_block_based_table_options_t" #-} BLOCKTABLEOPTIONS
+
+foreign import capi "rocksdb/c.h rocksdb_block_based_options_create"
+  rocksdb_block_based_options_create :: IO (Ptr BLOCKTABLEOPTIONS)
+
+foreign import capi "rocksdb/c.h rocksdb_block_based_options_destroy"
+  rocksdb_block_based_options_destroy :: Ptr BLOCKTABLEOPTIONS -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_block_based_options_set_filter_policy"
+  rocksdb_block_based_options_set_filter_policy :: Ptr BLOCKTABLEOPTIONS -> Ptr FILTERPOLICY -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_options_set_block_based_table_factory"
+  rocksdb_options_set_block_based_table_factory :: Ptr OPTIONS -> Ptr BLOCKTABLEOPTIONS -> IO ()
+
+-------------------------------------------------------------------------------
+-- filter policy
+-------------------------------------------------------------------------------
+
+data {-# CTYPE "rocksdb/c.h" "rocksdb_filterpolicy_t" #-} FILTERPOLICY
+
+foreign import capi "rocksdb/c.h rocksdb_filterpolicy_destroy"
+  rocksdb_filterpolicy_destroy :: Ptr FILTERPOLICY -> IO ()
+
+foreign import capi "rocksdb/c.h rocksdb_filterpolicy_create_bloom"
+  rocksdb_filterpolicy_create_bloom :: CInt -> IO (Ptr FILTERPOLICY)


### PR DESCRIPTION
On my machine

```
% cabal run rocksdb-bench-wp8 -- run  
GlobalOpts {rootDir = "_bench_rocksdb", initialSize = 100000000}
CmdRun (RunOpts {batchCount = 1000, batchSize = 256, check = False, seed = 1337})
Proper run:             11.229 sec
Operations per second: 22798.0 ops

% cabal run rocksdb-bench-wp8 -- run
GlobalOpts {rootDir = "_bench_rocksdb", initialSize = 100000000}
CmdRun (RunOpts {batchCount = 1000, batchSize = 256, check = False, seed = 1337})
Proper run:             11.091 sec
Operations per second: 23082.4 ops

% cabal run rocksdb-bench-wp8 -- run
GlobalOpts {rootDir = "_bench_rocksdb", initialSize = 100000000}
CmdRun (RunOpts {batchCount = 1000, batchSize = 256, check = False, seed = 1337})
Proper run:             11.048 sec
Operations per second: 23171.7 ops
```

Note, the 100M entry database isn't small:

```
du -hs _bench_rocksdb 
5,8G	_bench_rocksdb
```

(100 bytes * 100M is 10G, rocksdb compression helps a bit)

---

This benchmark demonstrates that our performance goals are realistic, but stretch goals aren't easy.