### PR TITLE
Implement monoidal table API

### DIFF
--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -95,10 +95,8 @@ module Database.LSMTree.Normal (
   ) where
 
 import           Control.Monad
-import           Control.Monad.Class.MonadThrow (MonadThrow (..))
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Kind (Type)
-import           Data.Maybe (isJust)
 import           Data.Typeable (Proxy (..), Typeable)
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (BlobRef (BlobRef), IOLike, Range (..),
@@ -107,7 +105,7 @@ import           Database.LSMTree.Common (BlobRef (BlobRef), IOLike, Range (..),
                      withSession)
 import qualified Database.LSMTree.Common as Common
 import qualified Database.LSMTree.Internal as Internal
-import           Database.LSMTree.Internal.Entry (updateToEntryNormal)
+import qualified Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.Normal
 import qualified Database.LSMTree.Internal.Serialise as Internal
 import qualified Database.LSMTree.Internal.Vector as V
@@ -222,7 +220,8 @@ withTable ::
   -> Internal.TableConfig
   -> (TableHandle m k v blob -> m a)
   -> m a
-withTable (Session sesh) conf action = Internal.withTable sesh conf (action . TableHandle)
+withTable (Session sesh) conf action =
+    Internal.withTable sesh conf (action . TableHandle)
 
 {-# SPECIALISE new :: Session IO -> Internal.TableConfig -> IO (TableHandle IO k v blob) #-}
 -- | Create a new empty table, returning a fresh table handle.
@@ -265,7 +264,16 @@ lookups ::
   -> m (V.Vector (LookupResult v (BlobRef m blob)))
 lookups ks (TableHandle th) =
     V.mapStrict (bimap Internal.deserialiseValue BlobRef) <$!>
-    Internal.lookups (V.map Internal.serialiseKey ks) th Internal.toNormalLookupResult
+    Internal.lookups const (V.map Internal.serialiseKey ks) th toNormalLookupResult
+
+toNormalLookupResult :: Maybe (Entry.Entry v b) -> LookupResult v b
+toNormalLookupResult = \case
+    Just e -> case e of
+      Entry.Insert v            -> Found v
+      Entry.InsertWithBlob v br -> FoundWithBlob v br
+      Entry.Mupdate _           -> error "toNormalLookupResult: Mupdate unexpected"
+      Entry.Delete              -> NotFound
+    Nothing -> NotFound
 
 {-# SPECIALISE rangeLookup :: (SerialiseKey k, SerialiseValue v) => Range k -> TableHandle IO k v blob -> IO (V.Vector (RangeLookupResult k v (BlobRef IO blob))) #-}
 -- | Perform a range lookup.
@@ -291,14 +299,11 @@ updates ::
   -> TableHandle m k v blob
   -> m ()
 updates es (TableHandle th) = do
-    -- make sure not to insert any blobs into monoidal tables
-    when (isJust (Internal.confResolveMupsert (Internal.tableConfig th))) $
-      throwIO Internal.ErrExpectedNormalTable
-    Internal.updates (V.mapStrict serialiseEntry es) th
+    Internal.updates const (V.mapStrict serialiseEntry es) th
   where
     serialiseEntry = bimap Internal.serialiseKey serialiseOp
     serialiseOp = bimap Internal.serialiseValue Internal.serialiseBlob
-                . updateToEntryNormal
+                . Entry.updateToEntryNormal
 
 {-# SPECIALISE inserts :: (SerialiseKey k, SerialiseValue v, SerialiseValue blob) => V.Vector (k, v, Maybe blob) -> TableHandle IO k v blob -> IO () #-}
 -- | Perform a batch of inserts.
@@ -383,8 +388,10 @@ snapshot ::
   => SnapshotName
   -> TableHandle m k v blob
   -> m ()
-snapshot snap (TableHandle th) = void $ Internal.snapshot snap label th
-  where label = Common.makeSnapshotLabel (Proxy @(k, v, blob))
+snapshot snap (TableHandle th) = void $ Internal.snapshot const snap label th
+  where
+    -- to ensure we don't open a normal table as monoidal later
+    label = Common.makeSnapshotLabel (Proxy @(k, v, blob)) <> " (normal)"
 
 {-# SPECIALISE open :: (SerialiseKey k, SerialiseValue v, SerialiseValue blob, Common.Labellable (k, v, blob)) => Session IO -> Internal.TableConfigOverride -> SnapshotName -> IO (TableHandle IO k v blob ) #-}
 -- | Open a table from a named snapshot, returning a new table handle.
@@ -417,8 +424,11 @@ open ::
   -> Internal.TableConfigOverride -- ^ Optional config override
   -> SnapshotName
   -> m (TableHandle m k v blob)
-open (Session sesh) override snap = TableHandle <$> Internal.open sesh label override snap
-  where label = Common.makeSnapshotLabel (Proxy @(k, v, blob))
+open (Session sesh) override snap =
+    TableHandle <$> Internal.open sesh label override snap
+  where
+    -- to ensure that the table is really a normal table
+    label = Common.makeSnapshotLabel (Proxy @(k, v, blob)) <> " (normal)"
 
 {-------------------------------------------------------------------------------
   Mutiple writable table handles

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -281,8 +281,8 @@ rangeLookup = undefined
 {-# SPECIALISE updates :: (SerialiseKey k, SerialiseValue v, SerialiseValue blob) => V.Vector (k, Update v blob) -> TableHandle IO k v blob -> IO () #-}
 -- | Perform a mixed batch of inserts and deletes.
 --
--- If there are duplicate keys in the same batch, then keys nearer the front of
--- the vector take precedence.
+-- If there are duplicate keys in the same batch, then keys nearer to the front
+-- of the vector take precedence.
 --
 -- Updates can be performed concurrently from multiple Haskell threads.
 updates ::
@@ -378,7 +378,7 @@ retrieveBlobs _ brs
 snapshot ::
      forall m k v blob. ( IOLike m
      , SerialiseKey k, SerialiseValue v, SerialiseValue blob
-     , Common.Labellable (k, v , blob)
+     , Common.Labellable (k, v, blob)
      )
   => SnapshotName
   -> TableHandle m k v blob

--- a/test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Database/LSMTree/Class/Monoidal.hs
@@ -96,7 +96,7 @@ class (IsSession (Session h)) => IsTableHandle h where
         -> m ()
 
     snapshot ::
-        ( IOLike m, SerialiseKey k, SerialiseValue v
+        ( IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v
         , Labellable (k, v)
           -- Model-specific constraints
         , Typeable k, Typeable v

--- a/test/Database/LSMTree/Class/Normal.hs
+++ b/test/Database/LSMTree/Class/Normal.hs
@@ -102,10 +102,10 @@ class (IsSession (Session h)) => IsTableHandle h where
         -> m ()
 
     snapshot ::
-        ( IOLike m, SerialiseKey k, SerialiseValue v , SerialiseValue blob
+        ( IOLike m, SerialiseKey k, SerialiseValue v, SerialiseValue blob
         , Labellable (k, v, blob)
           -- Model-specific constraints
-        , Typeable k , Typeable v , Typeable blob
+        , Typeable k, Typeable v, Typeable blob
         )
         => SnapshotName
         -> h m k v blob

--- a/test/Test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Test/Database/LSMTree/Class/Monoidal.hs
@@ -46,7 +46,6 @@ tests = testGroup "Test.Database.LSMTree.Class.Monoidal"
             , R.confSizeRatio = R.Four
             , R.confWriteBufferAlloc = R.AllocNumEntries (R.NumEntries 3)
             , R.confBloomFilterAlloc = R.AllocFixed 10
-            , R.confResolveMupsert = Nothing
             , R.confDiskCachePolicy = R.DiskCacheNone
             }
         , testWithSessionArgs = \action ->
@@ -54,7 +53,22 @@ tests = testGroup "Test.Database.LSMTree.Class.Monoidal"
               action (SessionArgs hfs hbio (FS.mkFsPath []))
         }
 
-    expectFailures2 = repeat True
+    expectFailures2 = [
+        False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , True  -- lookupRange-insert
+      , False
+      , False
+      , False
+      , True  -- merge
+      ] ++ repeat False
 
     props tbl =
       [ testProperty' "lookup-insert" $ prop_lookupInsert tbl
@@ -83,8 +97,6 @@ newtype Value = Value BS.ByteString
   deriving stock (Eq, Show)
   deriving newtype (Arbitrary, R.SerialiseValue)
 
--- TODO: this is currently not used at all, only the value from the config
--- is taken into account!
 instance ResolveValue Value where
     resolveValue = resolveDeserialised resolve
 

--- a/test/Test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Test/Database/LSMTree/Class/Monoidal.hs
@@ -11,11 +11,12 @@ import           Data.Word (Word64)
 import           Database.LSMTree.Class.Monoidal hiding (withTableDuplicate,
                      withTableNew, withTableOpen)
 import qualified Database.LSMTree.Class.Monoidal as Class
+import           Database.LSMTree.Common (Labellable (..), mkSnapshotName)
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.ModelIO.Monoidal (IOLike, LookupResult (..),
                      Range (..), RangeLookupResult (..), Update (..))
 import qualified Database.LSMTree.ModelIO.Monoidal as M
-import           Database.LSMTree.Monoidal (ResolveValue (..), mkSnapshotName,
+import           Database.LSMTree.Monoidal (ResolveValue (..),
                      resolveDeserialised)
 import qualified Database.LSMTree.Monoidal as R
 import qualified System.FS.API as FS
@@ -82,11 +83,16 @@ newtype Value = Value BS.ByteString
   deriving stock (Eq, Show)
   deriving newtype (Arbitrary, R.SerialiseValue)
 
+-- TODO: this is currently not used at all, only the value from the config
+-- is taken into account!
 instance ResolveValue Value where
     resolveValue = resolveDeserialised resolve
 
 resolve :: Value -> Value -> Value
 resolve (Value x) (Value y) = Value (x <> y)
+
+instance Labellable (Key, Value) where
+  makeSnapshotLabel _ = "Word64 ByteString"
 
 type Proxy h = Setup h IO
 

--- a/test/Test/Database/LSMTree/Class/Normal.hs
+++ b/test/Test/Database/LSMTree/Class/Normal.hs
@@ -52,7 +52,6 @@ tests = testGroup "Test.Database.LSMTree.Class.Normal"
             , R.confSizeRatio = R.Four
             , R.confWriteBufferAlloc = R.AllocNumEntries (R.NumEntries 3)
             , R.confBloomFilterAlloc = R.AllocFixed 10
-            , R.confResolveMupsert = Nothing
             , R.confDiskCachePolicy = R.DiskCacheNone
             }
         , testWithSessionArgs = \action ->

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -67,7 +67,6 @@ import qualified Database.LSMTree.Class.Normal as Class
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact)
 import           Database.LSMTree.Internal (LSMTreeError (..))
-import qualified Database.LSMTree.Internal as R.Internal
 import qualified Database.LSMTree.Model.Normal.Session as Model
 import qualified Database.LSMTree.ModelIO.Normal as M
 import qualified Database.LSMTree.Normal as R
@@ -224,8 +223,6 @@ instance Arbitrary M.TableConfig where
   arbitrary :: Gen M.TableConfig
   arbitrary = pure M.TableConfig
 
--- |  This always generates 'Nothing' for the 'R.confResolveMupsert'
--- field.
 instance Arbitrary R.TableConfig where
   arbitrary :: Gen R.TableConfig
   arbitrary = pure $ R.TableConfig {
@@ -233,27 +230,19 @@ instance Arbitrary R.TableConfig where
       , R.confSizeRatio        = R.Four
       , R.confWriteBufferAlloc = R.AllocNumEntries (R.NumEntries 30)
       , R.confBloomFilterAlloc = R.AllocFixed 10
-      , R.confResolveMupsert   = Nothing
       , R.confDiskCachePolicy  = R.DiskCacheNone
       }
 
 instance Eq R.TableConfig where
-  R.TableConfig pol1 size1 wbAlloc1 bfAlloc1 mups1 cache1
-    == R.TableConfig pol2 size2 wbAlloc2 bfAlloc2 mups2 cache2
+  R.TableConfig pol1 size1 wbAlloc1 bfAlloc1 cache1
+    == R.TableConfig pol2 size2 wbAlloc2 bfAlloc2 cache2
     = and [
         pol1 == pol2
       , size1 == size2
       , wbAlloc1 == wbAlloc2
       , bfAlloc1 == bfAlloc2
-      , mups1 == mups2 -- Errors if either is 'Just'. This is intended behaviour.
       , cache1 == cache2
       ]
-
--- | 'R.ResolveMupsert's are arbitrary functions, so they don't have a
--- sensible 'Eq' instance. This (bottom) instance is only included to make
--- @quickheck-dynamic@ happy. Do not use this instance!
-instance Eq R.Internal.ResolveMupsert where
-  _ == _ = error "(==) on ResolveMupserts should not be used!"
 
 {-------------------------------------------------------------------------------
   Key and value types


### PR DESCRIPTION
~~Depends on #314. Before un-drafting this, I want to make sure all the tests are enabled and run successfully.~~

As a bonus, the `Internal` module now doesn't know anything about the normal/monoidal distinction. We prevent opening a normal snapshot as monoidal through the labels (although we might iterate on the exact design of that).

I haven't touched any of the TODOs from #314 yet, we should first discuss what we want to do there.

The tests all seem to be enabled now, unless I missed something.