### PR TITLE
bloomfilter bulk query optimisation with memory prefetching

### DIFF
--- a/bench/macro/lsm-tree-bench-bloomfilter.hs
+++ b/bench/macro/lsm-tree-bench-bloomfilter.hs
@@ -13,10 +13,10 @@ import           Data.BloomFilter (Bloom)
 import qualified Data.BloomFilter as Bloom
 import qualified Data.BloomFilter.Hash as Bloom
 import qualified Data.BloomFilter.Mutable as MBloom
-import qualified Data.Foldable as Fold
 import           Data.Time
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
+import qualified Data.Vector.Primitive as VP
 import           Data.WideWord.Word256 (Word256)
 import           GHC.Stats
 import           Numeric
@@ -27,6 +27,7 @@ import           Text.Printf (printf)
 
 import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Internal.Assertions (fromIntegralChecked)
+import qualified Database.LSMTree.Internal.BloomFilterQuery1 as Bloom1
 import           Database.LSMTree.Internal.Serialise (SerialisedKey,
                      serialiseKey)
 import qualified Monkey
@@ -50,6 +51,10 @@ benchmarkSizeBase = 16
 -- part of the point of this benchmark).
 benchmarkNumLookups :: Integer
 benchmarkNumLookups = 25_000_000
+
+-- | The number of lookups to do in a single batch.
+benchmarkBatchSize :: Int
+benchmarkBatchSize = 256
 
 benchmarkNumBitsPerEntry :: Integer
 benchmarkNumBitsPerEntry = 10
@@ -82,29 +87,31 @@ benchmarks = do
     putStrLn " finished."
     putStrLn ""
 
-    baseline <-
-      benchmark "baseline"
-                "(This is the cost of just computing the keys.)"
-                (benchBaseline vbs rng0) benchmarkNumLookups
-                (0, 0)
-#ifdef NO_IGNORE_ASSERTS
-                80  -- https://gitlab.haskell.org/ghc/ghc/-/issues/24625
-#else
-                48
-#endif
-
     hashcost <-
       benchmark "makeCheapHashes"
-                "(This includes the cost of hashing the keys, less the cost of computing the keys)"
-                (benchMakeCheapHashes vbs rng0) benchmarkNumLookups
-                baseline
-                0
+                "(This baseline is the cost of computing and hashing the keys)"
+                (benchInBatches benchmarkBatchSize rng0
+                   (benchMakeCheapHashes vbs))
+                (fromIntegralChecked benchmarkNumLookups)
+                (0, 0)
+                289
 
     _ <-
       benchmark "elemCheapHashes"
                 "(this is the simple one-by-one lookup, less the cost of computing and hashing the keys)"
-                (benchElemCheapHashes vbs rng0) benchmarkNumLookups
-                (fst hashcost + fst baseline, snd hashcost + snd baseline)
+                (benchInBatches benchmarkBatchSize rng0
+                  (benchElemCheapHashes vbs))
+                (fromIntegralChecked benchmarkNumLookups)
+                hashcost
+                0
+
+    _ <-
+      benchmark "bloomQueries1"
+                "(this is the batch lookup, less the cost of computing and hashing the keys)"
+                (benchInBatches benchmarkBatchSize rng0
+                  (\ks -> Bloom1.bloomQueriesDefault vbs ks `seq` ()))
+                (fromIntegralChecked benchmarkNumLookups)
+                hashcost
                 0
 
     return ()
@@ -113,8 +120,8 @@ type Alloc = Int
 
 benchmark :: String
           -> String
-          -> (Integer -> ())
-          -> Integer
+          -> (Int -> ())
+          -> Int
           -> (NominalDiffTime, Alloc)
           -> Int
           -> IO (NominalDiffTime, Alloc)
@@ -237,33 +244,40 @@ elemManyEnv filterSizes rng0 =
                   , mb' <- replicate (fromIntegralChecked sizeFactor) mb ]))
     V.fromList <$> mapM Bloom.unsafeFreeze mbs
 
--- | This gives us a baseline cost of just calculating the series of keys.
-benchBaseline :: Vector (Bloom SerialisedKey) -> StdGen -> Integer -> ()
-benchBaseline !_  !_   0 = ()
-benchBaseline !bs !rng !n =
-    let k :: Word256
-        (!k, !rng') = uniform rng
-        !k' = serialiseKey k
-     in k' `seq` benchBaseline bs rng' (n-1)
+type BatchBench = V.Vector SerialisedKey -> ()
+
+{-# NOINLINE benchInBatches #-}
+benchInBatches :: Int -> StdGen -> BatchBench -> Int -> ()
+benchInBatches !b !rng0 !action =
+    go rng0
+  where
+    go !rng !n
+      | n <= 0    = ()
+      | otherwise =
+        let (!rng'', !rng') = split rng
+            ks  :: VP.Vector Word256
+            !ks  = VP.unfoldrExactN b uniform rng'
+            ks' :: V.Vector SerialisedKey
+            !ks' = V.map serialiseKey (V.convert ks)
+        in action ks' `seq` go rng'' (n-b)
 
 -- | This gives us a combined cost of calculating the series of keys and their
--- hashes.
-benchMakeCheapHashes :: Vector (Bloom SerialisedKey) -> StdGen -> Integer -> ()
-benchMakeCheapHashes !_  !_   0 = ()
-benchMakeCheapHashes !bs !rng !n =
-    let k :: Word256
-        (!k, !rng') = uniform rng
-        !kh = Bloom.makeHashes (serialiseKey k) :: Bloom.CheapHashes SerialisedKey
-     in kh `seq` benchMakeCheapHashes bs rng' (n-1)
+-- hashes (when used with 'benchInBatches').
+benchMakeCheapHashes :: Vector (Bloom SerialisedKey) -> BatchBench
+benchMakeCheapHashes !_bs !ks =
+    let khs :: VP.Vector (Bloom.CheapHashes SerialisedKey)
+        !khs = V.convert (V.map Bloom.makeHashes ks)
+     in khs `seq` ()
 
 -- | This gives us a combined cost of calculating the series of keys, their
--- hashes, and then using 'Bloom.elemCheapHashes' with each filter.
-benchElemCheapHashes :: Vector (Bloom SerialisedKey) -> StdGen -> Integer -> ()
-benchElemCheapHashes !_  !_   0  = ()
-benchElemCheapHashes !bs !rng !n =
-    let k :: Word256
-        (!k, !rng') = uniform rng
-        !kh =  Bloom.makeHashes (serialiseKey k)
-     in Fold.foldl' (\_ b -> Bloom.elemHashes kh b `seq` ()) () bs
-  `seq` benchElemCheapHashes bs rng' (n-1)
-
+-- hashes, and then using 'Bloom.elemCheapHashes' with each filter  (when used
+-- with 'benchInBatches').
+benchElemCheapHashes :: Vector (Bloom SerialisedKey) -> BatchBench
+benchElemCheapHashes !bs !ks =
+    let khs :: VP.Vector (Bloom.CheapHashes SerialisedKey)
+        !khs = V.convert (V.map Bloom.makeHashes ks)
+     in V.foldl'
+          (\_ b -> VP.foldl'
+                     (\_ kh -> Bloom.elemHashes kh b `seq` ())
+                     () khs)
+          () bs

--- a/bench/macro/lsm-tree-bench-bloomfilter.hs
+++ b/bench/macro/lsm-tree-bench-bloomfilter.hs
@@ -32,6 +32,10 @@ import           Database.LSMTree.Internal.Serialise (SerialisedKey,
                      serialiseKey)
 import qualified Monkey
 
+#ifdef BLOOM_QUERY_FAST
+import qualified Database.LSMTree.Internal.BloomFilterQuery2 as Bloom2
+#endif
+
 main :: IO ()
 main = do
   hSetBuffering stdout NoBuffering
@@ -113,6 +117,17 @@ benchmarks = do
                 (fromIntegralChecked benchmarkNumLookups)
                 hashcost
                 0
+
+#ifdef BLOOM_QUERY_FAST
+    _ <-
+      benchmark "bloomQueries2"
+                "(this is the optimised batch lookup, less the cost of computing and hashing the keys)"
+                (benchInBatches benchmarkBatchSize rng0
+                  (\ks -> Bloom2.bloomQueriesDefault vbs ks  `seq` ()))
+                (fromIntegralChecked benchmarkNumLookups)
+                hashcost
+                0
+#endif
 
     return ()
 

--- a/bench/macro/lsm-tree-bench-bloomfilter.hs
+++ b/bench/macro/lsm-tree-bench-bloomfilter.hs
@@ -113,7 +113,7 @@ benchmarks = do
       benchmark "bloomQueries1"
                 "(this is the batch lookup, less the cost of computing and hashing the keys)"
                 (benchInBatches benchmarkBatchSize rng0
-                  (\ks -> Bloom1.bloomQueriesDefault vbs ks `seq` ()))
+                  (\ks -> Bloom1.bloomQueries vbs ks `seq` ()))
                 (fromIntegralChecked benchmarkNumLookups)
                 hashcost
                 0
@@ -123,7 +123,7 @@ benchmarks = do
       benchmark "bloomQueries2"
                 "(this is the optimised batch lookup, less the cost of computing and hashing the keys)"
                 (benchInBatches benchmarkBatchSize rng0
-                  (\ks -> Bloom2.bloomQueriesDefault vbs ks  `seq` ()))
+                  (\ks -> Bloom2.bloomQueries vbs ks `seq` ()))
                 (fromIntegralChecked benchmarkNumLookups)
                 hashcost
                 0

--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -18,7 +18,7 @@ import qualified Data.Vector as V
 import           Data.Vector.Algorithms.Merge as Merge
 import qualified Data.Vector.Generic.Mutable as VGM
 import qualified Data.Vector.Mutable as VM
-import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word (Word64)
 import           Database.LSMTree.Extras.Orphans ()
@@ -515,7 +515,7 @@ classifyLookups !bs !keyRng0 !n0 =
           unsafePerformIO (putStr ".") `seq`
           let (!ks, !keyRng') = genLookupBatch keyRng benchmarkGenBatchSize
               !rkixs = bloomQueriesDefault bs ks
-          in  loop (positives + VU.length rkixs) keyRng' (n-benchmarkGenBatchSize)
+          in  loop (positives + VP.length rkixs) keyRng' (n-benchmarkGenBatchSize)
 
 -- | Fill a mutable vector with uniformly random values.
 vectorOfUniforms ::

--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -419,7 +419,7 @@ benchBloomQueries !bs !keyRng !n
   | n <= 0 = ()
   | otherwise =
       let (!ks, !keyRng') = genLookupBatch keyRng benchmarkGenBatchSize
-      in  bloomQueriesDefault bs ks `seq`
+      in  bloomQueries bs ks `seq`
           benchBloomQueries bs keyRng' (n-benchmarkGenBatchSize)
 
 -- | This gives us the combined cost of calculating batches of keys, performing
@@ -436,7 +436,7 @@ benchIndexSearches !arenaManager !bs !ics !hs !keyRng !n
   | n <= 0 = pure ()
   | otherwise = do
     let (!ks, !keyRng') = genLookupBatch keyRng benchmarkGenBatchSize
-        !rkixs = bloomQueriesDefault bs ks
+        !rkixs = bloomQueries bs ks
     !_ioops <- withArena arenaManager $ \arena -> stToIO $ indexSearches arena ics hs ks rkixs
     benchIndexSearches arenaManager bs ics hs keyRng' (n-benchmarkGenBatchSize)
 
@@ -514,7 +514,7 @@ classifyLookups !bs !keyRng0 !n0 =
       | otherwise =
           unsafePerformIO (putStr ".") `seq`
           let (!ks, !keyRng') = genLookupBatch keyRng benchmarkGenBatchSize
-              !rkixs = bloomQueriesDefault bs ks
+              !rkixs = bloomQueries bs ks
           in  loop (positives + VP.length rkixs) keyRng' (n-benchmarkGenBatchSize)
 
 -- | Fill a mutable vector with uniformly random values.

--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -22,8 +22,8 @@ import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry (Entry (..), unNumEntries)
 import           Database.LSMTree.Internal.IndexCompact (getNumPages)
-import           Database.LSMTree.Internal.Lookup (bloomQueriesDefault,
-                     indexSearches, intraPageLookups, lookupsIO, prepLookups)
+import           Database.LSMTree.Internal.Lookup (bloomQueries, indexSearches,
+                     intraPageLookups, lookupsIO, prepLookups)
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
@@ -92,10 +92,10 @@ benchLookups conf@Config{name} =
             -- The bloomfilter is queried for all lookup keys. The result is an
             -- unboxed vector, so only use @whnf@.
             bench "Bloomfilter query" $
-              whnf (\ks' -> bloomQueriesDefault blooms ks') ks
+              whnf (\ks' -> bloomQueries blooms ks') ks
             -- The compact index is only searched for (true and false) positive
             -- lookup keys. We use whnf here because the result is
-          , env (pure $ bloomQueriesDefault blooms ks) $ \rkixs ->
+          , env (pure $ bloomQueries blooms ks) $ \rkixs ->
               bench "Compact index search" $
                 whnfAppIO (\ks' -> withArena arenaManager $ \arena -> stToIO $ indexSearches arena indexes kopsFiles ks' rkixs) ks
             -- prepLookups combines bloom filter querying and index searching.

--- a/bloomfilter/src/Data/BloomFilter.hs
+++ b/bloomfilter/src/Data/BloomFilter.hs
@@ -58,11 +58,12 @@ module Data.BloomFilter (
     notElem,
 ) where
 
+import           Control.Exception (assert)
 import           Control.Monad (forM_, liftM)
 import           Control.Monad.ST (ST, runST)
 import           Data.BloomFilter.Hash (CheapHashes, Hash, Hashable,
                      Hashes (..), RealHashes)
-import           Data.BloomFilter.Internal (Bloom' (..))
+import           Data.BloomFilter.Internal (Bloom' (..), bloomInvariant)
 import           Data.BloomFilter.Mutable (MBloom, MBloom', insert, new)
 import qualified Data.BloomFilter.Mutable.Internal as MB
 import           Data.Word (Word64)
@@ -102,15 +103,19 @@ create hash numBits body = runST $ do
 -- | Create an immutable Bloom filter from a mutable one.  The mutable
 -- filter may be modified afterwards.
 freeze :: MBloom' s h a -> ST s (Bloom' h a)
-freeze mb = Bloom (MB.hashesN mb) (MB.size mb) `liftM`
-            V.freeze (MB.bitArray mb)
+freeze mb = do
+    ba <- V.freeze (MB.bitArray mb)
+    let !bf = Bloom (MB.hashesN mb) (MB.size mb) ba
+    assert (bloomInvariant bf) $ pure bf
 
 -- | Create an immutable Bloom filter from a mutable one.  The mutable
 -- filter /must not/ be modified afterwards, or a runtime crash may
 -- occur.  For a safer creation interface, use 'freeze' or 'create'.
 unsafeFreeze :: MBloom' s h a -> ST s (Bloom' h a)
-unsafeFreeze mb = Bloom (MB.hashesN mb) (MB.size mb) `liftM`
-                    V.unsafeFreeze (MB.bitArray mb)
+unsafeFreeze mb = do
+    ba <- V.unsafeFreeze (MB.bitArray mb)
+    let !bf = Bloom (MB.hashesN mb) (MB.size mb) ba
+    assert (bloomInvariant bf) $ pure bf
 
 -- | Copy an immutable Bloom filter to create a mutable one.  There is
 -- no non-copying equivalent.

--- a/bloomfilter/src/Data/BloomFilter.hs
+++ b/bloomfilter/src/Data/BloomFilter.hs
@@ -143,12 +143,18 @@ elem elt ub = elemHashes (makeHashes elt) ub
 elemHashes :: Hashes h => h a -> Bloom' h a -> Bool
 elemHashes !ch !ub = go 0 where
     go :: Int -> Bool
-    go !i | i >= hashesN ub = True
-          | otherwise       = let !idx' = evalHashes ch i in
-                              let !idx = idx' `rem` size ub in
-                              if V.unsafeIndex (bitArray ub) idx
-                              then go (i + 1)
-                              else False
+    go !i | i >= hashesN ub
+          = True
+    go !i = let idx' :: Word64
+                !idx' = evalHashes ch i in
+            let idx :: Int
+                !idx = fromIntegral (idx' `V.unsafeRemWord64` size ub) in
+            -- While the idx' can cover the full Word64 range,
+            -- after taking the remainder, it now must fit in
+            -- and Int because it's less than the filter size.
+            if V.unsafeIndex (bitArray ub) idx
+              then go (i + 1)
+              else False
 {-# SPECIALIZE elemHashes :: CheapHashes a -> Bloom a -> Bool #-}
 
 -- | Query an immutable Bloom filter for non-membership.  If the value

--- a/bloomfilter/src/Data/BloomFilter/BitVec64.hs
+++ b/bloomfilter/src/Data/BloomFilter/BitVec64.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE CPP       #-}
-{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE MagicHash     #-}
+{-# LANGUAGE UnboxedTuples #-}
 -- | Minimal bit vector implementation.
 module Data.BloomFilter.BitVec64 (
     BitVec64 (..),
     unsafeIndex,
+    prefetchIndex,
     MBitVec64 (..),
     new,
     unsafeWrite,
@@ -16,17 +18,22 @@ module Data.BloomFilter.BitVec64 (
 
 import           Control.Monad.ST (ST)
 import           Data.Bits
-import           Data.Primitive.ByteArray (newPinnedByteArray, setByteArray)
+import           Data.Primitive.ByteArray (ByteArray (ByteArray),
+                     newPinnedByteArray, setByteArray)
 import qualified Data.Vector.Primitive as P
 import qualified Data.Vector.Primitive.Mutable as MP
-import           Data.Word (Word64)
+import           Data.Word (Word64, Word8)
+
+import           GHC.Exts (Int (I#), prefetchByteArray0#, uncheckedIShiftRL#,
+                     (+#))
+import           GHC.ST (ST (ST))
+import           GHC.Word (Word64 (W64#))
 
 #if MIN_VERSION_base(4,17,0)
 import           GHC.Exts (remWord64#)
 #else
 import           GHC.Exts (remWord#)
 #endif
-import           GHC.Word (Word64 (W64#), Word8)
 
 -- | Bit vector backed up by an array of Word64
 --
@@ -39,13 +46,22 @@ unsafeIndex :: BitVec64 -> Int -> Bool
 unsafeIndex (BV64 bv) i =
     unsafeTestBit (P.unsafeIndex bv j) k
   where
-    !j = unsafeShiftR i 6 -- `div` 64
-    !k = i .&. 63         -- `mod` 64
+    !j = unsafeShiftR i 6 -- `div` 64, bit index to Word64 index.
+    !k = i .&. 63         -- `mod` 64, bit within Word64
 
 {-# INLINE unsafeTestBit #-}
 -- like testBit but using unsafeShiftL instead of shiftL
 unsafeTestBit :: Word64 -> Int -> Bool
 unsafeTestBit w k = w .&. (1 `unsafeShiftL` k) /= 0
+
+{-# INLINE prefetchIndex #-}
+prefetchIndex :: BitVec64 -> Int -> ST s ()
+prefetchIndex (BV64 (P.Vector (I# off#) _ (ByteArray ba#))) (I# i#) =
+    ST (\s -> case prefetchByteArray0# ba# (off# +# uncheckedIShiftRL# i# 3#) s of
+                s' -> (# s', () #))
+    -- We only need to shiftR 3 here, not 6, because we're going from a bit
+    -- offset to a byte offset for prefetch. Whereas in unsafeIndex, we go from
+    -- a bit offset to a Word64 offset, so an extra shiftR 3, for 6 total.
 
 newtype MBitVec64 s = MBV64 (P.MVector s Word64)
 

--- a/bloomfilter/src/Data/BloomFilter/BitVec64.hs
+++ b/bloomfilter/src/Data/BloomFilter/BitVec64.hs
@@ -26,7 +26,7 @@ import           GHC.Exts (remWord64#)
 #else
 import           GHC.Exts (remWord#)
 #endif
-import           GHC.Word (Word64 (W64#))
+import           GHC.Word (Word64 (W64#), Word8)
 
 -- | Bit vector backed up by an array of Word64
 --
@@ -60,7 +60,7 @@ new :: Word64 -> ST s (MBitVec64 s)
 new s
   | numWords >= 128 = do
     mba <- newPinnedByteArray numBytes
-    setByteArray mba 0 numWords (0 :: Word64)
+    setByteArray mba 0 numBytes (0 :: Word8)
     return (MBV64 (P.MVector 0 numWords mba))
   | otherwise =
     MBV64 <$> MP.new numWords

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -374,6 +374,7 @@ test-suite lsm-tree-test
     Test.System.Posix.Fcntl.NoCache
     Test.Util.FS
     Test.Util.Orphans
+    Test.Util.QC
     Test.Util.RawPage
     Test.Util.TypeFamilyWrappers
 
@@ -391,9 +392,9 @@ test-suite lsm-tree-test
     , directory
     , filepath
     , fs-api
-    , fs-sim                   ^>=0.3
-    , io-classes               ^>=1.5
-    , io-sim                   ^>=1.5
+    , fs-sim                ^>=0.3
+    , io-classes            ^>=1.5
+    , io-sim                ^>=1.5
     , lsm-tree
     , lsm-tree:blockio-api
     , lsm-tree:blockio-sim
@@ -406,7 +407,7 @@ test-suite lsm-tree-test
     , nothunks
     , primitive
     , QuickCheck
-    , quickcheck-classes-base
+    , quickcheck-classes
     , quickcheck-dynamic
     , quickcheck-instances
     , quickcheck-lockstep

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -100,8 +100,17 @@ common language
     RoleAnnotations
     ViewPatterns
 
+flag bloom-query-fast
+  description: Use an optimised Bloom filter query implementation
+  default:     True
+  manual:      True
+
+common bloom-query-fast
+  if (flag(bloom-query-fast) && impl(ghc >=9.4))
+    cpp-options: -DBLOOM_QUERY_FAST
+
 library
-  import:          language, warnings, wno-x-partial
+  import:          language, warnings, wno-x-partial, bloom-query-fast
   hs-source-dirs:  src
   exposed-modules:
     Data.Arena
@@ -171,6 +180,14 @@ library
     , strict-mvar           ^>=1.5
     , vector                ^>=0.13
     , vector-algorithms     ^>=0.9
+
+  if (flag(bloom-query-fast) && impl(ghc >=9.4))
+    -- The bulk bloom filter query uses some fancy stuff
+    exposed-modules:
+      Database.LSMTree.Internal.BloomFilterQuery2
+      Database.LSMTree.Internal.StrictArray
+
+    build-depends:   data-elevator ^>=0.1.0.2
 
 -- this exists due windows
 library xxhash
@@ -310,7 +327,7 @@ library extras
     , wide-word
 
 test-suite lsm-tree-test
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings, wno-x-partial, bloom-query-fast
   type:           exitcode-stdio-1.0
   hs-source-dirs: test
   main-is:        Main.hs
@@ -450,7 +467,7 @@ benchmark lsm-tree-micro-bench
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded
 
 benchmark lsm-tree-bench-bloomfilter
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings, wno-x-partial, bloom-query-fast
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench/macro
   main-is:        lsm-tree-bench-bloomfilter.hs

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -112,6 +112,7 @@ library
     Database.LSMTree.Internal.BitMath
     Database.LSMTree.Internal.BlobRef
     Database.LSMTree.Internal.BloomFilter
+    Database.LSMTree.Internal.BloomFilterQuery1
     Database.LSMTree.Internal.ByteString
     Database.LSMTree.Internal.Chunk
     Database.LSMTree.Internal.Config

--- a/src/Database/LSMTree/Internal/BloomFilterQuery1.hs
+++ b/src/Database/LSMTree/Internal/BloomFilterQuery1.hs
@@ -1,0 +1,97 @@
+module Database.LSMTree.Internal.BloomFilterQuery1 (
+  bloomQueries,
+  bloomQueriesDefault,
+  RunIx, KeyIx,
+) where
+
+import           Data.BloomFilter (Bloom)
+import qualified Data.BloomFilter as Bloom
+import qualified Data.BloomFilter.Hash as Bloom
+import qualified Data.Vector as V
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector.Unboxed.Mutable as VUM
+import           Data.Word (Word32)
+
+import           Control.Monad.ST (ST)
+
+import           Database.LSMTree.Internal.Serialise (SerialisedKey)
+
+
+-- Bulk query
+-----------------------------------------------------------
+
+type KeyIx = Int
+type RunIx = Int
+
+-- | 'bloomQueries' with a default result vector size of @V.length ks * 2@.
+--
+-- TODO: tune the starting estimate based on the expected true- and
+-- false-positives.
+bloomQueriesDefault ::
+     V.Vector (Bloom SerialisedKey)
+  -> V.Vector SerialisedKey
+  -> VU.Vector (RunIx, KeyIx)
+bloomQueriesDefault blooms ks = bloomQueries blooms ks (fromIntegral $ V.length ks * 2)
+
+type ResIx = Int -- Result index
+
+-- | Perform a batch of bloom queries. The result is a tuple of indexes into the
+-- vector of runs and vector of keys respectively.
+--
+-- The result vector can be of variable length. An estimate should be provided,
+-- and the vector is grown if needed.
+--
+-- TODO: we consider it likely that we could implement a optimised, batched
+-- version of bloom filter queries, which would largely replace this function.
+bloomQueries ::
+     V.Vector (Bloom SerialisedKey)
+  -> V.Vector SerialisedKey
+  -> Word32
+  -> VU.Vector (RunIx, KeyIx)
+bloomQueries !blooms !ks !resN
+  | rsN == 0 || ksN == 0 = VU.empty
+  | otherwise            = VU.create $ do
+      res <- VUM.unsafeNew (fromIntegral resN)
+      loop1 res 0 0
+  where
+    !rsN = V.length blooms
+    !ksN = V.length ks
+
+    hs :: VP.Vector (Bloom.CheapHashes SerialisedKey)
+    !hs  = VP.generate ksN $ \i -> Bloom.makeCheapHashes (V.unsafeIndex ks i)
+
+    -- Loop over all run indexes
+    loop1 ::
+         VUM.MVector s (RunIx, KeyIx)
+      -> ResIx
+      -> RunIx
+      -> ST s (VUM.MVector s (RunIx, KeyIx))
+    loop1 !res1 !resix1 !rix
+      | rix == rsN = pure $ VUM.slice 0 resix1 res1
+      | otherwise
+      = do
+          (res1', resix1') <- loop2 res1 resix1 0 (blooms `V.unsafeIndex` rix)
+          loop1 res1' resix1' (rix+1)
+      where
+        -- Loop over all key indexes
+        loop2 ::
+             VUM.MVector s (RunIx, KeyIx)
+          -> ResIx
+          -> KeyIx
+          -> Bloom SerialisedKey
+          -> ST s (VUM.MVector s (RunIx, KeyIx), ResIx)
+        loop2 !res2 !resix2 !kix !b
+          | kix == ksN = pure (res2, resix2)
+          | let !h = hs `VP.unsafeIndex` kix
+          , Bloom.elemHashes h b = do
+              -- Grows the vector if we've reached the end.
+              --
+              -- TODO: tune how much much we grow the vector each time based on
+              -- the expected true- and false-positives.
+              res2' <- if resix2 == VUM.length res2
+                        then VUM.unsafeGrow res2 ksN
+                        else pure res2
+              VUM.unsafeWrite res2' resix2 (rix, kix)
+              loop2 res2' (resix2+1) (kix+1) b
+          | otherwise = loop2 res2 resix2 (kix+1) b

--- a/src/Database/LSMTree/Internal/BloomFilterQuery2.hs
+++ b/src/Database/LSMTree/Internal/BloomFilterQuery2.hs
@@ -1,0 +1,450 @@
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnboxedTuples       #-}
+
+{-# OPTIONS_GHC -O2 -fregs-iterative -fmax-inline-alloc-size=512 #-}
+-- The use of -fregs-iterative here does a better job in the hot loop for
+-- the bloomQueriesBody below. It eliminates all spilling to the stack.
+-- There's just 6 stack reads in the loop now, no writes.
+
+-- | An implementation of batched bloom filter query, optimised for memory
+-- prefetch.
+module Database.LSMTree.Internal.BloomFilterQuery2 (
+  bloomQueriesDefault,
+  RunIxKeyIx(RunIxKeyIx),
+  RunIx, KeyIx,
+  -- $algorithm
+  -- * Internals exposed for tests
+  CandidateProbe (..),
+) where
+
+import           Prelude hiding (filter)
+
+import           Data.Bits
+import qualified Data.Primitive as P
+import qualified Data.Vector as V
+import qualified Data.Vector.Primitive as VP
+import           Data.Word (Word32, Word64)
+
+import           Control.Exception (assert)
+import           Control.Monad.ST (ST, runST)
+
+import           GHC.Exts (Int#, uncheckedIShiftL#, (+#))
+
+import           Data.BloomFilter (Bloom)
+import qualified Data.BloomFilter as Bloom
+import qualified Data.BloomFilter.BitVec64 as BV64
+import qualified Data.BloomFilter.Hash as Bloom
+import qualified Data.BloomFilter.Internal as BF
+import           Database.LSMTree.Internal.Serialise (SerialisedKey)
+import qualified Database.LSMTree.Internal.StrictArray as P
+import qualified Database.LSMTree.Internal.Vector as P
+
+-- Bulk query
+-----------------------------------------------------------
+
+type KeyIx = Int
+type RunIx = Int
+
+-- $algorithm
+--
+-- == Key algorithm concepts
+--
+-- There is almost no opportunity for memory prefetching when looking up a
+-- single key in a single Bloom filter. So this is a bulk algorithm, to do a
+-- lot of work all in one go, which does create the opportunity to prefetch
+-- memory. It also provides an opportunity to share key hashes across filters.
+--
+-- We have as inputs N bloom filters and M keys to look up in them. So overall
+-- there are N * M independent bloom filter tests. The result is expected to be
+-- sparse, with roughly M*(1+FPR) positive results. So we use a sparse
+-- representation for the result: pairs of indexes identifying input Bloom
+-- filters and input keys with a positive test result.
+--
+-- We aim for the number of memory operations in-flight simultaneously to be on
+-- the order of 32. This trades-off memory parallelism with cache use. In
+-- particular this means the algorithm must be able to use a fixed prefetch
+-- \"distance\" rather than this being dependent on the input sizes. To achieve
+-- this, we use a fixed size circular buffer (queue). The buffer size can be
+-- tuned to optimise the prefetch behaviour: indeed we pick exactly 32.
+--
+-- == Micro optimisation
+--
+-- We use primitive arrays and arrays -- rather than vectors -- so as to
+-- minimise the number of function variables, to be able to keep most things in
+-- registers. Normal vectors use two additional variables, which triples
+-- register pressure.
+--
+-- We use an Array of Strict BloomFilter. This avoids the test for WHNF in the
+-- inner loop, which causes all registered to be spilled to and restored from
+--the stack.
+--
+
+-- | A 'RunIxKeyIx' is a (compact) pair of a 'RunIx' and a 'KeyIx'.
+--
+-- We represent it as a 32bit word, using:
+--
+-- * 16 bits for the run\/filter index (MSB)
+-- * 16 bits for the key index (LSB)
+--
+newtype RunIxKeyIx = MkRunIxKeyIx Word32
+  deriving stock Eq
+  deriving newtype P.Prim
+
+pattern RunIxKeyIx :: RunIx -> KeyIx -> RunIxKeyIx
+pattern RunIxKeyIx r k <- (unpackRunIxKeyIx -> (r, k))
+  where
+    RunIxKeyIx r k = packRunIxKeyIx r k
+{-# INLINE RunIxKeyIx #-}
+{-# COMPLETE RunIxKeyIx #-}
+
+packRunIxKeyIx :: Int -> Int -> RunIxKeyIx
+packRunIxKeyIx r k =
+    assert (r >= 0 && r <= 0xffff
+         && k >= 0 && k <= 0xffff) $
+    MkRunIxKeyIx $
+      (fromIntegral :: Word -> Word32) $
+        (fromIntegral r `unsafeShiftL` 16)
+     .|. fromIntegral k
+{-# INLINE packRunIxKeyIx #-}
+
+unpackRunIxKeyIx :: RunIxKeyIx -> (Int, Int)
+unpackRunIxKeyIx (MkRunIxKeyIx c) =
+    ( fromIntegral (c `unsafeShiftR` 16)
+    , fromIntegral (c .&. 0xfff)
+    )
+{-# INLINE unpackRunIxKeyIx #-}
+
+instance Show RunIxKeyIx where
+  showsPrec _ (RunIxKeyIx r k) =
+    showString "RunIxKeyIx " . showsPrec 11 r
+              . showChar ' ' . showsPrec 11 k
+
+type Candidate = RunIxKeyIx
+
+-- | A candidate probe point is the combination of a filter\/run index,
+-- key index and hash number. This combination determines the probe location
+-- in the bloom filter, which is also cached.
+--
+-- We store these in 'PrimArray's as a pair of 64bit words:
+--
+-- * Low 64bit word:
+--   - 16 bits padding (always 0s)    (MSB)
+--   - 16 bits for the hash number
+--   - 16 bits for the filter index
+--   - 16 bits for the key index      (LSB)
+--
+-- * High 64bit word: FilterBitIx
+--
+data CandidateProbe = MkCandidateProbe !Word64 !Word64
+
+type HashNo = Int
+type FilterBitIx = Int
+
+instance P.Prim CandidateProbe where
+    sizeOfType# _ = 16#
+    alignmentOfType# _ = 8#
+
+    indexByteArray# ba i =
+      MkCandidateProbe
+        (P.indexByteArray# ba (indexLo i))
+        (P.indexByteArray# ba (indexHi i))
+    readByteArray# ba i s1 =
+        case P.readByteArray# ba (indexLo i) s1 of { (# s2, lo #) ->
+        case P.readByteArray# ba (indexHi i) s2 of { (# s3, hi #) ->
+        (# s3, MkCandidateProbe lo hi #)
+        }}
+    writeByteArray# ba i (MkCandidateProbe lo hi) s =
+        P.writeByteArray# ba (indexHi i) hi
+       (P.writeByteArray# ba (indexLo i) lo s)
+
+    indexOffAddr# ba i =
+      MkCandidateProbe
+        (P.indexOffAddr# ba (indexLo i))
+        (P.indexOffAddr# ba (indexHi i))
+    readOffAddr# ba i s1 =
+        case P.readOffAddr# ba (indexLo i) s1 of { (# s2, lo #) ->
+        case P.readOffAddr# ba (indexHi i) s2 of { (# s3, hi #) ->
+        (# s3, MkCandidateProbe lo hi #)
+        }}
+    writeOffAddr# ba i (MkCandidateProbe lo hi) s =
+        P.writeOffAddr# ba (indexHi i) hi
+       (P.writeOffAddr# ba (indexLo i) lo s)
+
+indexLo :: Int# -> Int#
+indexLo i = uncheckedIShiftL# i 1#
+
+indexHi :: Int# -> Int#
+indexHi i = uncheckedIShiftL# i 1# +# 1#
+
+pattern CandidateProbe :: RunIx
+                       -> KeyIx
+                       -> HashNo
+                       -> FilterBitIx
+                       -> CandidateProbe
+pattern CandidateProbe r k h p <- (unpackCandidateProbe -> (r, k, h, p))
+  where
+    CandidateProbe r k h p = packCandidateProbe r k h p
+{-# INLINE CandidateProbe #-}
+{-# COMPLETE CandidateProbe #-}
+
+unpackCandidateProbe :: CandidateProbe -> (Int, Int, Int, Int)
+unpackCandidateProbe (MkCandidateProbe lo hi) =
+    ( fromIntegral ((lo `unsafeShiftR` 16) .&. 0xffff) -- run ix
+    , fromIntegral ( lo                    .&. 0xffff) -- key ix
+    , fromIntegral (lo `unsafeShiftR` 32)            -- hashno
+    , fromIntegral  hi
+    )
+{-# INLINE unpackCandidateProbe #-}
+
+packCandidateProbe :: Int -> Int -> Int -> Int -> CandidateProbe
+packCandidateProbe r k h p =
+    assert (r >= 0 && r <= 0xffff) $
+    assert (k >= 0 && k <= 0xffff) $
+    assert (h >= 0 && h <= 0xffff) $
+    MkCandidateProbe
+      (   fromIntegral r `unsafeShiftL` 16  -- run ix
+      .|. fromIntegral k                    -- key ix
+      .|. fromIntegral h `unsafeShiftL` 32) -- hashno
+      (fromIntegral p)
+{-# INLINE packCandidateProbe #-}
+
+instance Show CandidateProbe where
+  showsPrec _ (CandidateProbe r k h p) =
+      showString "CandidateProbe "
+    . showsPrec 11 r
+    . showChar ' '
+    . showsPrec 11 k
+    . showChar ' '
+    . showsPrec 11 h
+    . showChar ' '
+    . showsPrec 11 p
+
+
+
+bloomQueriesDefault ::
+     V.Vector (Bloom SerialisedKey)
+  -> V.Vector SerialisedKey
+  -> VP.Vector RunIxKeyIx
+bloomQueriesDefault filters keys | V.null filters || V.null keys
+                                 = VP.empty
+bloomQueriesDefault filters keys =
+  assert (all BF.bloomInvariant filters) $
+  -- in particular the bloomInvariant checks the size is > 0
+  runST $ do
+    let !keyhashes = prepKeyHashes keys
+        !filters'  = P.vectorToStrictArray filters
+    candidateProbes <- P.newPrimArray 0x20
+    -- We deliberately do not clear this array as it will get overwritten.
+    -- But for debugging, it's less confusing to initialise to all zeros.
+    -- To do that, uncomment the following line:
+    --P.setPrimArray 0 0x20 candidateProbes (MkCandidateProbe 0 0)
+
+    let i_r = 0
+    (i_w, nextCandidate) <-
+      prepInitialCandidateProbes
+        filters' keyhashes
+        candidateProbes
+        0 (RunIxKeyIx 0 0)
+
+    output <- bloomQueriesBody filters' keyhashes candidateProbes
+                               i_r i_w nextCandidate
+    return $! P.primArrayToPrimVector output
+
+prepKeyHashes :: V.Vector SerialisedKey
+              -> P.PrimArray (Bloom.CheapHashes SerialisedKey)
+prepKeyHashes keys =
+    P.generatePrimArray (V.length keys) $ \i ->
+      Bloom.makeCheapHashes (V.unsafeIndex keys i)
+
+prepInitialCandidateProbes
+  :: P.StrictArray (Bloom SerialisedKey)
+  -> P.PrimArray (Bloom.CheapHashes SerialisedKey)
+     -- ^ The pre-computed \"cheap hashes\" of the keys.
+  -> P.MutablePrimArray s CandidateProbe
+     -- ^ The array of candidates: of FilterIx, KeyIx and HashNo. This is
+     -- used as a fixed size rolling buffer.
+  -> Int
+     -- ^ The write index within the rolling buffer. This wraps around.
+  -> RunIxKeyIx
+     -- ^ The last candidate added to the rolling buffer.
+  -> ST s (Int,  RunIxKeyIx)
+prepInitialCandidateProbes
+    filters keyhashes
+    candidateProbes i_w
+    nextCandidate@(RunIxKeyIx rix kix)
+
+  | i_w < 0x1f && rix < P.sizeofStrictArray filters = do
+    -- We prepare at most 31 (not 32) candidates, in the buffer of size 32.
+    -- This is because we define the buffer to be empty when i_r == i_w. Hence
+    -- we cannot fill all entries in the array.
+
+    let !filter  = P.indexStrictArray filters rix
+        !keyhash = P.indexPrimArray keyhashes kix
+        !hn      = BF.hashesN filter - 1
+        !bix     = (fromIntegral :: Word64 -> Int) $
+                   Bloom.evalCheapHashes keyhash hn
+                     `BV64.unsafeRemWord64` -- size must be > 0
+                   BF.size filter           -- bloomInvariant ensures this
+    BV64.prefetchIndex (BF.bitArray filter) bix
+    assert ((rix, kix, hn, bix) == unpackCandidateProbe (CandidateProbe rix kix hn bix)) $ return ()
+    P.writePrimArray candidateProbes i_w (CandidateProbe rix kix hn bix)
+    prepInitialCandidateProbes
+      filters keyhashes
+      candidateProbes
+      (i_w+1)
+      (succCandidate keyhashes nextCandidate)
+
+    -- Filled the buffer or ran out of candidates
+  | otherwise = return (i_w, nextCandidate)
+
+
+{-# NOINLINE bloomQueriesBody #-}
+bloomQueriesBody
+  :: forall s.
+     P.StrictArray (Bloom SerialisedKey)
+  -> P.PrimArray (Bloom.CheapHashes SerialisedKey)
+     -- ^ The pre-computed \"cheap hashes\" of the keys.
+  -> P.MutablePrimArray s CandidateProbe
+     -- ^ The array of candidates: of FilterIx, KeyIx, HashNo and FilterBitIx.
+     -- This is used as a fixed size rolling buffer. It is used to communicate
+     -- between iterations. On each iteration it is read to do the (already
+     -- prefetched) memory reads. And it is written with the prefetched bit indexes for the next iteration.
+  -> Int -> Int -> RunIxKeyIx
+  -> ST s (P.PrimArray RunIxKeyIx)
+bloomQueriesBody !filters !keyhashes !candidateProbes =
+   \ !i_r !i_w !nextCandidate -> do
+    output <- P.newPrimArray (P.sizeofPrimArray keyhashes * 2)
+    output' <-
+      testCandidateProbe
+        i_r i_w nextCandidate
+        output 0
+    P.unsafeFreezePrimArray output'
+  where
+    {-# INLINE prepGivenCandidateProbe #-}
+
+    -- assume buff size of 0x20, so mask of 0x1f
+    testCandidateProbe, prepNextCandidateProbe
+      :: Int -> Int
+         -- ^ The read and write indexes within the rolling buffer. These wrap
+         -- around.
+      -> RunIxKeyIx
+         -- ^ The run and key index of the next candidate add to the rolling buffer.
+         -- When this passes the maximum then no more candidates are added, and we
+         -- just drain the buffer.
+      -> P.MutablePrimArray s RunIxKeyIx
+         -- ^ The output array.
+      -> Int
+         -- ^ The output array next free index.
+      -> ST s (P.MutablePrimArray s RunIxKeyIx)
+
+    testCandidateProbe !i_r !i_w
+                       !nextCandidate
+                       !output !outputix =
+      assert (i_r >= 0 && i_r <= 0x1f) $
+      assert (i_w >= 0 && i_w <= 0x1f) $ do
+        -- A candidate probe is the combination of a filter, key, hash no and
+        -- the corresponding probe location in the bloom filter. When a candidate
+        -- probe is prepared, its probe location is computed and prefetched.
+        candidateProbe <- P.readPrimArray candidateProbes i_r
+        let CandidateProbe rix kix hn bix = candidateProbe
+
+        -- Now test the actual Bloom filter bit to see if it's set or not.
+        let filter = P.indexStrictArray filters rix
+        if BV64.unsafeIndex (BF.bitArray filter) bix
+
+          -- The Bloom filter bit is set. Now we either keep this candidate but
+          -- probe the next hash number, or if the hash number reached zero then
+          -- this candidate (run index, key index) pair goes into the output, and
+          -- we prepare the next candidate.
+          then
+            if hn == 0
+              then do
+                -- Output the candidate
+                P.writePrimArray output outputix (RunIxKeyIx rix kix)
+                outputsz <- P.getSizeofMutablePrimArray output
+                output'  <- if outputix+1 < outputsz
+                              then return output
+                              else P.resizeMutablePrimArray output (outputsz * 2)
+                prepNextCandidateProbe
+                  i_r i_w nextCandidate
+                  output' (outputix+1)
+
+              else do
+                -- The hashno has not reached zero, so we prepare a new candidate
+                -- with the same (filter,key) pair, but with the next hashno.
+                prepGivenCandidateProbe
+                  i_r i_w nextCandidate
+                  output outputix
+                  rix kix (hn-1) filter
+
+          -- The Bloom filter bit is not set, so abandon this filter,key pair and
+          -- prepare the next candidate.
+          else prepNextCandidateProbe
+                 i_r i_w nextCandidate
+                 output outputix
+
+    prepNextCandidateProbe !i_r !i_w nextCandidate@(RunIxKeyIx rix kix)
+                           !output !outputix
+        -- There is a next candidate. Write it into the rolling buffer at the write
+        -- index, and continue with an incremented buffer read and write index.
+      | rix < P.sizeofStrictArray filters =
+        let filter         = P.indexStrictArray filters rix
+            hn             = BF.hashesN filter - 1
+            nextCandidate' = succCandidate keyhashes nextCandidate
+         in prepGivenCandidateProbe
+              i_r i_w nextCandidate'
+              output outputix
+              rix kix hn filter
+
+        -- There is no next candidate but the candidate buffer is non-empty.
+        -- Don't write into the candidate buffer. Continue with incrementing the
+        -- buffer read pointer but not the write pointer.
+      | ((i_r + 1) .&. 0x1f) /= i_w =
+          testCandidateProbe
+            ((i_r + 1) .&. 0x1f)
+              i_w
+            nextCandidate
+            output outputix
+
+        -- There is no next candidate and the candidate buffer is empty.
+        -- We're done!
+      | otherwise =
+          P.resizeMutablePrimArray output outputix
+
+    prepGivenCandidateProbe
+      :: Int -> Int
+      -> RunIxKeyIx
+      -> P.MutablePrimArray s RunIxKeyIx
+      -> Int
+      -> Int -> Int -> Int
+      -> Bloom.Bloom SerialisedKey
+      -> ST s (P.MutablePrimArray s RunIxKeyIx)
+    prepGivenCandidateProbe !i_r !i_w
+                            !nextCandidate
+                            !output !outputix
+                            !rix !kix !hn !filter =
+      assert (hn >= 0 && hn < BF.hashesN filter) $ do
+        let !keyhash = P.indexPrimArray keyhashes kix
+            !bix     = (fromIntegral :: Word64 -> Int) $
+                       Bloom.evalCheapHashes keyhash hn
+                         `BV64.unsafeRemWord64` -- size must be > 0
+                       BF.size filter           -- bloomInvariant ensures this
+        BV64.prefetchIndex (BF.bitArray filter) bix
+        P.writePrimArray candidateProbes i_w (CandidateProbe rix kix hn bix)
+        testCandidateProbe
+            ((i_r + 1) .&. 0x1f)
+            ((i_w + 1) .&. 0x1f)
+            -- or if we merge them: ((i_rw + 0x0101) .&. 0x1f1f)
+            nextCandidate
+            output outputix
+
+succCandidate :: P.PrimArray (Bloom.CheapHashes SerialisedKey)
+              -> Candidate
+              -> Candidate
+succCandidate keyhashes (RunIxKeyIx rix kix)
+  | kix+1 < P.sizeofPrimArray keyhashes = RunIxKeyIx rix (kix+1)
+  | otherwise                           = RunIxKeyIx (rix+1) 0
+  --TODO: optimise with bit twiddling
+

--- a/src/Database/LSMTree/Internal/BloomFilterQuery2.hs
+++ b/src/Database/LSMTree/Internal/BloomFilterQuery2.hs
@@ -11,7 +11,7 @@
 -- | An implementation of batched bloom filter query, optimised for memory
 -- prefetch.
 module Database.LSMTree.Internal.BloomFilterQuery2 (
-  bloomQueriesDefault,
+  bloomQueries,
   RunIxKeyIx(RunIxKeyIx),
   RunIx, KeyIx,
   -- $algorithm
@@ -184,13 +184,13 @@ instance Show CandidateProbe where
 
 
 
-bloomQueriesDefault ::
+bloomQueries ::
      V.Vector (Bloom SerialisedKey)
   -> V.Vector SerialisedKey
   -> VP.Vector RunIxKeyIx
-bloomQueriesDefault filters keys | V.null filters || V.null keys
-                                 = VP.empty
-bloomQueriesDefault filters keys =
+bloomQueries filters keys | V.null filters || V.null keys
+                          = VP.empty
+bloomQueries filters keys =
   assert (all BF.bloomInvariant filters) $
   -- in particular the bloomInvariant checks the size is > 0
   runST $ do

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -22,25 +22,24 @@ module Database.LSMTree.Internal.Lookup (
   , intraPageLookups
   ) where
 
+import           Data.Arena (Arena, ArenaManager, allocateFromArena, withArena)
+import           Data.Bifunctor
+import           Data.BloomFilter (Bloom)
+import           Data.Primitive.ByteArray
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as VM
+import qualified Data.Vector.Unboxed as VU
+
 import           Control.Exception (Exception, assert)
 import           Control.Monad
 import           Control.Monad.Class.MonadST as Class
 import           Control.Monad.Class.MonadThrow (MonadThrow (..))
 import           Control.Monad.Primitive
 import           Control.Monad.ST.Strict
-import           Data.Arena (Arena, ArenaManager, allocateFromArena, withArena)
-import           Data.Bifunctor
-import           Data.BloomFilter (Bloom)
-import qualified Data.BloomFilter as Bloom
-import qualified Data.BloomFilter.Hash as Bloom
-import           Data.Primitive.ByteArray
-import qualified Data.Vector as V
-import qualified Data.Vector.Mutable as VM
-import qualified Data.Vector.Primitive as VP
-import qualified Data.Vector.Unboxed as VU
-import qualified Data.Vector.Unboxed.Mutable as VUM
-import           Data.Word (Word32)
+
 import           Database.LSMTree.Internal.BlobRef (WeakBlobRef (..))
+import           Database.LSMTree.Internal.BloomFilterQuery1 (bloomQueries,
+                     bloomQueriesDefault)
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.IndexCompact (IndexCompact,
                      PageSpan (..))
@@ -74,77 +73,6 @@ prepLookups arena blooms indexes kopsFiles ks = do
 
 type KeyIx = Int
 type RunIx = Int
-type ResIx = Int -- Result index
-
--- | 'bloomQueries' with a default result vector size of @V.length ks * 2@.
---
--- TODO: tune the starting estimate based on the expected true- and
--- false-positives.
-bloomQueriesDefault ::
-     V.Vector (Bloom SerialisedKey)
-  -> V.Vector SerialisedKey
-  -> VU.Vector (RunIx, KeyIx)
-bloomQueriesDefault blooms ks = bloomQueries blooms ks (fromIntegral $ V.length ks * 2)
-
--- | Perform a batch of bloom queries. The result is a tuple of indexes into the
--- vector of runs and vector of keys respectively.
---
--- The result vector can be of variable length. An estimate should be provided,
--- and the vector is grown if needed.
---
--- TODO: we consider it likely that we could implement a optimised, batched
--- version of bloom filter queries, which would largely replace this function.
-bloomQueries ::
-     V.Vector (Bloom SerialisedKey)
-  -> V.Vector SerialisedKey
-  -> Word32
-  -> VU.Vector (RunIx, KeyIx)
-bloomQueries !blooms !ks !resN
-  | rsN == 0 || ksN == 0 = VU.empty
-  | otherwise            = VU.create $ do
-      res <- VUM.unsafeNew (fromIntegral resN)
-      loop1 res 0 0
-  where
-    !rsN = V.length blooms
-    !ksN = V.length ks
-
-    hs :: VP.Vector (Bloom.CheapHashes SerialisedKey)
-    !hs  = VP.generate ksN $ \i -> Bloom.makeCheapHashes (V.unsafeIndex ks i)
-
-    -- Loop over all run indexes
-    loop1 ::
-         VUM.MVector s (RunIx, KeyIx)
-      -> ResIx
-      -> RunIx
-      -> ST s (VUM.MVector s (RunIx, KeyIx))
-    loop1 !res1 !resix1 !rix
-      | rix == rsN = pure $ VUM.slice 0 resix1 res1
-      | otherwise
-      = do
-          (res1', resix1') <- loop2 res1 resix1 0 (blooms `V.unsafeIndex` rix)
-          loop1 res1' resix1' (rix+1)
-      where
-        -- Loop over all key indexes
-        loop2 ::
-             VUM.MVector s (RunIx, KeyIx)
-          -> ResIx
-          -> KeyIx
-          -> Bloom SerialisedKey
-          -> ST s (VUM.MVector s (RunIx, KeyIx), ResIx)
-        loop2 !res2 !resix2 !kix !b
-          | kix == ksN = pure (res2, resix2)
-          | let !h = hs `VP.unsafeIndex` kix
-          , Bloom.elemHashes h b = do
-              -- Grows the vector if we've reached the end.
-              --
-              -- TODO: tune how much much we grow the vector each time based on
-              -- the expected true- and false-positives.
-              res2' <- if resix2 == VUM.length res2
-                        then VUM.unsafeGrow res2 ksN
-                        else pure res2
-              VUM.unsafeWrite res2' resix2 (rix, kix)
-              loop2 res2' (resix2+1) (kix+1) b
-          | otherwise = loop2 res2 resix2 (kix+1) b
 
 -- | Perform a batch of fence pointer index searches, and create an 'IOOp' for
 -- each search result. The resulting vector has the same length as the

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -17,7 +17,7 @@ module Database.LSMTree.Internal.Lookup (
   , KeyIx
   , RunIxKeyIx(..)
   , prepLookups
-  , bloomQueriesDefault
+  , bloomQueries
   , indexSearches
   , intraPageLookups
   ) where
@@ -54,13 +54,12 @@ import qualified Database.LSMTree.Internal.WriteBufferBlobs as WBB
 import           System.FS.API (BufferOffset (..), Handle)
 import           System.FS.BlockIO.API
 
-import           Database.LSMTree.Internal.BloomFilterQuery1 (RunIxKeyIx (..))
 #ifdef BLOOM_QUERY_FAST
-import           Database.LSMTree.Internal.BloomFilterQuery2
-                     (bloomQueriesDefault)
+import           Database.LSMTree.Internal.BloomFilterQuery2 (RunIxKeyIx (..),
+                     bloomQueries)
 #else
-import           Database.LSMTree.Internal.BloomFilterQuery1
-                     (bloomQueriesDefault)
+import           Database.LSMTree.Internal.BloomFilterQuery1 (RunIxKeyIx (..),
+                     bloomQueries)
 #endif
 
 -- | Prepare disk lookups by doing bloom filter queries, index searches and
@@ -75,7 +74,7 @@ prepLookups ::
   -> V.Vector SerialisedKey
   -> ST s (VP.Vector RunIxKeyIx, V.Vector (IOOp s h))
 prepLookups arena blooms indexes kopsFiles ks = do
-  let !rkixs = bloomQueriesDefault blooms ks
+  let !rkixs = bloomQueries blooms ks
   !ioops <- indexSearches arena indexes kopsFiles ks rkixs
   pure (rkixs, ioops)
 

--- a/src/Database/LSMTree/Internal/StrictArray.hs
+++ b/src/Database/LSMTree/Internal/StrictArray.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE UnboxedTuples       #-}
+module Database.LSMTree.Internal.StrictArray (
+    StrictArray,
+    vectorToStrictArray,
+    indexStrictArray,
+    sizeofStrictArray,
+) where
+
+import           Data.Elevator (Strict (Strict))
+import qualified Data.Vector as V
+import           GHC.Exts ((+#))
+import qualified GHC.Exts as GHC
+import           GHC.ST (ST (ST), runST)
+import           Unsafe.Coerce (unsafeCoerce)
+
+data StrictArray a = StrictArray !(GHC.Array# (Strict a))
+
+vectorToStrictArray :: forall a. V.Vector a -> StrictArray a
+vectorToStrictArray v =
+    runST $ ST $ \s0 ->
+    case GHC.newArray# (case V.length v of GHC.I# l# -> l#)
+                       (Strict (unsafeCoerce ())) s0 of
+                       -- initialise with (), will be overwritten.
+      (# s1, a#  #) ->
+        case go a# 0# s1 of
+          s2 -> case GHC.unsafeFreezeArray# a# s2 of
+                  (# s3, a'# #) -> (# s3, StrictArray a'# #)
+  where
+    go :: forall s.
+          GHC.MutableArray# s (Strict a)
+       -> GHC.Int#
+       -> GHC.State# s
+       -> GHC.State# s
+    go a# i# s
+      | GHC.I# i# < V.length v
+      = let x = V.unsafeIndex v (GHC.I# i#)
+            -- We have to use seq# here to force the array element to WHNF
+            -- before putting it into the strict array. This should not be
+            -- necessary. https://github.com/sgraf812/data-elevator/issues/4
+         in case GHC.seq# x s of
+              (# s', x' #) ->
+                case GHC.writeArray# a# i# (Strict x') s' of
+                  s'' -> go a# (i# +# 1#) s''
+      | otherwise = s
+
+{-# INLINE indexStrictArray #-}
+indexStrictArray :: StrictArray a -> Int -> a
+indexStrictArray (StrictArray a#) (GHC.I# i#) =
+    case GHC.indexArray# a# i# of
+      (# Strict x #) -> x
+
+{-# INLINE sizeofStrictArray #-}
+sizeofStrictArray :: StrictArray a -> Int
+sizeofStrictArray (StrictArray a#) =
+    GHC.I# (GHC.sizeofArray# a#)

--- a/src/Database/LSMTree/Internal/Vector.hs
+++ b/src/Database/LSMTree/Internal/Vector.hs
@@ -5,6 +5,7 @@ module Database.LSMTree.Internal.Vector (
     mkPrimVector,
     byteVectorFromPrim,
     noRetainedExtraMemory,
+    primArrayToPrimVector,
     mapStrict,
     mapMStrict,
     imapMStrict,
@@ -16,6 +17,7 @@ module Database.LSMTree.Internal.Vector (
 
 import           Control.Monad
 import           Control.Monad.Primitive (PrimMonad, PrimState)
+import qualified Data.Primitive as P
 import           Data.Primitive.ByteArray (ByteArray, newByteArray,
                      runByteArray, sizeofByteArray, writeByteArray)
 import           Data.Primitive.Types (Prim (sizeOfType#), sizeOfType)
@@ -50,6 +52,11 @@ noRetainedExtraMemory (VP.Vector off len ba) =
     off == 0 && len * sizeof == sizeofByteArray ba
    where
     sizeof = I# (sizeOfType# (Proxy @a))
+
+{-# INLINE primArrayToPrimVector #-}
+primArrayToPrimVector :: Prim a => P.PrimArray a -> VP.Vector a
+primArrayToPrimVector pa@(P.PrimArray ba) =
+    VP.Vector 0 (P.sizeofPrimArray pa) (P.ByteArray ba)
 
 {-# INLINE mapStrict #-}
 -- | /( O(n) /) Like 'V.map', but strict in the produced elements of type @b@.

--- a/test/Test/Database/LSMTree/Internal/BloomFilter.hs
+++ b/test/Test/Database/LSMTree/Internal/BloomFilter.hs
@@ -100,7 +100,7 @@ prop_bloomQueries1 filters keys =
         ]
        ===
         map (\(Bloom1.RunIxKeyIx rix kix) -> (rix, kix))
-            (VP.toList (Bloom1.bloomQueriesDefault (V.fromList filters')
+            (VP.toList (Bloom1.bloomQueries (V.fromList filters')
                                                    (V.fromList keys')))
 
 #ifdef BLOOM_QUERY_FAST
@@ -121,8 +121,8 @@ prop_bloomQueries2 filters keys =
         ]
        ===
         map (\(Bloom2.RunIxKeyIx rix kix) -> (rix, kix))
-            (VP.toList (Bloom2.bloomQueriesDefault (V.fromList filters')
-                                                   (V.fromList keys')))
+            (VP.toList (Bloom2.bloomQueries (V.fromList filters')
+                                            (V.fromList keys')))
 
 instance Arbitrary Bloom2.CandidateProbe where
   arbitrary = Bloom2.MkCandidateProbe <$> arbitrary <*> arbitrary

--- a/test/Test/Database/LSMTree/Internal/BloomFilter.hs
+++ b/test/Test/Database/LSMTree/Internal/BloomFilter.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
 import           Data.Primitive.ByteArray (ByteArray (..), byteArrayFromList)
 import qualified Data.Vector as V
-import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word32, Word64)
 
 import           Test.Tasty (TestTree, testGroup)
@@ -23,7 +23,6 @@ import           Database.LSMTree.Internal.Serialise (SerialisedKey,
                      serialiseKey)
 
 #ifdef BLOOM_QUERY_FAST
-import qualified Data.Vector.Primitive as VP
 import qualified Database.LSMTree.Internal.BloomFilterQuery2 as Bloom2
 import           Test.QuickCheck.Classes (primLaws)
 import           Test.Util.QC
@@ -100,8 +99,9 @@ prop_bloomQueries1 filters keys =
         , BF.elem k f
         ]
        ===
-        VU.toList (Bloom1.bloomQueriesDefault (V.fromList filters')
-                                              (V.fromList keys'))
+        map (\(Bloom1.RunIxKeyIx rix kix) -> (rix, kix))
+            (VP.toList (Bloom1.bloomQueriesDefault (V.fromList filters')
+                                                   (V.fromList keys')))
 
 #ifdef BLOOM_QUERY_FAST
 prop_bloomQueries2 :: [[Small Word64]]

--- a/test/Test/Database/LSMTree/Internal/BloomFilter.hs
+++ b/test/Test/Database/LSMTree/Internal/BloomFilter.hs
@@ -7,10 +7,12 @@ import           Data.Bits (unsafeShiftL, unsafeShiftR, (.&.))
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
 import           Data.Primitive.ByteArray (ByteArray (..), byteArrayFromList)
+import qualified Data.Set as Set
 import qualified Data.Vector as V
 import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word32, Word64)
 
+import           Test.QuickCheck.Gen (genDouble)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck hiding ((.&.))
 
@@ -83,42 +85,84 @@ prop_total_deserialisation_whitebox hsn (Small len64) =
       , unsafeShiftR len64 (32 - 6)  -- len64 * 64 (upper 32 bits)
       ]
 
-prop_bloomQueries1 :: [[Small Word64]]
+newtype FPR = FPR Double deriving stock Show
+
+instance Arbitrary FPR where
+  arbitrary =
+    FPR <$> frequency
+      [ (1, pure 0.999)
+      , (9, (fmap (/2) genDouble) `suchThat` \fpr -> fpr > 0) ]
+
+prop_bloomQueries1 :: FPR
+                   -> [[Small Word64]]
                    -> [Small Word64]
                    -> Property
-prop_bloomQueries1 filters keys =
+prop_bloomQueries1 (FPR fpr) filters keys =
     let filters' :: [BF.Bloom SerialisedKey]
-        filters' = map (BF.easyList 0.1 . map (\(Small k) -> serialiseKey k)) filters
+        filters' = map (BF.easyList fpr . map (\(Small k) -> serialiseKey k))
+                       filters
 
         keys' :: [SerialisedKey]
         keys' = map (\(Small k) -> serialiseKey k) keys
 
-     in [ (f_i, k_i)
-        | (f, f_i) <- zip filters' [0..]
-        , (k, k_i) <- zip keys' [0..]
-        , BF.elem k f
-        ]
+        referenceResults :: [(Int, Int)]
+        referenceResults =
+          [ (f_i, k_i)
+          | (f, f_i) <- zip filters' [0..]
+          , (k, k_i) <- zip keys' [0..]
+          , BF.elem k f
+          ]
+
+        filterSets = map (Set.fromList . map (\(Small k) -> serialiseKey k)) filters
+        referenceCmp =
+          [ (BF.elem k f, k `Set.member` f')
+          | (f, f') <- zip filters' filterSets
+          , k       <- keys'
+          ]
+        truePositives  = [ "true positives"  | (True,  True)  <- referenceCmp ]
+        falsePositives = [ "false positives" | (True,  False) <- referenceCmp ]
+        trueNegatives  = [ "true negatives"  | (False, False) <- referenceCmp ]
+        falseNegatives = [ "false negatives" | (False, True)  <- referenceCmp ]
+        distribution   = truePositives ++ falsePositives
+                      ++ trueNegatives ++ falseNegatives
+
+    -- To get coverage of Bloom1.bloomQueries array resizing we want some
+    -- cases with high FPRs.
+     in tabulate "FPR" [show (round (fpr * 10) * 10 :: Int) ++ "%"] $
+        coverTable "FPR" [("100%", 5)] $
+        tabulate "distribution of true/false positives/negatives" distribution $
+        referenceResults
        ===
         map (\(Bloom1.RunIxKeyIx rix kix) -> (rix, kix))
             (VP.toList (Bloom1.bloomQueries (V.fromList filters')
-                                                   (V.fromList keys')))
+                                            (V.fromList keys')))
 
 #ifdef BLOOM_QUERY_FAST
-prop_bloomQueries2 :: [[Small Word64]]
+prop_bloomQueries2 :: FPR
+                   -> [[Small Word64]]
                    -> [Small Word64]
                    -> Property
-prop_bloomQueries2 filters keys =
+prop_bloomQueries2 (FPR fpr) filters keys =
     let filters' :: [BF.Bloom SerialisedKey]
-        filters' = map (BF.easyList 0.1 . map (\(Small k) -> serialiseKey k)) filters
+        filters' = map (BF.easyList fpr . map (\(Small k) -> serialiseKey k)) filters
 
         keys' :: [SerialisedKey]
         keys' = map (\(Small k) -> serialiseKey k) keys
 
-     in [ (f_i, k_i)
-        | (f, f_i) <- zip filters' [0..]
-        , (k, k_i) <- zip keys' [0..]
-        , BF.elem k f
-        ]
+        referenceResults :: [(Int, Int)]
+        referenceResults =
+          [ (f_i, k_i)
+          | (f, f_i) <- zip filters' [0..]
+          , (k, k_i) <- zip keys' [0..]
+          , BF.elem k f
+          ]
+
+    -- To get coverage of Bloom2.bloomQueries array resizing we want some
+    -- cases with high FPRs.
+     in tabulate "FPR" [show (round (fpr * 10) * 10 :: Int) ++ "%"] $
+        coverTable "FPR" [("100%", 5)] $
+
+        referenceResults
        ===
         map (\(Bloom2.RunIxKeyIx rix kix) -> (rix, kix))
             (VP.toList (Bloom2.bloomQueries (V.fromList filters')

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -123,7 +123,7 @@ prop_bloomQueriesModel dats =
     blooms = fmap snd3 runs
     lookupss = concatMap lookups $ getSmallList dats
     real  = map (\(RunIxKeyIx rix kix) -> (rix,kix)) $ VP.toList $
-            bloomQueriesDefault (V.fromList blooms) (V.fromList lookupss)
+            bloomQueries (V.fromList blooms) (V.fromList lookupss)
     model = bloomQueriesModel blooms lookupss
 
 bloomQueriesModel :: [Bloom SerialisedKey] -> [SerialisedKey] -> [(RunIx, KeyIx)]

--- a/test/Test/Util/QC.hs
+++ b/test/Test/Util/QC.hs
@@ -1,0 +1,17 @@
+module Test.Util.QC (
+    testClassLaws,
+    Proxy (..)
+  ) where
+
+import           Data.Proxy (Proxy (..))
+import           Test.QuickCheck.Classes (Laws (..))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+testClassLaws :: String -> Laws -> TestTree
+testClassLaws typename Laws {lawsTypeclass, lawsProperties} =
+  testGroup ("class laws" ++ lawsTypeclass ++ " " ++ typename)
+    [ testProperty name prop
+    | (name, prop) <- lawsProperties ]
+
+


### PR DESCRIPTION
For the bloom filter macrobenchmark (on my laptop with 6Mb L3 cache) this is about 2x faster at 25M entries, and about 3x faster at 100M entries.