### PR TITLE
Use vectors in the public API functions for lookups

### DIFF
--- a/bench/macro/lsm-tree-bench-wp8.hs
+++ b/bench/macro/lsm-tree-bench-wp8.hs
@@ -51,6 +51,7 @@ import qualified Data.IntSet as IS
 import           Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import           Data.Traversable (mapAccumL)
 import           Data.Tuple (swap)
+import qualified Data.Vector as V
 import           Data.Void (Void)
 import           Data.Word (Word64)
 import qualified MCG
@@ -359,7 +360,7 @@ doRun' gopts opts = do
             let (batch1, batch2) = toOperations lookups inserts
 
             -- lookups
-            _ <- LSM.lookups batch1 tbl
+            _ <- LSM.lookups (V.fromList batch1) tbl -- TODO: use vectors directly, update the RocksDB benchmark
 
             -- deletes and inserts
             LSM.updates batch2 tbl

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -287,6 +287,7 @@ test-suite lsm-tree-test
     , these
     , transformers
     , vector
+    , vector-algorithms
     , wide-word
 
   ghc-options:    -fno-ignore-asserts -threaded
@@ -391,6 +392,7 @@ benchmark lsm-tree-bench-wp8
     , lsm-tree:fs-api-blockio
     , lsm-tree:mcg
     , optparse-applicative
+    , vector
 
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded
 

--- a/prototypes/ScheduledMergesTestQLS.hs
+++ b/prototypes/ScheduledMergesTestQLS.hs
@@ -267,9 +267,9 @@ runActionIO action lookUp =
     lookUpVar :: ModelVar Model a -> a
     lookUpVar = lookUpGVar (Proxy :: Proxy IO) lookUp
 
-    lookupResultValue (NotFound _k)           = Nothing
-    lookupResultValue (Found _k v)            = Just v
-    lookupResultValue (FoundWithBlob _k v _b) = Just v
+    lookupResultValue NotFound             = Nothing
+    lookupResultValue (Found v)            = Just v
+    lookupResultValue (FoundWithBlob v _b) = Just v
 
     tr :: Tracer (ST RealWorld) Event
     tr = nullTracer

--- a/src/Database/LSMTree/Internal/Normal.hs
+++ b/src/Database/LSMTree/Internal/Normal.hs
@@ -7,10 +7,10 @@ module Database.LSMTree.Internal.Normal (
 import           Control.DeepSeq (NFData (..))
 
 -- | Result of a single point lookup.
-data LookupResult k v blobref =
-    NotFound      !k
-  | Found         !k !v
-  | FoundWithBlob !k !v !blobref
+data LookupResult v blobref =
+    NotFound
+  | Found         !v
+  | FoundWithBlob !v !blobref
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 -- | A result for one point in a range lookup.

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -85,6 +85,7 @@ module Database.LSMTree.Normal (
 
 import           Data.Kind (Type)
 import           Data.Typeable (Typeable)
+import qualified Data.Vector as V
 import           Database.LSMTree.Common (BlobRef, IOLike, Range (..),
                      SerialiseKey, SerialiseValue, Session (..), SnapshotName,
                      closeSession, deleteSnapshot, listSnapshots, openSession)
@@ -204,9 +205,9 @@ close (TableHandle th) = Internal.close th
 -- Lookups can be performed concurrently from multiple Haskell threads.
 lookups ::
      (IOLike m, SerialiseKey k, SerialiseValue v)
-  => [k]
+  => V.Vector k
   -> TableHandle m k v blob
-  -> m [LookupResult k v (BlobRef m blob)]
+  -> m (V.Vector (LookupResult v (BlobRef m blob)))
 lookups = undefined
 
 -- | Perform a range lookup.
@@ -216,7 +217,7 @@ rangeLookup ::
      (IOLike m, SerialiseKey k, SerialiseValue v)
   => Range k
   -> TableHandle m k v blob
-  -> m [RangeLookupResult k v (BlobRef m blob)]
+  -> m (V.Vector (RangeLookupResult k v (BlobRef m blob)))
 rangeLookup = undefined
 
 -- | Perform a mixed batch of inserts and deletes.
@@ -259,8 +260,8 @@ deletes = updates . fmap (,Delete)
 retrieveBlobs ::
      (IOLike m, SerialiseValue blob)
   => Session m
-  -> [BlobRef m blob]
-  -> m [blob]
+  -> V.Vector (BlobRef m blob)
+  -> m (V.Vector blob)
 retrieveBlobs = undefined
 
 {-------------------------------------------------------------------------------

--- a/test/Test/Database/LSMTree/Model/Normal.hs
+++ b/test/Test/Database/LSMTree/Model/Normal.hs
@@ -2,6 +2,7 @@
 module Test.Database.LSMTree.Model.Normal (tests) where
 
 import qualified Data.ByteString as BS
+import qualified Data.Vector as V
 import           Database.LSMTree.Model.Normal
 import           GHC.Exts (IsList (..))
 import           Test.QuickCheck.Instances ()
@@ -25,12 +26,12 @@ type Tbl = Table Key Value Blob
 -- | You can lookup what you inserted.
 prop_lookupInsert :: Key -> Value -> Tbl -> Property
 prop_lookupInsert k v tbl =
-    lookups [k] (inserts [(k, v, Nothing)] tbl) === [Found k v]
+    lookups (V.singleton k) (inserts [(k, v, Nothing)] tbl) === V.singleton (Found v)
 
 -- | You cannot lookup what you have deleted
 prop_lookupDelete :: Key -> Tbl -> Property
 prop_lookupDelete k tbl =
-    lookups [k] (deletes [k] tbl) === [NotFound k]
+    lookups (V.singleton k) (deletes [k] tbl) === V.singleton NotFound
 
 -- | Last insert wins.
 prop_insertInsert :: Key -> Key -> Value -> Tbl -> Property

--- a/test/Test/Database/LSMTree/ModelIO/Class.hs
+++ b/test/Test/Database/LSMTree/ModelIO/Class.hs
@@ -13,6 +13,7 @@ import           Control.Monad.Class.MonadThrow (MonadThrow (throwIO))
 import           Data.Kind (Constraint, Type)
 import           Data.Proxy (Proxy)
 import           Data.Typeable (Typeable)
+import qualified Data.Vector as V
 import           Database.LSMTree.Common (IOLike, Range (..), SerialiseKey,
                      SerialiseValue, SnapshotName)
 import qualified Database.LSMTree.ModelIO.Normal as M
@@ -61,21 +62,21 @@ class (IsSession (Session h)) => IsTableHandle h where
     lookups ::
            (IOLike m, SerialiseKey k, SerialiseValue v)
         => h m k v blob
-        -> [k]
-        -> m [LookupResult k v (BlobRef h m blob)]
+        -> V.Vector k
+        -> m (V.Vector (LookupResult v (BlobRef h m blob)))
 
     rangeLookup ::
            (IOLike m, SerialiseKey k, SerialiseValue v)
         => h m k v blob
         -> Range k
-        -> m [RangeLookupResult k v (BlobRef h m blob)]
+        -> m (V.Vector (RangeLookupResult k v (BlobRef h m blob)))
 
     retrieveBlobs ::
            (IOLike m, SerialiseValue blob)
         => proxy h
         -> Session h m
-        -> [BlobRef h m blob]
-        -> m [blob]
+        -> V.Vector (BlobRef h m blob)
+        -> m (V.Vector blob)
 
     updates ::
            (IOLike m, SerialiseKey k, SerialiseValue v, SerialiseValue blob)

--- a/test/Test/Util/Orphans.hs
+++ b/test/Test/Util/Orphans.hs
@@ -49,7 +49,7 @@ type family RealizeIOSim s a where
   RealizeIOSim s (Real.MVar a)  = MVar (IOSim s) a
   -- lsm-tree
   RealizeIOSim s (TableHandle IO k v blob)       = TableHandle (IOSim s) k v blob
-  RealizeIOSim s (LookupResult k v blobref)      = LookupResult k v (RealizeIOSim s blobref)
+  RealizeIOSim s (LookupResult v blobref)        = LookupResult v (RealizeIOSim s blobref)
   RealizeIOSim s (RangeLookupResult k v blobref) = RangeLookupResult k v (RealizeIOSim s blobref)
   RealizeIOSim s (BlobRef IO blob)               = BlobRef (IOSim s) blob
   -- Type family wrappers


### PR DESCRIPTION
Most of the changes are mechnical. One TODO I left in the `lsm-tree-bench-wp8` module is that we'd preferably use vectors directly in the generation of batches. I'm first going to ensure that the public API also uses vectors for updates.