### PR TITLE
Fix/improve the find script for stylish-haskell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ cabal.project.local~
 
 # Documentation
 docs/haddocks
+
+# Benchmarks
+_bench_*

--- a/scripts/format-cabal-find.sh
+++ b/scripts/format-cabal-find.sh
@@ -2,6 +2,5 @@
 
 set -euo pipefail
 
-find . -iname '*.cabal' \
-  -not -path "./dist-newstyle" \
-  -exec cabal-fmt -i {} +
+find . -path "./dist-newstyle" -prune -o \
+  -name '*.cabal' -exec cabal-fmt -i {} +

--- a/scripts/format-stylish-find.sh
+++ b/scripts/format-stylish-find.sh
@@ -19,6 +19,6 @@ echo "Running stylish-haskell script with arguments: $PARGS $CARGS"
 export LC_ALL=C.UTF-8
 
 # shellcheck disable=SC2086
-find $PARGS -iname '*.hs' \
-  -not -path "./dist-newstyle" \
-  -exec stylish-haskell -i -c .stylish-haskell.yaml {} +
+find $PARGS \
+  \( -path './dist-newstyle' -o -path './.git*' -o -path './_bench_*' \) -prune \
+  -o \( -iname '*.hs' -exec stylish-haskell -i -c .stylish-haskell.yaml {} + \)


### PR DESCRIPTION
Avoid looking at .hs files under ./dist-newstyle, and all files under ./.git* and ./_bench_*.

This fixes the script (which was failing to parse the .hs files in some dependencies) and makes it faster (looking at fewer files).