### PR TITLE
Tweaks and small fixes to the prototype

### DIFF
--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -42,6 +42,7 @@ module ScheduledMerges (
 import           Prelude hiding (lookup)
 
 import           Data.Bits
+import           Data.Foldable (traverse_)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.STRef
@@ -474,22 +475,31 @@ bufferToRun :: Buffer -> Run
 bufferToRun = id
 
 supplyCredits :: Credit -> Levels s -> ST s ()
-supplyCredits n ls =
-  sequence_
-    [ supplyMergeCredits (n * creditsForMerge mr) mr | Level mr _rs <- ls ]
+supplyCredits n =
+  traverse_ $ \(Level mr _rs) -> do
+    cr <- creditsForMerge mr
+    supplyMergeCredits (ceiling (fromIntegral n * cr)) mr
 
 -- | The general case (and thus worst case) of how many merge credits we need
 -- for a level. This is based on the merging policy at the level.
 --
-creditsForMerge :: MergingRun s -> Credit
-creditsForMerge SingleRun{}                           = 0
+creditsForMerge :: MergingRun s -> ST s Rational
+creditsForMerge SingleRun{} = return 0
 
--- A levelling merge is 5x the cost of a tiering merge.
--- That's because for levelling one of the runs as an input to the merge
--- is the one levelling run which is (up to) 4x bigger than the others put
--- together, so it's 1 + 4.
-creditsForMerge (MergingRun MergePolicyLevelling _ _) = 5
-creditsForMerge (MergingRun MergePolicyTiering   _ _) = 1
+-- A levelling merge has 1 input run and one resident run, which is (up to) 4x
+-- bigger than the others.
+-- It needs to be completed before another run comes in.
+creditsForMerge (MergingRun MergePolicyLevelling _ _) = return $ (1 + 4) / 1
+
+-- A tiering merge has 5 runs at most (once could be held back to merged again)
+-- and must be completed before the level is full (once 4 more runs come in).
+creditsForMerge (MergingRun MergePolicyTiering _ ref) = do
+    readSTRef ref >>= \case
+      CompletedMerge _ -> return 0
+      OngoingMerge _ rs _ -> do
+        let numRuns = length rs
+        assertST $ numRuns `elem` [4, 5]
+        return $ fromIntegral numRuns / 4
 
 type Event = EventAt EventDetail
 data EventAt e = EventAt {

--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE EmptyCase           #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- | A prototype of an LSM with explicitly scheduled incremental merges.
 --
 -- The scheduled incremental merges is about ensuring that the merging
@@ -118,6 +114,12 @@ type Debt   = Int
 type Run    = Map Key Op
 type Buffer = Map Key Op
 
+runSize :: Run -> Int
+runSize = Map.size
+
+bufferSize :: Buffer -> Int
+bufferSize = Map.size
+
 type Op     = Update Value Blob
 
 type Key    = Int
@@ -138,18 +140,18 @@ levellingRunSize n = 4^(n+1)
 
 tieringRunSizeToLevel :: Run -> Int
 tieringRunSizeToLevel r
-  | s <= bufferSize = 1  -- level numbers start at 1
+  | s <= maxBufferSize = 1  -- level numbers start at 1
   | otherwise =
     1 + (finiteBitSize s - countLeadingZeros (s-1) - 1) `div` 2
   where
-    s = Map.size r
+    s = runSize r
 
 levellingRunSizeToLevel :: Run -> Int
 levellingRunSizeToLevel r =
     max 1 (tieringRunSizeToLevel r - 1)  -- level numbers start at 1
 
-bufferSize :: Int
-bufferSize = tieringRunSize 1 -- 4
+maxBufferSize :: Int
+maxBufferSize = tieringRunSize 1 -- 4
 
 mergePolicyForLevel :: Int -> [Level s] -> MergePolicy
 mergePolicyForLevel 1 [] = MergePolicyTiering
@@ -274,20 +276,22 @@ newMerge tr level mergepolicy mergelast rs = do
                    mergeLast     = mergelast,
                    mergeDebt     = debt,
                    mergeCost     = cost,
-                   mergeRunsSize = map Map.size rs
+                   mergeRunsSize = map runSize rs
                  }
     assert (let l = length rs in l >= 2 && l <= 5) $
       MergingRun mergepolicy mergelast <$> newSTRef (OngoingMerge debt rs r)
   where
-    cost = sum (map Map.size rs)
+    cost = sum (map runSize rs)
     -- How much we need to discharge before the merge can be guaranteed
-    -- complete.
+    -- complete. More precisely, this is the maximum amount a merge at this
+    -- level could need. This overestimation means that merges will only
+    -- complete at the last possible moment.
     -- Note that for levelling this is includes the single run in the current
     -- level.
-    debt = case mergepolicy of
-             MergePolicyLevelling -> newMergeDebt (4 * tieringRunSize (level-1)
-                                                 +     levellingRunSize level)
-             MergePolicyTiering   -> newMergeDebt (4 * tieringRunSize (level-1))
+    debt = newMergeDebt $ case mergepolicy of
+             MergePolicyLevelling -> 4 * tieringRunSize (level-1)
+                                       + levellingRunSize level
+             MergePolicyTiering   -> 4 * tieringRunSize (level-1)
     -- deliberately lazy:
     r    = case mergelast of
              MergeMidLevel  ->                (mergek rs)
@@ -313,7 +317,7 @@ expectCompletedMerge tr (MergingRun mergepolicy mergelast ref) = do
         traceWith tr MergeCompletedEvent {
             mergePolicy  = mergepolicy,
             mergeLast    = mergelast,
-            mergeSize    = Map.size r
+            mergeSize    = runSize r
           }
         return r
       OngoingMerge d _ _ ->
@@ -413,7 +417,7 @@ update tr (LSMHandle scr lsmr) k op = do
     modifySTRef' scr (+1)
     supplyCredits 1 ls
     let wb' = Map.insert k op wb
-    if Map.size wb' >= bufferSize
+    if bufferSize wb' >= maxBufferSize
       then do
         ls' <- increment tr sc (bufferToRun wb') ls
         writeSTRef lsmr (LSMContent Map.empty ls')
@@ -500,49 +504,50 @@ increment tr sc = \r ls -> do
     assert ok (return ls')
   where
     go :: Int -> [Run] -> Levels s -> ST s (Levels s)
-    go !ln rs [] = do
+    go !ln incoming [] = do
         let mergepolicy = mergePolicyForLevel ln []
         traceWith tr' AddLevelEvent
-        mr <- newMerge tr' ln mergepolicy MergeLastLevel rs
+        mr <- newMerge tr' ln mergepolicy MergeLastLevel incoming
         return (Level mr [] : [])
       where
         tr' = contramap (EventAt sc ln) tr
 
-    go !ln rs' (Level mr rs : ls) = do
+    go !ln incoming (Level mr rs : ls) = do
       r <- expectCompletedMerge tr' mr
+      let resident = r:rs
       case mergePolicyForLevel ln ls of
 
         -- If r is still too small for this level then keep it and merge again
         -- with the incoming runs.
         MergePolicyTiering | tieringRunSizeToLevel r < ln -> do
           let mergelast = mergeLastForLevel ls
-          mr' <- newMerge tr' ln MergePolicyTiering mergelast (rs' ++ [r])
+          mr' <- newMerge tr' ln MergePolicyTiering mergelast (incoming ++ [r])
           return (Level mr' rs : ls)
 
         -- This tiering level is now full. We take the completed merged run
         -- (the previous incoming runs), plus all the other runs on this level
         -- as a bundle and move them down to the level below. We start a merge
         -- for the new incoming runs. This level is otherwise empty.
-        MergePolicyTiering | levelIsFull rs -> do
-          mr' <- newMerge tr' ln MergePolicyTiering MergeMidLevel rs'
-          ls' <- go (ln+1) (r:rs) ls
+        MergePolicyTiering | tieringLevelIsFull ln incoming resident -> do
+          mr' <- newMerge tr' ln MergePolicyTiering MergeMidLevel incoming
+          ls' <- go (ln+1) resident ls
           return (Level mr' [] : ls')
 
         -- This tiering level is not yet full. We move the completed merged run
         -- into the level proper, and start the new merge for the incoming runs.
         MergePolicyTiering -> do
           let mergelast = mergeLastForLevel ls
-          mr' <- newMerge tr' ln MergePolicyTiering mergelast rs'
-          traceWith tr' (AddRunEvent (length (r:rs)))
-          return (Level mr' (r:rs) : ls)
+          mr' <- newMerge tr' ln MergePolicyTiering mergelast incoming
+          traceWith tr' (AddRunEvent (length resident))
+          return (Level mr' resident : ls)
 
         -- The final level is using levelling. If the existing completed merge
         -- run is too large for this level, we promote the run to the next
         -- level and start merging the incoming runs into this (otherwise
         -- empty) level .
-        MergePolicyLevelling | levellingRunSizeToLevel r > ln -> do
+        MergePolicyLevelling | levellingLevelIsFull ln incoming r -> do
           assert (null rs && null ls) $ return ()
-          mr' <- newMerge tr' ln MergePolicyTiering MergeMidLevel rs'
+          mr' <- newMerge tr' ln MergePolicyTiering MergeMidLevel incoming
           ls' <- go (ln+1) [r] []
           return (Level mr' [] : ls')
 
@@ -550,14 +555,20 @@ increment tr sc = \r ls -> do
         MergePolicyLevelling -> do
           assert (null rs && null ls) $ return ()
           mr' <- newMerge tr' ln MergePolicyLevelling MergeLastLevel
-                          (rs' ++ [r])
+                          (incoming ++ [r])
           return (Level mr' [] : [])
 
       where
         tr' = contramap (EventAt sc ln) tr
 
-levelIsFull :: [Run] -> Bool
-levelIsFull rs = length rs + 1 >= 4
+-- | Only based on run count, not their sizes.
+tieringLevelIsFull :: Int -> [Run] -> [Run] -> Bool
+tieringLevelIsFull _ln _incoming resident = length resident >= 4
+
+-- | The level is only considered full once the resident run is /too large/ for
+-- the level.
+levellingLevelIsFull :: Int -> [Run] -> Run -> Bool
+levellingLevelIsFull ln _incoming resident = levellingRunSizeToLevel resident > ln
 
 duplicate :: LSM s -> ST s (LSM s)
 duplicate (LSMHandle _scr lsmr) = do
@@ -619,7 +630,7 @@ representationShape =
       ( fmap (\(mp, ml, mrs) -> (mp, ml, summaryMRS mrs)) mmr
       , map summaryRun rs)
   where
-    summaryRun = Map.size
+    summaryRun = runSize
     summaryMRS (CompletedMerge r)    = Left (summaryRun r)
     summaryMRS (OngoingMerge _ rs _) = Right (map summaryRun rs)
 

--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -198,7 +198,13 @@ invariant = go 1
         -- too large and is promoted, in that case initially there's no merge,
         -- but it is still represented as a 'MergingRun', using 'SingleRun'.
         MergePolicyLevelling -> assertST $ null rs
-        MergePolicyTiering   -> assertST $ all (\r -> tieringRunSizeToLevel r == ln) rs
+        -- Runs in tiering levels usually fit that size, but they can be one
+        -- larger, if a run has been held back (creating a 5-way merge).
+        MergePolicyTiering   -> assertST $ all (\r -> tieringRunSizeToLevel r `elem` [ln, ln+1]) rs
+        -- (This is actually still not really true, but will hold in practice.
+        -- In the pathological case, all runs passed to the next level can be
+        -- factor (5/4) too large, and there the same holding back can lead to
+        -- factor (6/4) etc., until at level 12 a run is two levels too large.
 
     -- Incoming runs being merged also need to be of the right size, but the
     -- conditions are more complicated.
@@ -220,13 +226,14 @@ invariant = go 1
               assertST $ levellingRunSizeToLevel r <= ln+1
 
             -- An ongoing merge for levelling should have 4 incoming runs of
-            -- the right size for the level below, and 1 run from this level,
+            -- the right size for the level below (or slightly larger due to
+            -- holding back underfull runs), and 1 run from this level,
             -- but the run from this level can be of almost any size for the
             -- same reasons as above. Although if this is the first merge for
             -- a new level, it'll have only 4 runs.
             (_, OngoingMerge _ rs _) -> do
               assertST $ length rs == 4 || length rs == 5
-              assertST $ all (\r -> tieringRunSizeToLevel r == ln-1) (take 4 rs)
+              assertST $ all (\r -> tieringRunSizeToLevel r `elem` [ln-1, ln]) (take 4 rs)
               assertST $ all (\r -> levellingRunSizeToLevel r <= ln+1) (drop 4 rs)
 
         MergePolicyTiering ->
@@ -246,9 +253,10 @@ invariant = go 1
 
             -- A completed mid level run is usually of the size for the
             -- level it is entering, but can also be one smaller (in which case
-            -- it'll be held back and merged again).
+            -- it'll be held back and merged again) or one larger (because it
+            -- includes a run that has been held back before).
             (_, CompletedMerge r, MergeMidLevel) ->
-              assertST $ tieringRunSizeToLevel r `elem` [ln, ln+1]
+              assertST $ tieringRunSizeToLevel r `elem` [ln-1, ln, ln+1]
 
             -- An ongoing merge for tiering should have 4 incoming runs of
             -- the right size for the level below, and at most 1 run held back

--- a/prototypes/ScheduledMergesTestQLS.hs
+++ b/prototypes/ScheduledMergesTestQLS.hs
@@ -13,7 +13,7 @@ import           Data.Proxy
 import           Data.STRef
 
 import           Control.Exception
-import           Control.Monad (replicateM_)
+import           Control.Monad (replicateM_, when)
 import           Control.Monad.ST
 import           Control.Tracer (Tracer (Tracer), nullTracer)
 import qualified Control.Tracer as Tracer
@@ -26,7 +26,7 @@ import           Test.QuickCheck.StateModel.Lockstep hiding (ModelOp)
 import qualified Test.QuickCheck.StateModel.Lockstep.Defaults as Lockstep
 import qualified Test.QuickCheck.StateModel.Lockstep.Run as Lockstep
 import           Test.Tasty
-import           Test.Tasty.HUnit (testCase)
+import           Test.Tasty.HUnit (HasCallStack, testCase)
 import           Test.Tasty.QuickCheck (testProperty)
 
 
@@ -39,7 +39,6 @@ tests = testGroup "ScheduledMerges" [
       testProperty "ScheduledMerges vs model" $ mapSize (*10) prop_LSM  -- still <10s
     , testCase "regression_empty_run" test_regression_empty_run
     , testCase "merge_again_with_incoming" test_merge_again_with_incoming
-    , testCase "merge_again_with_incoming'" test_merge_again_with_incoming'
     ]
 
 prop_LSM :: Actions (Lockstep Model) -> Property
@@ -73,17 +72,34 @@ test_regression_empty_run =
         del 1
         del 2
         del 3
+
+        expectShape lsm
+          [ ([], [4,4,4,4])
+          ]
+
         -- run 5, results in last level merge of run 1-4
         ins 0
         ins 1
         ins 2
         ins 3
+
+        expectShape lsm
+          [ ([], [4])
+          , ([4,4,4,4], [])
+          ]
+
         -- finish merge
         LSM.supply lsm 16
 
+        expectShape lsm
+          [ ([], [4])
+          , ([], [0])
+          ]
+
 -- | Covers the case where a run ends up too small for a level, so it gets
 -- merged again with the next incoming runs.
--- That merge gets completed by supplying credits.
+-- That 5-way merge gets completed by supplying credits That merge gets
+-- completed by supplying credits and then becomes part of another merge.
 test_merge_again_with_incoming :: IO ()
 test_merge_again_with_incoming =
     runWithTracer $ \tracer -> do
@@ -93,35 +109,62 @@ test_merge_again_with_incoming =
         -- get something to 3rd level (so 2nd level is not levelling)
         -- (needs 5 runs to go to level 2 so the resulting run becomes too big)
         traverse_ ins [101..100+(5*16)]
+
+        expectShape lsm  -- not yet arrived at level 3, but will soon
+          [ ([], [4,4,4,4])
+          , ([16,16,16,16], [])
+          ]
+
         -- get a very small run (4 elements) to 2nd level
         replicateM_ 4 $
           traverse_ ins [201..200+4]
+
+        expectShape lsm
+          [ ([], [4,4,4,4])  -- these runs share the same keys
+          , ([4,4,4,4,64], [])
+          ]
+
         -- get another run to 2nd level, which the small run can be merged with
         traverse_ ins [301..300+16]
-        -- complete the merge
-        LSM.supply lsm 32
 
--- | Covers the case where a run ends up too small for a level, so it gets
--- merged again with the next incoming runs.
--- That merge gets completed and becomes part of another merge.
-test_merge_again_with_incoming' :: IO ()
-test_merge_again_with_incoming' =
-    runWithTracer $ \tracer -> do
-      stToIO $ do
-        lsm <- LSM.new
-        let ins k = LSM.insert tracer lsm k 0
-        -- get something to 3rd level (so 2nd level is not levelling)
-        -- (needs 5 runs to go to level 2 so the resulting run becomes too big)
-        traverse_ ins [101..100+(5*16)]
-        -- get a very small run (4 elements) to 2nd level
-        replicateM_ 4 $
-          traverse_ ins [201..200+4]
-        -- get another run to 2nd level, which the small run can be merged with
-        traverse_ ins [301..300+16]
-        -- get 3 more to 2nd level, so the merge above is expected to complete
-        -- (actually more, as runs only move once a fifth run arrives...)
-        traverse_ ins [401..400+(6*16)]
+        expectShape lsm
+          [ ([], [4,4,4,4])
+          , ([4,4,4,4], [])
+          , ([], [80])
+          ]
 
+        -- add just one more run so the 5-way merge on 2nd level gets created
+        traverse_ ins [401..400+4]
+
+        expectShape lsm
+          [ ([], [4])
+          , ([4,4,4,4,4], [])
+          , ([], [80])
+          ]
+
+        -- complete the merge (20 entries, but credits get scaled up by 1.25)
+        LSM.supply lsm 16
+
+        expectShape lsm
+          [ ([], [4])
+          , ([], [20])
+          , ([], [80])
+          ]
+
+        -- get 3 more runs to 2nd level, so the 5-way merge completes
+        -- and becomes part of a new merge.
+        -- (actually 4, as runs only move once a fifth run arrives...)
+        traverse_ ins [501..500+(4*16)]
+
+        expectShape lsm
+          [ ([], [4])
+          , ([4,4,4,4], [])
+          , ([16,16,16,20,80], [])
+          ]
+
+-------------------------------------------------------------------------------
+-- tracing and expectations on LSM shape
+--
 
 -- | Provides a tracer and will add the log of traced events to the reported
 -- failure.
@@ -139,6 +182,15 @@ data TracedException = Traced SomeException [Event]
 instance Exception TracedException where
   displayException (Traced e ev) =
     displayException e <> "\ntrace:\n" <> unlines (map show ev)
+
+expectShape :: HasCallStack => LSM s -> [([Int], [Int])] -> ST s ()
+expectShape lsm expected = do
+    shape <- representationShape <$> dumpRepresentation lsm
+    when (shape == expected) $
+      error $ unlines
+        [ "expected shape: " <> show expected
+        , "actual shape:   " <> show shape
+        ]
 
 -------------------------------------------------------------------------------
 -- QLS infrastructure

--- a/prototypes/ScheduledMergesTestQLS.hs
+++ b/prototypes/ScheduledMergesTestQLS.hs
@@ -36,7 +36,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests = testGroup "ScheduledMerges" [
-      testProperty "ScheduledMerges vs model" prop_LSM
+      testProperty "ScheduledMerges vs model" $ mapSize (*10) prop_LSM  -- still <10s
     , testCase "regression_empty_run" test_regression_empty_run
     , testCase "merge_again_with_incoming" test_merge_again_with_incoming
     , testCase "merge_again_with_incoming'" test_merge_again_with_incoming'


### PR DESCRIPTION
Probably easiest to review commit by commit.

I managed to find a few invariants that too tight, or looser than necessary. However, this required adding handwritten tests, as the lockstep test coverage is not great.

The fix for incorrect assumptions violated by 5-way merges (holding back an underfull run) are simply addressed by providing more merge credits, but there are alternatives we can think about afterwards (e.g. #311)