### PR TITLE
Show unexpected outputs in session tests

### DIFF
--- a/test/Test/Database/LSMTree/Internal.hs
+++ b/test/Test/Database/LSMTree/Internal.hs
@@ -34,20 +34,28 @@ twiceOpenSession = withTempIOHasBlockIO "twiceOpenSession" $ \hfs hbio -> do
     void $ openSession hfs hbio (FS.mkFsPath [])
     try @LSMTreeError (openSession hfs hbio (FS.mkFsPath [])) >>= \case
       Left (SessionDirLocked _) -> pure ()
-      _ -> assertFailure "Opening a session twice in the same directory \
-                         \should fail with an SessionDirLocked error."
+      x -> assertFailure $ "Opening a session twice in the same directory \
+                           \should fail with an SessionDirLocked error, but \
+                           \it returned this instead: " <> showLeft "Session" x
 
 sessionDirLayoutMismatch :: Assertion
 sessionDirLayoutMismatch = withTempIOHasBlockIO "sessionDirLayoutMismatch" $ \hfs hbio -> do
     FS.createDirectory hfs (FS.mkFsPath ["unexpected-directory"])
     try @LSMTreeError (openSession hfs hbio (FS.mkFsPath [])) >>= \case
       Left (SessionDirMalformed _) -> pure ()
-      _ -> assertFailure "Restoring a session in a directory with a wrong \
-                         \layout should fail with a SessionDirMalformed."
+      x -> assertFailure $ "Restoring a session in a directory with a wrong \
+                           \layout should fail with a SessionDirMalformed, but \
+                           \it returned this instead: " <> showLeft "Session" x
 
 sessionDirDoesNotExist :: Assertion
 sessionDirDoesNotExist = withTempIOHasBlockIO "sessionDirDoesNotExist" $ \hfs hbio -> do
     try @LSMTreeError (openSession hfs hbio (FS.mkFsPath ["missing-dir"])) >>= \case
       Left (SessionDirDoesNotExist _) -> pure ()
-      _ -> assertFailure "Opening a session in a non-existent directory should \
-                         \fail with a SessionDirDoesNotExist error."
+      x -> assertFailure $ "Opening a session in a non-existent directory should \
+                           \fail with a SessionDirDoesNotExist error, but it \
+                           \returned this instead: " <> showLeft "Session" x
+
+showLeft :: Show a => String -> Either a b -> String
+showLeft x = \case
+    Left e -> show e
+    Right _ -> x


### PR DESCRIPTION
If https://github.com/IntersectMBO/lsm-tree/actions/runs/9225657061/job/25383623470#step:15:512 shows up again, then this will show what the unexpected output of the test was.