### PR TITLE
Correcting false positive of HLint passing GitHub workflow

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -335,5 +335,5 @@ jobs:
     - name: 'Run HLint'
       uses: haskell-actions/hlint-run@v2
       with:
-        path: '["src/", "test/"]'
+        path: '[ "src/", "test/", "src-extras/", "src-fcntl-nocache/", "src-kmerge/", "src-mcg/", "src-monkey/", "src-rocksdb/" ]'
         fail-on: suggestion

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -23,6 +23,7 @@
 - ignore: {name: "Use zipWithM"}
 - ignore: {name: "Redundant return"}
 - ignore: {name: "Use section"}
+- ignore: {name: "Redundant $!"}
 
 # Specify additional command line arguments
 #

--- a/bench/macro/lsm-tree-bench-bloomfilter.hs
+++ b/bench/macro/lsm-tree-bench-bloomfilter.hs
@@ -16,7 +16,7 @@ import qualified Data.BloomFilter.Mutable as MBloom
 import qualified Data.Foldable as Fold
 import           Data.Time
 import           Data.Vector (Vector)
-import qualified Data.Vector as Vector
+import qualified Data.Vector as V
 import           Data.WideWord.Word256 (Word256)
 import           GHC.Stats
 import           Numeric
@@ -61,7 +61,7 @@ benchmarks = do
 #endif
 
     enabled <- getRTSStatsEnabled
-    when (not enabled) $ fail "Need RTS +T statistics enabled"
+    unless enabled $ fail "Need RTS +T statistics enabled"
     let filterSizes = lsmStyleBloomFilters benchmarkSizeBase
                                            benchmarkNumBitsPerEntry
     putStrLn "Bloom filter stats:"
@@ -235,7 +235,7 @@ elemManyEnv filterSizes rng0 =
            (cycle [ mb'
                   | (mb, (_, sizeFactor, _, _)) <- zip mbs filterSizes
                   , mb' <- replicate (fromIntegralChecked sizeFactor) mb ]))
-    Vector.fromList <$> mapM Bloom.unsafeFreeze mbs
+    V.fromList <$> mapM Bloom.unsafeFreeze mbs
 
 -- | This gives us a baseline cost of just calculating the series of keys.
 benchBaseline :: Vector (Bloom SerialisedKey) -> StdGen -> Integer -> ()

--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -130,7 +130,7 @@ benchmarks !caching = withFS $ \hfs hbio -> do
 #endif
     arenaManager <- newArenaManager
     enabled <- getRTSStatsEnabled
-    when (not enabled) $ fail "Need RTS +T statistics enabled"
+    unless enabled $ fail "Need RTS +T statistics enabled"
     let runSizes = lsmStyleRuns benchmarkSizeBase
     putStrLn "Precomputed run stats:"
     putStrLn "(numEntries, sizeFactor)"

--- a/bench/macro/lsm-tree-bench-wp8.hs
+++ b/bench/macro/lsm-tree-bench-wp8.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings     #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {- Benchmark requirements:
@@ -392,20 +391,21 @@ doDryRun gopts opts = do
 doDryRun' :: GlobalOpts -> RunOpts -> IO ()
 doDryRun' gopts opts = do
     -- calculated some expected statistics for generated batches
-    id $ do
-        -- we generate n random numbers in range of [ 1 .. d ]
-        -- what is the chance they are all distinct
-        let n = fromIntegral (batchCount opts * batchSize opts) :: Double
-        let d = fromIntegral (initialSize gopts) :: Double
-        -- this is birthday problem.
-        let p = 1 - exp (negate $  (n * (n - 1)) / (2 * d))
+    -- using nested do block to limit scope of intermediate bindings n, d, p, and q
+    do
+       -- we generate n random numbers in range of [ 1 .. d ]
+       -- what is the chance they are all distinct
+       let n = fromIntegral (batchCount opts * batchSize opts) :: Double
+       let d = fromIntegral (initialSize gopts) :: Double
+       -- this is birthday problem.
+       let p = 1 - exp (negate $  (n * (n - 1)) / (2 * d))
 
-        -- number of people with a shared birthday
-        -- https://en.wikipedia.org/wiki/Birthday_problem#Number_of_people_with_a_shared_birthday
-        let q = n * (1 - ((d - 1) / d) ** (n - 1))
+       -- number of people with a shared birthday
+       -- https://en.wikipedia.org/wiki/Birthday_problem#Number_of_people_with_a_shared_birthday
+       let q = n * (1 - ((d - 1) / d) ** (n - 1))
 
-        printf "Probability of a duplicate:                          %5f\n" p
-        printf "Expected number of duplicates (extreme upper bound): %5f out of %f\n" q n
+       printf "Probability of a duplicate:                          %5f\n" p
+       printf "Expected number of duplicates (extreme upper bound): %5f out of %f\n" q n
 
     let g0 = initGen (initialSize gopts) (batchSize opts) (batchCount opts) (seed opts)
 

--- a/src-kmerge/KMerge/Heap.hs
+++ b/src-kmerge/KMerge/Heap.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+
 -- | Mutable heap for k-merge algorithm.
 --
 -- This data-structure represents a min-heap with the root node *removed*.
@@ -18,6 +19,7 @@ module KMerge.Heap (
     extract,
 ) where
 
+import           Control.Monad (when)
 import           Control.Monad.Primitive (PrimMonad (PrimState), RealWorld)
 import qualified Control.Monad.ST as Lazy
 import qualified Control.Monad.ST as Strict
@@ -106,12 +108,10 @@ siftUp !arr !x = loop where
         = do
             let !parent = halfOf (idx - 1)
             p <- readSmallArray arr parent
-            if x < p
-            then do
-                writeSmallArray arr parent x
-                writeSmallArray arr idx    p
-                loop parent
-            else return ()
+            when (x < p) $ do
+              writeSmallArray arr parent x
+              writeSmallArray arr idx    p
+              loop parent
 
 {-# SPECIALIZE siftUp :: forall a.   Ord a => SmallMutableArray RealWorld a -> a -> Int -> IO          () #-}
 {-# SPECIALIZE siftUp :: forall a s. Ord a => SmallMutableArray s         a -> a -> Int -> Strict.ST s () #-}

--- a/src-kmerge/KMerge/LoserTree.hs
+++ b/src-kmerge/KMerge/LoserTree.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+
 module KMerge.LoserTree (
     MutableLoserTree,
     newLoserTree,

--- a/src/Database/LSMTree/Internal/RawBytes.hs
+++ b/src/Database/LSMTree/Internal/RawBytes.hs
@@ -5,7 +5,10 @@
 {-# LANGUAGE UnboxedTuples      #-}
 {- HLINT ignore "Redundant lambda" -}
 
+#ifndef __HLINT__
+-- HLint would fail to find this file and emit a warning
 #include <MachDeps.h>
+#endif
 
 -- |
 --


### PR DESCRIPTION
Our GitHub action for running HLint on the code was previously emitting an alarming warning:
```
  Running hlint -j --json -- src/ test/
  Warning: Can't find file "MachDeps.h" in directories
  	src/Database/LSMTree/Internal
  	.
    Asked for by: src/Database/LSMTree/Internal/RawBytes.hs  at line 8 col 1
  hlint completed with status code 0
```

The `haskell.yml` workflow file's entry for the HLint action had previously specified only `fail-on: suggestion` whereas this PR increases the failure condition to `fail-on: warning`. This change causes our CI pipeline to have caught and require correcting the previously ignored warning.

Additionally, the PR corrects the warning by conditionally importing the offending file.
