### PR TITLE
Micro-benchmark `IndexCompact` with non-uniform UTXO keys

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/IndexCompact.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/IndexCompact.hs
@@ -10,9 +10,13 @@ module Bench.Database.LSMTree.Internal.IndexCompact (
   ) where
 
 import           Control.DeepSeq (deepseq)
+import           Control.Exception (assert)
 import           Control.Monad.ST.Strict
 import           Criterion.Main
 import           Data.Foldable (Foldable (..))
+import qualified Data.List as List
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 import           Data.Map.Range
 import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word
@@ -47,6 +51,7 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.IndexCompact" [
             bench "unsafeWriteRange-10k" $
               whnfAppIO (\x -> stToIO (unsafeWriteRange mv (BoundInclusive 10000) (BoundInclusive 20000) x)) 17
         ]
+    , benchNonUniform
     ]
 
 -- | Input environment for benchmarking 'searches'.
@@ -89,3 +94,77 @@ constructIndexCompact (ChunkSize csize) (RFPrecision rfprec, apps) = runST $ do
     mapM_ (`append` ica) apps
     (_, index) <- unsafeEnd ica
     pure index
+
+{-------------------------------------------------------------------------------
+  Benchmarks for UTxO keys that are /almost/ uniformly distributed
+-------------------------------------------------------------------------------}
+
+-- | UTXO keys are not truly uniformly distrbuted. The 'txId' is a uniformly
+-- distributed hash, but the same 'txId' can appear in multiple UTXO keys, but
+-- with a different 'txIx'. In the worst case, this means that we have a clash
+-- in the compact index for /every page/. The following benchmarks show
+benchNonUniform :: Benchmark
+benchNonUniform =
+    bgroup "non-uniformity" [
+        -- construction
+        env (pure $ (0, appsWithNearDups (mkStdGen 17) 1000)) $ \as ->
+          bench ("construct appsWithNearDups") $ whnf (constructIndexCompact 1000) as
+      , env (pure $ (0, appsWithoutNearDups (mkStdGen 17) 1000)) $ \as ->
+          bench ("construct appsWithoutNearDups") $ whnf (constructIndexCompact 1000) as
+        -- search
+      , env ( let ic = constructIndexCompact 100 (0, appsWithNearDups (mkStdGen 17) 1000)
+                  g  = mkStdGen 42
+                  ks = serialiseKey <$> uniformWithReplacement @UTxOKey g 1000
+              in  pure (ic, ks) ) $ \ ~(ic, ks) ->
+          bench "search appsWithNearDups" $ whnf (searches ic) ks
+      , env ( let ic = constructIndexCompact 100 (0, appsWithoutNearDups (mkStdGen 17) 1000)
+                  g  = mkStdGen 42
+                  ks = serialiseKey <$> uniformWithReplacement @UTxOKey g 1000
+              in  pure (ic, ks) ) $ \ ~(ic, ks) ->
+          bench "search appsWithoutNearDups" $ whnf (searches ic) ks
+      ]
+
+-- | 'Append's with truly uniformly distributed UTXO keys.
+appsWithoutNearDups ::
+     StdGen
+  -> Int -- ^ Number of pages
+  -> [Append]
+appsWithoutNearDups g n = assert (suggestRangeFinderPrecision n == 0) $
+    let ks  = uniformWithoutReplacement @UTxOKey g (n * 2)
+        ks' = List.sort ks
+        -- append a dummy UTXO key because appsWithNearDups does so too.
+        ps  = groupsOfN 2 (UTxOKey 0 0 : ks')
+    in  assert (length ps == n + 1) $
+        fmap fromNE ps
+
+-- | 'Append's with worst-case near-duplicates. Each page boundary splits UTXO
+-- keys with the same 'txId' but different a 'txIx'.
+appsWithNearDups ::
+     StdGen
+  -> Int -- ^ Number of pages
+  -> [Append]
+appsWithNearDups g n = assert (suggestRangeFinderPrecision n == 0) $
+    let ks  = uniformWithoutReplacement @UTxOKey g n
+        ks' = flip concatMap (List.sort ks) $ \k -> [k {txIx = 0}, k {txIx = 1}]
+        -- append a dummy UTXO key so that each pair of near-duplicate keys is
+        -- split between pages. That is, the left element of the pair is the
+        -- maximum key in a page, and the right element of the pair is the
+        -- minimum key on the next page.
+        ps  = groupsOfN 2 (UTxOKey 0 0 : ks')
+    in  -- check that the number of pages
+        assert (length ps == n + 1) $
+        fmap fromNE ps
+
+fromNE :: NonEmpty UTxOKey -> Append
+fromNE xs =
+    assert (NE.sort xs == xs) $
+    assert (NE.nub xs == xs) $
+    AppendSinglePage (serialiseKey $ NE.head xs) (serialiseKey $ NE.last xs)
+
+-- | Make groups of @n@ elements from a list @xs@
+groupsOfN :: Int -> [a] -> [NonEmpty a]
+groupsOfN n
+  | n <= 0 = error "groupsOfN: n <= 0"
+  | otherwise = List.unfoldr f
+  where f xs = let (ys, zs) = List.splitAt n xs
+               in  (,zs) <$> NE.nonEmpty ys


### PR DESCRIPTION
Construction becomes ~5x slower and has ~3.5x more allocated bytes. Search becomes 35x slower, and has 4876x allocations
```
❯ cabal run lsm-tree-micro-bench -- -m pattern non-uniformity --regress allocated:iters
benchmarking Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/construct appsWithNearDups
time                 191.5 μs   (189.7 μs .. 193.8 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 190.2 μs   (189.5 μs .. 191.7 μs)
std dev              3.189 μs   (2.175 μs .. 4.562 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              907512.241 (907511.284 .. 907513.119)
  y                  3005.069   (2605.877 .. 3408.336)

benchmarking Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/construct appsWithoutNearDups
time                 38.53 μs   (38.14 μs .. 39.16 μs)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 38.40 μs   (38.19 μs .. 38.81 μs)
std dev              925.4 ns   (506.1 ns .. 1.615 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              247160.024 (247159.828 .. 247160.240)
  y                  2968.467   (2614.805 .. 3347.596)
variance introduced by outliers: 22% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/search appsWithNearDups
time                 941.7 μs   (938.8 μs .. 945.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 941.9 μs   (940.5 μs .. 943.9 μs)
std dev              5.432 μs   (3.845 μs .. 7.557 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              156033.353 (156027.533 .. 156039.668)
  y                  3006.892   (2500.693 .. 3610.068)

benchmarking Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/search appsWithoutNearDups
time                 26.52 μs   (26.34 μs .. 26.71 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 26.54 μs   (26.39 μs .. 26.74 μs)
std dev              549.2 ns   (423.0 ns .. 719.2 ns)
allocated:           0.999 R²   (0.999 R² .. 1.000 R²)
  iters              31.971     (31.868 .. 32.104)
  y                  3084.545   (2792.265 .. 3396.580)
variance introduced by outliers: 18% (moderately inflated)
```
This is because in a worst-case `appsWithNearDups` scenario, there is a clash for every page. This means we'll construct a full tie-breaker map, and we'll consult it on every search.