### PR TITLE
Change the serialisation of `UTxOKey`

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Serialise.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Serialise.hs
@@ -1,0 +1,20 @@
+module Bench.Database.LSMTree.Internal.Serialise (
+    benchmarks
+  ) where
+
+import           Criterion.Main
+import           Database.LSMTree.Extras.UTxO
+import           Database.LSMTree.Internal.Serialise.Class
+import           System.Random
+
+benchmarks :: Benchmark
+benchmarks = bgroup "Bench.Database.LSMTree.Internal.Serialise" [
+      env (pure $ fst $ uniform (mkStdGen 12)) $ \(k :: UTxOKey) ->
+        bgroup "UTxOKey" [
+            bench "serialiseKey" $ whnf serialiseKey k
+          , bench "serialiseKeyRoundtrip" $ whnf serialiseKeyRoundtrip k
+          ]
+    ]
+
+serialiseKeyRoundtrip :: SerialiseKey k => k -> k
+serialiseKeyRoundtrip k = deserialiseKey (serialiseKey k)

--- a/bench/micro/Main.hs
+++ b/bench/micro/Main.hs
@@ -1,12 +1,4 @@
 -- | Micro-benchmarks for the @lsm-tree@ library.
---
--- === TODO
---
--- This is temporary module header documentation. The module will be
--- fleshed out more as we implement bits of it.
---
--- Related work packages: 5, 6
---
 module Main (main) where
 
 import qualified Bench.Database.LSMTree.Internal.BloomFilter
@@ -14,6 +6,7 @@ import qualified Bench.Database.LSMTree.Internal.IndexCompact
 import qualified Bench.Database.LSMTree.Internal.Lookup
 import qualified Bench.Database.LSMTree.Internal.Merge
 import qualified Bench.Database.LSMTree.Internal.RawPage
+import qualified Bench.Database.LSMTree.Internal.Serialise
 import qualified Bench.Database.LSMTree.Internal.WriteBuffer
 import           Criterion.Main (defaultMain)
 
@@ -24,5 +17,6 @@ main = defaultMain [
     , Bench.Database.LSMTree.Internal.Lookup.benchmarks
     , Bench.Database.LSMTree.Internal.Merge.benchmarks
     , Bench.Database.LSMTree.Internal.RawPage.benchmarks
+    , Bench.Database.LSMTree.Internal.Serialise.benchmarks
     , Bench.Database.LSMTree.Internal.WriteBuffer.benchmarks
     ]

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -325,6 +325,7 @@ benchmark lsm-tree-micro-bench
     Bench.Database.LSMTree.Internal.Lookup
     Bench.Database.LSMTree.Internal.Merge
     Bench.Database.LSMTree.Internal.RawPage
+    Bench.Database.LSMTree.Internal.Serialise
     Bench.Database.LSMTree.Internal.WriteBuffer
     Database.LSMTree.Extras
     Database.LSMTree.Extras.Generators

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -37,6 +37,9 @@ import           Numeric (showInt)
 --
 -- [Identity] @'deserialiseKey' ('serialiseKey' x) == x@
 -- [Identity up to slicing] @'deserialiseKey' ('packSlice' prefix ('serialiseKey' x) suffix) == x@
+--
+-- Instances /may/ satisfy the following:
+--
 -- [Ordering-preserving] @x \`'compare'\` y == 'serialiseKey' x \`'compare'\` 'serialiseKey' y@
 --
 -- Raw bytes are lexicographically ordered, so in particular this means that

--- a/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
@@ -20,28 +20,29 @@ import           Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class"
-    [ testGroup "Word64"          (allProperties @Word64)
-    , testGroup "ByteString"      (allProperties @ByteString)
-    , testGroup "LazyByteString"  (allProperties @LazyByteString)
-    , testGroup "ShortByteString" (allProperties @ShortByteString)
+    [ testGroup "Word64"          (allProperties @Word64 True)
+    , testGroup "ByteString"      (allProperties @ByteString True)
+    , testGroup "LazyByteString"  (allProperties @LazyByteString True)
+    , testGroup "ShortByteString" (allProperties @ShortByteString True)
     , testGroup "ByteArray"       (valueProperties @ByteArray)
-    , testGroup "Word128"         (allProperties @Word128)
-    , testGroup "Word256"         (allProperties @Word256)
-    , testGroup "UTxOKey"         (keyProperties @UTxOKey)
+    , testGroup "Word128"         (allProperties @Word128 True)
+    , testGroup "Word256"         (allProperties @Word256 True)
+    , testGroup "UTxOKey"         (keyProperties @UTxOKey False)
     , testGroup "UTxOValue"       (valueProperties @UTxOValue)
     ]
 
-allProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a, SerialiseValue a) => [TestTree]
-allProperties = keyProperties @a <> valueProperties @a
+allProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a, SerialiseValue a) => Bool -> [TestTree]
+allProperties orderPreserving = keyProperties @a orderPreserving <> valueProperties @a
 
-keyProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a) => [TestTree]
-keyProperties =
+keyProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a) => Bool -> [TestTree]
+keyProperties orderPreserving =
     [ testProperty "prop_roundtripSerialiseKey" $
         prop_roundtripSerialiseKey @a
     , testProperty "prop_roundtripSerialiseKeyUpToSlicing" $
         prop_roundtripSerialiseKeyUpToSlicing @a
-    , testProperty "prop_orderPreservationSerialiseKey" $
-        prop_orderPreservationSerialiseKey @a
+    , testProperty "prop_orderPreservationSerialiseKey" $ \k1 k2 ->
+        (if orderPreserving then id else expectFailure)
+          (prop_orderPreservationSerialiseKey @a k1 k2)
     ]
 
 valueProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseValue a) => [TestTree]


### PR DESCRIPTION
**Comparing the `Serialise` benchmark before and after #308**
```
Benchmark                                                                before    after
Bench.Database.LSMTree.Internal.Serialise/UTxOKey/serialiseKey           0.593e-8  2.870e-8 +383.88%
Bench.Database.LSMTree.Internal.Serialise/UTxOKey/serialiseKeyRoundtrip  0.734e-8  4.863e-8 +562.07%
Geometric mean                                                           0.660e-8  3.736e-8 +466.00%
```

[before.log](https://github.com/user-attachments/files/16411256/before.log)
[before.csv](https://github.com/user-attachments/files/16411257/before.csv)
[after.log](https://github.com/user-attachments/files/16411258/after.log)
[after.csv](https://github.com/user-attachments/files/16411259/after.csv)

**Comparing the first commit of #306 and after #308**
```
Benchmark                                                                                  before    after
Bench.Database.LSMTree.Internal.IndexCompact/construction/construction-1k-100              0.404e-4  0.255e-4 -36.90%
Bench.Database.LSMTree.Internal.IndexCompact/construction/unsafeWriteRange-10k             0.585e-6  0.593e-6  +1.42%
Bench.Database.LSMTree.Internal.IndexCompact/construction/unsafeWriteRange-1k              0.947e-7  0.984e-7  +3.82%
Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/construct appsWithNearDups     1.959e-4  0.248e-4 -87.33%
Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/construct appsWithoutNearDups  0.393e-4  0.247e-4 -37.09%
Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/search appsWithNearDups        0.944e-3  0.021e-3 -97.76%
Bench.Database.LSMTree.Internal.IndexCompact/non-uniformity/search appsWithoutNearDups     2.884e-5  2.308e-5 -19.97%
Bench.Database.LSMTree.Internal.IndexCompact/searches-10-1k                                0.411e-4  0.429e-4  +4.28%
Geometric mean                                                                             1.930e-5  0.813e-5 -57.89%
```

[before.log](https://github.com/user-attachments/files/16411584/before.log)
[before.csv](https://github.com/user-attachments/files/16411585/before.csv)
[after.log](https://github.com/user-attachments/files/16411586/after.log)
[after.csv](https://github.com/user-attachments/files/16411587/after.csv)
