### PR TITLE
Performing TODO: Create newtype

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -20,6 +20,7 @@ import           Database.LSMTree.Extras.Random (frequency,
                      sampleUniformWithReplacement, uniformWithoutReplacement)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Entry (Entry (..), unNumEntries)
+import           Database.LSMTree.Internal.IndexCompact (getNumPages)
 import           Database.LSMTree.Internal.Lookup (bloomQueriesDefault,
                      indexSearches, intraPageLookups, lookupsIO, prepLookups)
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
@@ -182,8 +183,8 @@ lookupsInBatchesEnv Config {..} = do
     let nentriesReal = unNumEntries $ Run.runNumEntries r
     assert (nentriesReal == nentries) $ pure ()
     let npagesReal = Run.sizeInPages r
-    assert (npagesReal * 42 <= nentriesReal) $ pure ()
-    assert (npagesReal * 43 >= nentriesReal) $ pure ()
+    assert (getNumPages npagesReal * 42 <= nentriesReal) $ pure ()
+    assert (getNumPages npagesReal * 43 >= nentriesReal) $ pure ()
     pure ( benchTmpDir
          , arenaManager
          , hasFS

--- a/src/Database/LSMTree/Internal/IndexCompact.hs
+++ b/src/Database/LSMTree/Internal/IndexCompact.hs
@@ -395,7 +395,7 @@ newtype NumPages = NumPages Word
   deriving newtype (NFData)
 
 -- | A type-safe "unwrapper" for 'NumPages'. Use this accessor whenever you want
--- to convert 'NumPages' to a more versitile number type.
+-- to convert 'NumPages' to a more versatile number type.
 {-# INLINE getNumPages #-}
 getNumPages :: Integral i => NumPages -> i
 getNumPages (NumPages w) = fromIntegral w

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -166,13 +166,13 @@ indexSearches !arena !indexes !kopsFiles !ks !rkixs = V.generateM n $ \i -> do
     -- byte array for each 'IOOp'. One optimisation we are planning to
     -- do is to use a cache of re-usable buffers, in which case we
     -- decrease the GC load. TODO: re-usable buffers.
-    (!off, !buf) <- allocateFromArena arena (size * 4096) 4096
+    (!off, !buf) <- allocateFromArena arena (Index.getNumPages size * 4096) 4096
     pure $! IOOpRead
               h
               (fromIntegral $ Index.unPageNo (pageSpanStart pspan) * 4096)
               buf
               (fromIntegral off)
-              (fromIntegral $ size * 4096)
+              (Index.getNumPages size * 4096)
   where
     !n = VU.length rkixs
 


### PR DESCRIPTION
This PR performs the TODO task of changing the type-synonym `NumPages` to a proper `newtype`.

The `NumPages` is now a `newtype` wrapper of the `Word` data-type, as there cannot ever be a negative number of pages.

Additionally, I added documentation for `NumPages` and corrected a few typos in the module's existing documentation.