### PR TITLE
pipelined mode for WP8 benchmark

### DIFF
--- a/bench/macro/lsm-tree-bench-wp8.hs
+++ b/bench/macro/lsm-tree-bench-wp8.hs
@@ -48,7 +48,7 @@ import           Control.Exception (evaluate)
 import           Control.Monad (forM_, void, when)
 import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Data.Binary as B
-import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as BS
 import qualified Data.IntSet as IS
 import           Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import           Data.Traversable (mapAccumL)
@@ -73,8 +73,8 @@ import qualified Database.LSMTree.Normal as LSM
 -- Keys and values
 -------------------------------------------------------------------------------
 
-type K = BS.ByteString
-type V = BS.ByteString
+type K = BS.ShortByteString
+type V = BS.ShortByteString
 type B = Void
 
 instance LSM.Labellable (K, V, B) where
@@ -87,7 +87,7 @@ instance LSM.Labellable (K, V, B) where
 -- This is purely CPU bound operation, and we should be able to push IO
 -- when doing these in between.
 makeKey :: Word64 -> K
-makeKey w64 = SHA256.hashlazy (B.encode w64) <> "=="
+makeKey w64 = BS.toShort (SHA256.hashlazy (B.encode w64) <> "==")
 
 -- We use constant value. This shouldn't affect anything.
 theValue :: V

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -417,6 +417,7 @@ benchmark lsm-tree-bench-wp8
   hs-source-dirs: bench/macro src-extras
   main-is:        lsm-tree-bench-wp8.hs
   build-depends:
+    , async
     , base
     , binary
     , bytestring

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -36,6 +36,7 @@ module Database.LSMTree.Internal (
   , listSnapshots
     -- * configuration
   , TableConfig (..)
+  , defaultTableConfig
   , resolveMupsert
   , ResolveMupsert (..)
   , SizeRatio (..)
@@ -1123,6 +1124,23 @@ data TableConfig = TableConfig {
 -- | TODO: this should be removed once we have proper snapshotting with proper
 -- persistence of the config to disk.
 deriving instance Read TableConfig
+
+-- | A reasonable default 'TableConfig', for normal tables.
+--
+-- For monoidal tables, override the 'confResolveMupsert' field.
+--
+-- This uses a write buffer with up to 20,000 elements and a generous amount of
+-- memory for Bloom filters (FPR of 2%).
+--
+defaultTableConfig :: TableConfig
+defaultTableConfig =
+    TableConfig
+      { confMergePolicy      = MergePolicyLazyLevelling
+      , confSizeRatio        = Four
+      , confWriteBufferAlloc = AllocNumEntries (NumEntries 20_000)
+      , confBloomFilterAlloc = AllocRequestFPR 0.02
+      , confResolveMupsert   = Nothing
+      }
 
 resolveMupsert :: TableConfig -> SerialisedValue -> SerialisedValue -> SerialisedValue
 resolveMupsert conf = maybe const unResolveMupsert (confResolveMupsert conf)

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -39,6 +39,7 @@ module Database.LSMTree.Monoidal (
     -- * Table handles
   , TableHandle
   , Internal.TableConfig (..)
+  , Internal.defaultTableConfig
   , Internal.ResolveMupsert (..)
   , Internal.SizeRatio (..)
   , Internal.MergePolicy (..)

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -431,5 +431,5 @@ duplicate ::
      IOLike m
   => TableHandle m k v blob
   -> m (TableHandle m k v blob)
-duplicate = undefined
+duplicate = error "Database.LSMTree.Normal.duplicate: not yet implemented"
 -- TODO: implementation note: reuse the handles' ArenaManager

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -41,6 +41,7 @@ module Database.LSMTree.Normal (
     -- * Table handles
   , TableHandle
   , Internal.TableConfig (..)
+  , Internal.defaultTableConfig
   , Internal.SizeRatio (..)
   , Internal.MergePolicy (..)
   , Internal.WriteBufferAlloc (..)


### PR DESCRIPTION
Add the pipelined mode to the WP8 benchmark.

This is a bit awkward because to work with the real implementation it requires the duplicate action, which isn't implemented yet. So we can't get performance results for this yet.

I've tested the pipelined mode with the model implementation and that works fine, but I don't want to include that in the benchmark code because it pulls in too many other dependencies.

So to test the pipelined (and sequential) versions I've included a dynamic check that the results are the same as a simple pure reference function. This is enabled by --check. Hopefully the presence of the observation/output doesn't have much of a performance impact when it is disabled. Casual benchmark runs indicated the cost was less than the run-to-run variation.

The PR starts with a bunch of tidying up, including the patch from #271.