### PR TITLE
Extend and simplify tests for PageAcc and PageAcc1

### DIFF
--- a/src-extras/Database/LSMTree/Extras/ReferenceImpl.hs
+++ b/src-extras/Database/LSMTree/Extras/ReferenceImpl.hs
@@ -26,6 +26,7 @@ module Database.LSMTree.Extras.ReferenceImpl (
 
     -- * Conversions to real implementation types
     toRawPage,
+    toRawPageMaybeOverfull,
     toEntry,
     toEntryPrefix,
     toSerialisedKey,
@@ -165,14 +166,18 @@ instance Arbitrary PageContentSingle where
 --
 toRawPage :: PageContentFits -> (RawPage, [RawOverflowPage])
 toRawPage (PageContentFits kops) =
-    fromMaybe overfull $ do
-      serialised <- serialisePage <$> encodePage DiskPage4k kops
-      (page : overflowPages) <- pure (pageSerialisedChunks DiskPage4k serialised)
-      pure (makeRawPageBS page, map makeRawOverflowPageBS overflowPages)
+    fromMaybe overfull (toRawPageMaybeOverfull (PageContentMaybeOverfull kops))
   where
     overfull =
       error $ "toRawPage: encountered overfull page, but PageContentFits is "
            ++ "supposed to be guaranteed to fit, i.e. not to be overfull."
+
+toRawPageMaybeOverfull :: PageContentMaybeOverfull
+                       -> Maybe (RawPage, [RawOverflowPage])
+toRawPageMaybeOverfull (PageContentMaybeOverfull kops) = do
+    serialised <- serialisePage <$> encodePage DiskPage4k kops
+    (page : overflowPages) <- pure (pageSerialisedChunks DiskPage4k serialised)
+    pure (makeRawPageBS page, map makeRawOverflowPageBS overflowPages)
 
 makeRawPageBS :: BS.ByteString -> RawPage
 makeRawPageBS bs =

--- a/src-extras/Database/LSMTree/Extras/ReferenceImpl.hs
+++ b/src-extras/Database/LSMTree/Extras/ReferenceImpl.hs
@@ -21,7 +21,7 @@ module Database.LSMTree.Extras.ReferenceImpl (
 
     -- * Overflow pages
     pageOverflowPrefixSuffixLen,
-    pageOverflowPages,
+    pageDiskPages,
     pageSerialisedChunks,
 
     -- * Conversions to real implementation types

--- a/test/Test/Database/LSMTree/Internal/PageAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/PageAcc.hs
@@ -21,7 +21,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests = testGroup "Database.LSMTree.Internal.PageAcc"
-    [ testProperty "prototype" prototype
+    [ testProperty "prototype" (\(PageContentMaybeOverfull kops) -> prototype kops)
 
     , testProperty "example-00" $ prototype []
     , testProperty "example-01" $ prototype [(Proto.Key "foobar", Proto.Delete)]


### PR DESCRIPTION
Use new general real/reference conversion functions to help write simpler tests. Also find and fix a bug.

This PR should be read patch by patch. See the descriptions for each patch individually.

This builds on top of #229 but that should be merged first, and then this rebased.