### PR TITLE
Refactor run merging

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
@@ -233,8 +233,8 @@ merge fs Config {..} targetPaths runs = do
   where
     go m =
         Merge.steps fs m stepSize >>= \case
-          Merge.MergeComplete run -> return run
-          Merge.MergeInProgress -> go m
+          (_, Merge.MergeComplete run) -> return run
+          (_, Merge.MergeInProgress) -> go m
 
 outputRunPaths :: Run.RunFsPaths
 outputRunPaths = RunFsPaths 0

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -71,6 +71,7 @@ library
     Database.LSMTree.Internal.RunBuilder
     Database.LSMTree.Internal.RunFsPaths
     Database.LSMTree.Internal.RunReader
+    Database.LSMTree.Internal.RunReaders
     Database.LSMTree.Internal.Serialise
     Database.LSMTree.Internal.Serialise.Class
     Database.LSMTree.Internal.Unsliced

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -180,9 +180,9 @@ data RawPageIndex entry =
        -- fully within the page (but might be the only entry on the page).
      | IndexEntry !SerialisedKey !entry
        -- | The index is present and corresponds to an entry where the value
-       -- may have overflowed onto subsequent pages. In this case only the
-       -- length of the suffix is returned. The caller can copy the full
-       -- serialised pages themselves.
+       -- has overflowed onto subsequent pages. In this case only prefix entry
+       -- and the length of the suffix are returned.
+       -- The caller can copy the full serialised pages themselves.
      | IndexEntryOverflow !SerialisedKey !entry !Word32
   deriving (Eq, Functor, Show)
 

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -186,6 +186,7 @@ data RawPageIndex entry =
      | IndexEntryOverflow !SerialisedKey !entry !Word32
   deriving (Eq, Functor, Show)
 
+{-# INLINE rawPageIndex #-}
 rawPageIndex
     :: RawPage
     -> Word16

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Database.LSMTree.Internal.RunReaders (
+    Readers (..)
+  , new
+  , close
+  , peekKey
+  , HasMore (..)
+  , pop
+  , dropWhileKey
+  ) where
+
+import           Control.Monad (zipWithM)
+import           Control.Monad.Primitive (RealWorld)
+import           Data.Function (on)
+import           Data.IORef
+import           Data.Maybe (catMaybes)
+import           Data.Traversable (for)
+import           Database.LSMTree.Internal.Run (Run)
+import           Database.LSMTree.Internal.RunReader (RunReader)
+import qualified Database.LSMTree.Internal.RunReader as Reader
+import           Database.LSMTree.Internal.Serialise
+import qualified KMerge.Heap as Heap
+import qualified System.FS.API as FS
+import           System.FS.API (HasFS)
+
+-- | Abstraction for the collection of 'RunReader', yielding elements in order.
+-- More precisely, that means first ordered by their key, then by the input
+-- run they came from. This is important for resolving multiple entries with the
+-- same key into one.
+--
+-- Construct with 'new', then keep calling 'pop'.
+-- If aborting early, remember to call 'close'!
+data Readers fhandle = Readers {
+      readersHeap :: !(Heap.MutableHeap RealWorld (ReadCtx fhandle))
+      -- | Since there is always one reader outside of the heap, we need to
+      -- store it separately. This also contains the next k\/op to yield, unless
+      -- all readers are drained, i.e. both:
+      -- 1. the reader inside the 'ReadCtx' is empty
+      -- 2. the heap is empty
+    , readersNext :: !(IORef (ReadCtx fhandle))
+    }
+
+newtype ReaderNumber = ReaderNumber Int
+  deriving (Eq, Ord)
+
+-- | Each heap element needs some more context than just the reader.
+-- E.g. the 'Eq' instance we need to be able to access the first key to be read
+-- in a pure way.
+--
+-- TODO(optimisation): We allocate this record for each k/op. This might be
+-- avoidable, see ideas below.
+data ReadCtx fhandle = ReadCtx {
+      -- We could avoid this using a more specialised mutable heap with separate
+      -- arrays for keys and values (or even each of their components).
+      -- Using an 'STRef' could avoid reallocating the record for every entry,
+      -- but that might not be straightforward to integrate with the heap.
+      readCtxHeadKey   :: !SerialisedKey
+    , readCtxHeadEntry :: !(Reader.Entry fhandle)
+      -- We could get rid of this by making 'LoserTree' stable (for which there
+      -- is a prototype already).
+      -- Alternatively, if we decide to have an invariant that the number in
+      -- 'RunFsPaths' is always higher for newer runs, then we could use that
+      -- in the 'Ord' instance.
+    , readCtxNumber    :: !ReaderNumber
+    , readCtxReader    :: !(RunReader fhandle)
+    }
+
+instance Eq (ReadCtx fhandle) where
+  (==) = (==) `on` (\r -> (readCtxHeadKey r, readCtxNumber r))
+
+-- | Makes sure we resolve entries in the right order.
+instance Ord (ReadCtx fhandle) where
+  compare = compare `on` (\r -> (readCtxHeadKey r, readCtxNumber r))
+
+-- | On equal keys, elements from runs earlier in the list are yielded first.
+-- This means that the list of runs should be sorted from new to old.
+new ::
+     HasFS IO h
+  -> [Run (FS.Handle h)]
+  -> IO (Maybe (Readers (FS.Handle h)))
+new fs runs = do
+    readers <- zipWithM (fromRun . ReaderNumber) [1..] runs
+    (readersHeap, firstReadCtx) <- Heap.newMutableHeap (catMaybes readers)
+    for firstReadCtx $ \readCtx -> do
+      readersNext <- newIORef readCtx
+      return Readers {..}
+  where
+    fromRun n run = nextReadCtx fs n =<< Reader.new fs run
+
+-- | Only call when aborting before all readers have been drained.
+close ::
+     HasFS IO h
+  -> Readers (FS.Handle h)
+  -> IO ()
+close fs Readers {..} = do
+    ReadCtx {readCtxReader} <- readIORef readersNext
+    Reader.close fs readCtxReader
+    closeHeap
+  where
+    closeHeap =
+        Heap.extract readersHeap >>= \case
+          Nothing -> return ()
+          Just ReadCtx {readCtxReader} -> do
+            Reader.close fs readCtxReader
+            closeHeap
+
+peekKey ::
+     Readers (FS.Handle h)
+  -> IO SerialisedKey
+peekKey Readers {..} = do
+    readCtxHeadKey <$> readIORef readersNext
+
+-- | Once a function returned 'Drained', do not use the 'Readers' any more!
+data HasMore = HasMore | Drained
+
+pop ::
+     HasFS IO h
+  -> Readers (FS.Handle h)
+  -> IO (SerialisedKey, Reader.Entry (FS.Handle h), HasMore)
+pop fs r@Readers {..} = do
+    ReadCtx {..} <- readIORef readersNext
+    hasMore <- dropOne fs r readCtxNumber readCtxReader
+    return (readCtxHeadKey, readCtxHeadEntry, hasMore)
+
+dropWhileKey ::
+     HasFS IO h
+  -> Readers (FS.Handle h)
+  -> SerialisedKey
+  -> IO (Int, HasMore)  -- ^ How many were dropped?
+dropWhileKey fs Readers {..} key = do
+    cur <- readIORef readersNext
+    if readCtxHeadKey cur == key
+      then go 0 cur
+      else return (0, HasMore)  -- nothing to do
+  where
+    -- invariant: @readCtxHeadKey == key@
+    go !n ReadCtx {readCtxNumber, readCtxReader} = do
+        mNext <- nextReadCtx fs readCtxNumber readCtxReader >>= \case
+          Nothing  -> Heap.extract readersHeap
+          Just ctx -> Just <$> Heap.replaceRoot readersHeap ctx
+        let !n' = n + 1
+        case mNext of
+          Nothing -> do
+            return (n', Drained)
+          Just next -> do
+            -- hasMore
+            if readCtxHeadKey next == key
+              then
+                go n' next
+              else do
+                writeIORef readersNext next
+                return (n', HasMore)
+
+
+dropOne ::
+     HasFS IO h
+  -> Readers (FS.Handle h)
+  -> ReaderNumber
+  -> RunReader (FS.Handle h)
+  -> IO HasMore
+dropOne fs Readers {..} number reader = do
+    mNext <- nextReadCtx fs number reader >>= \case
+      Nothing  -> Heap.extract readersHeap
+      Just ctx -> Just <$> Heap.replaceRoot readersHeap ctx
+    case mNext of
+      Nothing ->
+        return Drained
+      Just next -> do
+        writeIORef readersNext next
+        return HasMore
+
+nextReadCtx ::
+     HasFS IO h
+  -> ReaderNumber
+  -> RunReader (FS.Handle h)
+  -> IO (Maybe (ReadCtx (FS.Handle h)))
+nextReadCtx fs readCtxNumber readCtxReader = do
+    res <- Reader.next fs readCtxReader
+    case res of
+      Reader.Empty -> do
+        return Nothing
+      Reader.ReadEntry readCtxHeadKey readCtxHeadEntry ->
+        return (Just ReadCtx {..})


### PR DESCRIPTION
The refactoring I had planned, getting rid of the `IORef Entry` and enabling a few other optimisations.

I realised I had run the benchmarks in #203 using an older GHC version (9.2), so I also included that comparison here.

In terms of allocated bytes per entry:

| benchmark                      | GHC 9.2 | main  | refactor |
|--------------------------------|---------|-------|----------|
| word64-insert-x4               |     899 |   823 |      655 |
| word64-delete-x4               |     750 |   667 |      483 |
| word64-delete-x4-lastlevel     |     452 |   356 |      172 |
| word64-blob-x4                 |   31340 | 31198 |    31030 |
| word64-mupsert-x4              |     899 |   823 |      671 |
| word64-mupsert-collisions-x4   |     723 |   653 |      475 |
| word64-mix-x4                  |     849 |   771 |      603 |
| word64-mix-collisions-x4       |     652 |   581 |      413 |
| insert-large-keys-x4           |   34140 | 36680 |    36510 |
| insert-mixed-vals-x4           |   34380 | 36950 |    36780 |
| insert-page-x4                 |   51140 | 55030 |    54860 |
| insert-page-plus-byte-x4       |   98280 | 97840 |    97680 |
| insert-huge-vals-x4            |  194160 |193290 |   193130 |
| utxo-x4                        |    1473 |  1444 |     1268 |
| utxo-x4-lastlevel              |    1178 |  1130 |      954 |

Time is less stable, but there still seems to be a noticeable improvement (all in milliseconds per 50k entries, or 5k where indicated by `(*)`):

| benchmark                      | GHC 9.2 | main   | refactor |
|--------------------------------|---------|--------|----------|
| word64-insert-x4               |   13.83 |  13.76 |    13.01 |
| word64-delete-x4               |   12.73 |  13.03 |    12.71 |
| word64-delete-x4-lastlevel     |   5.992 |   5.58 |     4.87 |
| word64-blob-x4                 |  351.60 | 344.27 |   365.82 |
| word64-mupsert-x4              |   13.98 |  14.04 |    13.62 |
| word64-mupsert-collisions-x4   |   10.63 |  10.51 |     9.98 |
| word64-mix-x4                  |   14.88 |  15.22 |    14.72 |
| word64-mix-collisions-x4       |   11.18 |  11.12 |    10.77 |
| (*) insert-large-keys-x4       |   28.43 |  27.56 |    27.69 |
| (*) insert-mixed-vals-x4       |   27.21 |  27.40 |    26.98 |
| (*) insert-page-x4             |   39.70 |  39.87 |    39.83 |
| (*) insert-page-plus-byte-x4   |   72.79 |  71.67 |    73.45 |
| (*) insert-huge-vals-x4        |  133.00 | 131.01 |   133.86 |
| utxo-x4                        |   20.45 |  20.45 |    19.78 |
| utxo-x4-lastlevel              |   15.42 |  15.21 |    14.33 |


Full final results:

<details>

<summary>benchmark log</summary>

```
benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x2/merge
time                 11.71 ms   (11.68 ms .. 11.74 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 11.72 ms   (11.70 ms .. 11.76 ms)
std dev              80.15 μs   (44.77 μs .. 143.3 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.274e7    (3.274e7 .. 3.274e7)
  y                  79.130     (-1665.762 .. 1860.589)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x4/merge
time                 13.01 ms   (12.98 ms .. 13.04 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 13.05 ms   (13.04 ms .. 13.07 ms)
std dev              39.65 μs   (30.68 μs .. 55.32 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.277e7    (3.277e7 .. 3.277e7)
  y                  -71.319    (-1559.516 .. 1236.057)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x7/merge
time                 14.44 ms   (14.38 ms .. 14.51 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 14.33 ms   (14.31 ms .. 14.36 ms)
std dev              74.34 μs   (56.99 μs .. 104.3 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.281e7    (3.281e7 .. 3.281e7)
  y                  -83.184    (-1401.697 .. 1156.121)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-insert-x13/merge
time                 16.06 ms   (15.92 ms .. 16.18 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 15.97 ms   (15.94 ms .. 16.04 ms)
std dev              125.7 μs   (67.11 μs .. 204.8 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.294e7    (3.294e7 .. 3.294e7)
  y                  -3.959     (-11.234 .. 4.790e-7)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-delete-x4/merge
time                 12.71 ms   (12.67 ms .. 12.74 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 12.67 ms   (12.65 ms .. 12.70 ms)
std dev              76.34 μs   (57.33 μs .. 113.9 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2.413e7    (2.413e7 .. 2.413e7)
  y                  -338.521   (-1520.617 .. 972.106)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-blob-x4/merge
time                 365.8 ms   (344.6 ms .. 409.0 ms)
                     0.998 R²   (0.997 R² .. 1.000 R²)
mean                 352.8 ms   (348.2 ms .. 360.5 ms)
std dev              7.320 ms   (259.8 μs .. 9.010 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.552e9    (1.552e9 .. 1.552e9)
  y                  -800.000   (-1600.000 .. 6.514e-6)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-mupsert-x4/merge
time                 13.62 ms   (13.59 ms .. 13.67 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 13.67 ms   (13.64 ms .. 13.73 ms)
std dev              103.3 μs   (43.18 μs .. 189.6 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.357e7    (3.357e7 .. 3.357e7)
  y                  -68.148    (-2268.175 .. 2273.629)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-mupsert-collisions-x4/merge
time                 9.975 ms   (9.955 ms .. 9.989 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.00 ms   (9.986 ms .. 10.05 ms)
std dev              73.55 μs   (27.33 μs .. 134.6 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2.377e7    (2.377e7 .. 2.377e7)
  y                  77.593     (-2489.459 .. 2580.939)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-mix-x4/merge
time                 14.72 ms   (14.69 ms .. 14.76 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 14.76 ms   (14.73 ms .. 14.86 ms)
std dev              112.0 μs   (48.87 μs .. 206.0 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              3.013e7    (3.013e7 .. 3.013e7)
  y                  -1172.462  (-2338.346 .. 2.152e-7)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-mix-collisions-x4/merge
time                 10.77 ms   (10.75 ms .. 10.79 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.80 ms   (10.78 ms .. 10.89 ms)
std dev              92.31 μs   (36.90 μs .. 185.3 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2.063e7    (2.063e7 .. 2.063e7)
  y                  -20.094    (-57.278 .. 2.221e-7)

benchmarking Bench.Database.LSMTree.Internal.Merge/word64-delete-x4-lastlevel/merge
time                 4.875 ms   (4.868 ms .. 4.881 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.879 ms   (4.876 ms .. 4.882 ms)
std dev              8.460 μs   (6.937 μs .. 10.77 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              8618808.736 (8618808.000 .. 8618809.669)
  y                  -25.408    (-56.114 .. 6.939e-8)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-large-keys-x4/merge
time                 27.70 ms   (27.62 ms .. 27.80 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.91 ms   (27.83 ms .. 28.01 ms)
std dev              194.6 μs   (153.5 μs .. 250.4 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.826e8    (1.826e8 .. 1.826e8)
  y                  -71.529    (-258.485 .. 73.587)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-mixed-vals-x4/merge
time                 26.98 ms   (26.89 ms .. 27.08 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.10 ms   (27.05 ms .. 27.17 ms)
std dev              123.2 μs   (93.18 μs .. 164.6 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.839e8    (1.839e8 .. 1.839e8)
  y                  100.601    (-8.217e-7 .. 243.108)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-page-x4/merge
time                 39.83 ms   (39.56 ms .. 40.15 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 39.84 ms   (39.68 ms .. 40.41 ms)
std dev              534.1 μs   (124.9 μs .. 987.4 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              2.743e8    (2.743e8 .. 2.743e8)
  y                  114.286    (-2.662e-6 .. 280.906)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-page-plus-byte-x4/merge
time                 73.45 ms   (73.21 ms .. 73.62 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 74.35 ms   (73.97 ms .. 74.96 ms)
std dev              840.9 μs   (274.9 μs .. 1.101 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.884e8    (4.884e8 .. 4.884e8)
  y                  471.467    (4.318e-6 .. 810.641)

benchmarking Bench.Database.LSMTree.Internal.Merge/insert-huge-vals-x4/merge
time                 133.9 ms   (133.5 ms .. 134.4 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 135.1 ms   (134.5 ms .. 136.8 ms)
std dev              1.494 ms   (144.6 μs .. 2.190 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              9.656e8    (9.656e8 .. 9.656e8)
  y                  137.143    (-9.562e-6 .. 278.400)
variance introduced by outliers: 12% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4/merge
time                 19.79 ms   (19.76 ms .. 19.82 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.84 ms   (19.80 ms .. 19.93 ms)
std dev              115.2 μs   (35.26 μs .. 228.1 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              6.341e7    (6.341e7 .. 6.341e7)
  y                  178.895    (-859.053 .. 1134.390)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4-uneven/merge
time                 19.78 ms   (19.73 ms .. 19.83 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.89 ms   (19.84 ms .. 20.01 ms)
std dev              173.5 μs   (59.68 μs .. 329.1 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              6.353e7    (6.353e7 .. 6.353e7)
  y                  84.876     (-912.941 .. 981.966)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4-lastlevel/merge
time                 14.33 ms   (14.30 ms .. 14.36 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 14.41 ms   (14.38 ms .. 14.55 ms)
std dev              142.3 μs   (41.13 μs .. 294.5 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.769e7    (4.769e7 .. 4.769e7)
  y                  -584.940   (-1742.689 .. 18.404)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4+1-min-skewed-lastlevel/merge
time                 14.75 ms   (14.72 ms .. 14.77 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 14.84 ms   (14.80 ms .. 14.92 ms)
std dev              120.9 μs   (52.12 μs .. 220.5 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.788e7    (4.788e7 .. 4.788e7)
  y                  12.026     (-178.448 .. 167.731)

benchmarking Bench.Database.LSMTree.Internal.Merge/utxo-x4+1-max-skewed-lastlevel/merge
time                 14.50 ms   (14.26 ms .. 14.81 ms)
                     0.998 R²   (0.997 R² .. 1.000 R²)
mean                 14.23 ms   (14.14 ms .. 14.35 ms)
std dev              264.5 μs   (157.8 μs .. 378.9 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              4.795e7    (4.795e7 .. 4.795e7)
  y                  27.764     (-247.371 .. 306.049)
```

</details>


I still have some ideas for future optimisations around how `MutableHeap`, `ReadCtx` and `RunReader` play together, but that can wait.

It's also not quite ideal how blob inserts go from having a `BlobSpan` to `BlobRef` to `SerialisedBlob`. If we resolve blobs immediately, this saves 40 byte per entry on the reading side, but on the other hand we might read some blobs unnecessarily if their entries turn out to be obsolete. I think this will get easier with the changes to `RunReader` I have in mind.