### PR TITLE
Improving type safety of `KMerge.Heap.newMutableHeap`

### DIFF
--- a/src-kmerge/KMerge/Heap.hs
+++ b/src-kmerge/KMerge/Heap.hs
@@ -25,6 +25,7 @@ import qualified Control.Monad.ST as Lazy
 import qualified Control.Monad.ST as Strict
 import           Data.Bits (unsafeShiftL, unsafeShiftR)
 import           Data.Foldable.WithIndex (ifor_)
+import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Primitive (SmallMutableArray, newSmallArray,
                      readSmallArray, writeSmallArray)
 import           Data.Primitive.PrimVar (PrimVar, newPrimVar, readPrimVar,
@@ -41,7 +42,7 @@ placeholder :: a
 placeholder = unsafeCoerce ()
 
 -- | Create new heap, and immediately extract its minimum value.
-newMutableHeap :: forall a m. (PrimMonad m, Ord a) => [a] -> m (MutableHeap (PrimState m) a, Maybe a)
+newMutableHeap :: forall a m. (PrimMonad m, Ord a) => NonEmpty a -> m (MutableHeap (PrimState m) a, a)
 newMutableHeap xs = do
     let !size = length xs
 
@@ -52,12 +53,11 @@ newMutableHeap xs = do
 
     sizeRef <- newPrimVar size
 
-    if size <= 0
-    then return $! (MH sizeRef arr, Nothing)
-    else do
-        x <- readSmallArray arr 0
-        writeSmallArray arr 0 placeholder
-        return $! (MH sizeRef arr, Just x)
+    -- This indexing is safe!
+    -- Due to the required NonEmpty input type, there must be at least one element to read.
+    x <- readSmallArray arr 0
+    writeSmallArray arr 0 placeholder
+    return $! (MH sizeRef arr, x)
 
 -- | Replace the minimum-value, and immediately extract the new minimum value.
 replaceRoot :: forall a m. (PrimMonad m, Ord a) => MutableHeap (PrimState m) a -> a -> m a


### PR DESCRIPTION
Rather than returning a `Maybe a` when creating a new mutable heap from an input list (`[]`), instead require that the input be `NonEmpty` and always be able to return an `a` value in the result tuple. This pushes the check for emptiness one level up in the computational logic, requiring the caller of `newMutableHeap` to have witnessed the non-emptiness of the function's input.

**Type signature change** *(constraints removed for clarity)*:
```
newMutableHeap :: [a]        -> m (MutableHeap (PrimState m) a, Maybe a)
newMutableHeap :: NonEmpty a -> m (MutableHeap (PrimState m) a,       a)
```