### PR TITLE
Move table config types to a new module

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -115,6 +115,7 @@ library
     Database.LSMTree.Internal.BloomFilter
     Database.LSMTree.Internal.ByteString
     Database.LSMTree.Internal.Chunk
+    Database.LSMTree.Internal.Config
     Database.LSMTree.Internal.CRC32C
     Database.LSMTree.Internal.Entry
     Database.LSMTree.Internal.IndexCompact

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -27,6 +27,21 @@ module Database.LSMTree.Common (
   , Internal.mkSnapshotName
     -- * Blob references
   , BlobRef (..)
+    -- * Table configuration
+  , Internal.TableConfig (..)
+  , Internal.defaultTableConfig
+  , Internal.SizeRatio (..)
+  , Internal.MergePolicy (..)
+  , Internal.WriteBufferAlloc (..)
+  , Internal.NumEntries (..)
+  , Internal.BloomFilterAlloc (..)
+  , Internal.defaultBloomFilterAlloc
+  , Internal.FencePointerIndex (..)
+  , Internal.DiskCachePolicy (..)
+    -- * Table configuration override
+  , Internal.TableConfigOverride
+  , Internal.configNoOverride
+  , Internal.configOverrideDiskCachePolicy
   ) where
 
 import           Control.Concurrent.Class.MonadMVar.Strict
@@ -39,6 +54,8 @@ import           Data.Kind (Type)
 import           Data.Typeable (Proxy, Typeable)
 import qualified Database.LSMTree.Internal as Internal
 import qualified Database.LSMTree.Internal.BlobRef as Internal
+import qualified Database.LSMTree.Internal.Config as Internal
+import qualified Database.LSMTree.Internal.Entry as Internal
 import qualified Database.LSMTree.Internal.Paths as Internal
 import qualified Database.LSMTree.Internal.Range as Internal
 import qualified Database.LSMTree.Internal.Run as Internal

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE CPP       #-}
 {-# LANGUAGE DataKinds #-}
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Database.LSMTree.Internal (
     -- * Exceptions
@@ -37,28 +34,13 @@ module Database.LSMTree.Internal (
   , SnapshotLabel
   , snapshot
   , open
-  , TableConfigOverride
-  , configNoOverride
-  , configOverrideDiskCachePolicy
   , deleteSnapshot
   , listSnapshots
     -- * Mutiple writable table handles
   , duplicate
-    -- * Configuration
-  , TableConfig (..)
-  , defaultTableConfig
-  , MergePolicy (..)
-  , SizeRatio (..)
-  , WriteBufferAlloc (..)
-  , NumEntries (..)
-  , BloomFilterAlloc (..)
-  , defaultBloomFilterAlloc
-  , FencePointerIndex (..)
-  , DiskCachePolicy (..)
     -- * Exported for cabal-docspec
   , MergePolicyForLevel (..)
   , maxRunSize
-  , LevelNo (..)
   ) where
 
 import           Control.Concurrent.Class.MonadMVar.Strict
@@ -80,14 +62,13 @@ import           Data.Foldable
 import           Data.Functor.Compose (Compose (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe)
-import           Data.Monoid (Last (..))
+import           Data.Maybe (catMaybes)
 import qualified Data.Set as Set
 import qualified Data.Vector as V
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.Assertions (assert, assertNoThunks,
-                     fromIntegralChecked)
+import           Database.LSMTree.Internal.Assertions (assert, assertNoThunks)
 import           Database.LSMTree.Internal.BlobRef
+import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..),
                      combineMaybe, unNumEntries)
 import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
@@ -107,7 +88,6 @@ import           Database.LSMTree.Internal.TempRegistry
 import qualified Database.LSMTree.Internal.Vector as V
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
-import qualified Monkey
 import           NoThunks.Class
 import qualified System.FS.API as FS
 import           System.FS.API (FsError, FsErrorPath (..), FsPath, Handle,
@@ -581,10 +561,6 @@ data Level s h = Level {
 
 -- TODO: proper instance
 deriving via OnlyCheckWhnfNamed "Level" (Level s h) instance NoThunks (Level s h)
-
-newtype LevelNo = LevelNo Int
-  deriving stock (Show, Eq)
-  deriving newtype Enum
 
 -- | A merging run is either a single run, or some ongoing merge.
 data MergingRun s h =
@@ -1091,6 +1067,7 @@ runSize run = Run.runNumEntries run
 
 -- $setup
 -- >>> import Database.LSMTree.Internal.Entry
+-- >>> import Database.LSMTree.Internal.Config
 
 -- | Compute the maximum size of a run for a given level.
 --
@@ -1247,50 +1224,6 @@ open sesh label override snap = do
         am <- newArenaManager
         (newWith sesh seshEnv conf' am WB.empty lvls)
 
--- | Override configuration options in 'TableConfig' that can be changed dynamically.
---
--- Some parts of the 'TableConfig' are considered fixed after a table is
--- created. That is, these options should (i) should stay the same over the
--- lifetime of a table, and (ii) these options should not be changed when a
--- snapshot is created or loaded. Other options can be changed dynamically
--- without sacrificing correctness.
---
--- This type has 'Semigroup' and 'Monoid' instances for composing override
--- options.
-data TableConfigOverride = TableConfigOverride {
-      -- | Override for 'confDiskCachePolicy'
-      confOverrideDiskCachePolicy  :: Last DiskCachePolicy
-    }
-    deriving stock Show
-
--- | Behaves like a point-wise 'Last' instance
-instance Semigroup TableConfigOverride where
-  override1 <> override2 = TableConfigOverride {
-        confOverrideDiskCachePolicy =
-          confOverrideDiskCachePolicy override1 <>
-          confOverrideDiskCachePolicy override2
-      }
-
--- | Behaves like a point-wise 'Last' instance
-instance Monoid TableConfigOverride where
-  mempty = configNoOverride
-
-applyOverride :: TableConfigOverride -> TableConfig -> TableConfig
-applyOverride TableConfigOverride{..} conf = conf {
-      confDiskCachePolicy =
-        fromMaybe (confDiskCachePolicy conf) (getLast confOverrideDiskCachePolicy)
-    }
-
-configNoOverride :: TableConfigOverride
-configNoOverride = TableConfigOverride {
-      confOverrideDiskCachePolicy = Last Nothing
-    }
-
-configOverrideDiskCachePolicy :: DiskCachePolicy -> TableConfigOverride
-configOverrideDiskCachePolicy pol = TableConfigOverride {
-      confOverrideDiskCachePolicy = Last (Just pol)
-    }
-
 {-# SPECIALISE openLevels :: HasFS IO h -> HasBlockIO IO h -> DiskCachePolicy -> V.Vector ((Bool, RunFsPaths), V.Vector RunFsPaths) -> Managed IO (Levels RealWorld (FS.Handle h)) #-}
 -- | Open multiple levels.
 --
@@ -1396,286 +1329,3 @@ duplicate th = do
             (tableHandleArenaManager th)
             (tableWriteBuffer content)
             (tableLevels content)
-
-{-------------------------------------------------------------------------------
-  Configuration
--------------------------------------------------------------------------------}
-
--- | Table configuration parameters, including LSM tree tuning parameters.
---
--- Some config options are fixed (for now):
---
--- * Merge policy: Tiering
---
--- * Size ratio: 4
-data TableConfig = TableConfig {
-    confMergePolicy       :: !MergePolicy
-    -- Size ratio between the capacities of adjacent levels.
-  , confSizeRatio         :: !SizeRatio
-    -- | Total number of bytes that the write buffer can use.
-    --
-    -- The maximum is 4GiB, which should be more than enough for realistic
-    -- applications.
-  , confWriteBufferAlloc  :: !WriteBufferAlloc
-  , confBloomFilterAlloc  :: !BloomFilterAlloc
-  , confFencePointerIndex :: !FencePointerIndex
-    -- | The policy for caching key\/value data from disk in memory.
-  , confDiskCachePolicy   :: !DiskCachePolicy
-  }
-  deriving stock (Show, Eq)
-
-instance NFData TableConfig where
-  rnf (TableConfig a b c d e f) =
-      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read TableConfig
-
--- | A reasonable default 'TableConfig'.
---
--- This uses a write buffer with up to 20,000 elements and a generous amount of
--- memory for Bloom filters (FPR of 2%).
---
-defaultTableConfig :: TableConfig
-defaultTableConfig =
-    TableConfig
-      { confMergePolicy      = MergePolicyLazyLevelling
-      , confSizeRatio        = Four
-      , confWriteBufferAlloc = AllocNumEntries (NumEntries 20_000)
-      , confBloomFilterAlloc = defaultBloomFilterAlloc
-      , confFencePointerIndex = CompactIndex
-      , confDiskCachePolicy  = DiskCacheAll
-      }
-
-
-
-data MergePolicy =
-    -- | Use tiering on intermediate levels, and levelling on the last level.
-    -- This makes it easier for delete operations to disappear on the last
-    -- level.
-    MergePolicyLazyLevelling
-{- TODO: disabled for now. Would we ever want to provide pure tiering?
-  | MergePolicyTiering
--}
-{- TODO: disabled for now
-  | MergePolicyLevelling
--}
-  deriving stock (Show, Eq)
-
-instance NFData MergePolicy where
-  rnf MergePolicyLazyLevelling = ()
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read MergePolicy
-
-data SizeRatio = Four
-  deriving stock (Show, Eq)
-
-instance NFData SizeRatio where
-  rnf Four = ()
-
-sizeRatioInt :: SizeRatio -> Int
-sizeRatioInt = \case Four -> 4
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read SizeRatio
-
--- | Allocation method for the write buffer.
-data WriteBufferAlloc =
-    -- | Total number of key\/value pairs that can be present in the write
-    -- buffer before flushing the write buffer to disk.
-    --
-    -- NOTE: if the sizes of values vary greatly, this can lead to wonky runs on
-    -- disk, and therefore unpredictable performance.
-    AllocNumEntries !NumEntries
-{- TODO: disabled for now
-  | -- | Total number of bytes that the write buffer can use.
-    --
-    -- The maximum is 4GiB, which should be more than enough for realistic
-    -- applications.
-    AllocTotalBytes !Word32
--}
-  deriving stock (Show, Eq)
-
-instance NFData WriteBufferAlloc where
-  rnf (AllocNumEntries n) = rnf n
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read WriteBufferAlloc
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read NumEntries
-
--- | Allocation method for bloom filters.
---
--- NOTE: a __physical__ database entry is a key\/operation pair that exists in a
--- file, i.e., a run. Multiple physical entries that have the same key
--- constitute a __logical__ database entry.
-data BloomFilterAlloc =
-    -- | Allocate a fixed number of bits per physical entry in each bloom
-    -- filter.
-    AllocFixed
-      Word64 -- ^ Bits per physical entry.
-  | -- | Allocate as many bits as required per physical entry to get the requested
-    -- false-positive rate. Do this for each bloom filter.
-    AllocRequestFPR
-      Double -- ^ Requested FPR.
-  | -- | Allocate bits amongst all bloom filters according to the Monkey algorithm.
-    --
-    -- The allocation algorithm will never go over the memory budget. If more
-    -- levels are added that the algorithm did not account for, then bloom
-    -- filters on those levels will be empty. This can happen for a number of
-    -- reasons:
-    --
-    -- * The number of budgeted physical entries is exceeded
-    -- * Underfull runs causes levels to be underfull, which causes entries to
-    --   reside in larger levels
-    --
-    -- To combat this, make sure to budget for a generous number of physical
-    -- entries.
-    AllocMonkey
-      Word64 -- ^ Total number of bytes that bloom filters can use collectively.
-      NumEntries -- ^ Total number of /physical/ entries expected to be in the database.
-  deriving stock (Show, Eq)
-
-instance NFData BloomFilterAlloc where
-  rnf (AllocFixed n)        = rnf n
-  rnf (AllocRequestFPR fpr) = rnf fpr
-  rnf (AllocMonkey a b)     = rnf a `seq` rnf b
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read BloomFilterAlloc
-
-defaultBloomFilterAlloc :: BloomFilterAlloc
-defaultBloomFilterAlloc = AllocFixed 10
-
-bloomFilterAllocForLevel :: TableConfig -> LevelNo -> RunBloomFilterAlloc
-bloomFilterAllocForLevel conf (LevelNo l) =
-    assert (l > 0) $
-    case confBloomFilterAlloc conf of
-      AllocFixed n -> RunAllocFixed n
-      AllocRequestFPR fpr -> RunAllocRequestFPR fpr
-      AllocMonkey totalBits (NumEntries n) ->
-        let !sr = sizeRatioInt (confSizeRatio conf)
-            !m = case confWriteBufferAlloc conf of
-                    AllocNumEntries (NumEntries x) -> x
-            !levelCount = Monkey.numLevels (fromIntegral n) (fromIntegral m) (fromIntegral sr)
-            !allocPerLevel = Monkey.monkeyBits
-                                (fromIntegralChecked totalBits)
-                                (fromIntegralChecked n)
-                                (fromIntegralChecked sr)
-                                levelCount
-        in  case allocPerLevel !? (l - 1) of
-              -- Default to an empty bloom filter in case the level wasn't
-              -- accounted for. See 'AllocMonkey'.
-              Nothing     -> RunAllocMonkey 0
-              Just (_, x) -> RunAllocMonkey (fromIntegralChecked x)
-  where
-    -- Copied from "Data.List"
-    {-# INLINABLE (!?) #-}
-    (!?) :: [a] -> Int -> Maybe a
-    xs !? n
-      | n < 0     = Nothing
-      | otherwise = foldr (\x r k -> case k of
-                                      0 -> Just x
-                                      _ -> r (k-1)) (const Nothing) xs n
-
--- | Configure the type of fence pointer index.
---
--- TODO: this configuration option currently has no effect: 'CompactIndex' is
--- always used.
-data FencePointerIndex =
-    -- | Use a compact fence pointer index.
-    --
-    -- The compact index type is designed to work with keys that are large
-    -- cryptographic hashes, e.g. 32 bytes.
-    --
-    -- When using the 'IndexCompact', additional constraints apply to the
-    -- 'Database.LSMTree.Internal.Serialise.Class.serialiseKey' function. The
-    -- __Minimal size__ law should be satisfied:
-    --
-    -- [Minimal size] @'Database.LSMTree.Internal.RawBytes.size'
-    --   ('Database.LSMTree.Internal.Serialise.Class.serialiseKey' x) >= 8@
-    --
-    -- Use 'Database.LSMTree.Internal.Serialise.Class.serialiseKeyMinimalSize'
-    -- to test this law.
-    CompactIndex
-    -- | Use an ordinary fence pointer index, without any constraints on
-    -- serialised keys.
-  | OrdinaryIndex
-  deriving stock (Show, Eq)
-
-instance NFData FencePointerIndex where
-  rnf CompactIndex  = ()
-  rnf OrdinaryIndex = ()
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read FencePointerIndex
-
--- | The policy for caching data from disk in memory (using the OS page cache).
---
--- Caching data in memory can improve performance if the access pattern has
--- good access locality or if the overall data size fits within memory. On the
--- other hand, caching is determental to performance and wastes memory if the
--- access pattern has poor spatial or temporal locality.
---
--- This implementation is designed to have good performance using a cacheless
--- policy, where main memory is used only to cache Bloom filters and indexes,
--- but none of the key\/value data itself. Nevertheless, some use cases will be
--- faster if some or all of the key\/value data is also cached in memory. This
--- implementation does not do any custom caching of key\/value data, relying
--- simply on the OS page cache. Thus caching is done in units of 4kb disk pages
--- (as opposed to individual key\/value pairs for example).
---
-data DiskCachePolicy =
-
-       -- | Use the OS page cache to cache any\/all key\/value data in the
-       -- table.
-       --
-       -- Use this policy if the expected access pattern for the table
-       -- has a good spatial or temporal locality.
-       DiskCacheAll
-
-       -- | Use the OS page cache to cache data in all LSMT levels at or below
-       -- a given level number. For example, use 1 to cache the first level.
-       -- (The write buffer is considered to be level 0.)
-       --
-       -- Use this policy if the expected access pattern for the table
-       -- has good temporal locality for recently inserted keys.
-     | DiskCacheLevelsAtOrBelow Int
-
-       --TODO: Add a policy based on size in bytes rather than internal details
-       -- like levels. An easy use policy would be to say: "cache the first 10
-       -- Mb" and have everything worked out from that.
-
-       -- | Do not cache any key\/value data in any level (except the write
-       -- buffer).
-       --
-       -- Use this policy if expected access pattern for the table has poor
-       -- spatial or temporal locality, such as uniform random access.
-     | DiskCacheNone
-  deriving stock (Eq, Show, Read)
-
-instance NFData DiskCachePolicy where
-  rnf DiskCacheAll                 = ()
-  rnf (DiskCacheLevelsAtOrBelow l) = rnf l
-  rnf DiskCacheNone                = ()
-
--- | Interpret the 'DiskCachePolicy' for a level: should we cache data in runs
--- at this level.
---
-diskCachePolicyForLevel :: DiskCachePolicy -> LevelNo -> RunDataCaching
-diskCachePolicyForLevel policy (LevelNo ln) =
-  case policy of
-    DiskCacheAll               -> CacheRunData
-    DiskCacheNone              -> NoCacheRunData
-    DiskCacheLevelsAtOrBelow n
-      | ln <= n                -> CacheRunData
-      | otherwise              -> NoCacheRunData

--- a/src/Database/LSMTree/Internal/Config.hs
+++ b/src/Database/LSMTree/Internal/Config.hs
@@ -1,0 +1,399 @@
+-- TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Database.LSMTree.Internal.Config (
+    LevelNo (..)
+    -- * Table configuration
+  , TableConfig (..)
+  , defaultTableConfig
+    -- * Table configuration override
+  , TableConfigOverride
+  , applyOverride
+  , configNoOverride
+  , configOverrideDiskCachePolicy
+    -- * Merge policy
+  , MergePolicy (..)
+    -- * Size ratio
+  , SizeRatio (..)
+  , sizeRatioInt
+    -- * Write buffer allocation
+  , WriteBufferAlloc (..)
+    -- * Bloom filter allocation
+  , BloomFilterAlloc (..)
+  , defaultBloomFilterAlloc
+  , bloomFilterAllocForLevel
+    -- * Fence pointer index
+  , FencePointerIndex (..)
+    -- * Disk cache policy
+  , DiskCachePolicy (..)
+  , diskCachePolicyForLevel
+  ) where
+
+import           Control.DeepSeq (NFData (..))
+import           Data.Maybe (fromMaybe)
+import           Data.Monoid (Last (..))
+import           Data.Word (Word64)
+import           Database.LSMTree.Internal.Assertions (assert,
+                     fromIntegralChecked)
+import           Database.LSMTree.Internal.Entry (NumEntries (..))
+import           Database.LSMTree.Internal.Run (RunDataCaching (..))
+import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..))
+import qualified Monkey
+
+newtype LevelNo = LevelNo Int
+  deriving stock (Show, Eq)
+  deriving newtype Enum
+
+{-------------------------------------------------------------------------------
+  Table configuration
+-------------------------------------------------------------------------------}
+
+-- | Table configuration parameters, including LSM tree tuning parameters.
+--
+-- Some config options are fixed (for now):
+--
+-- * Merge policy: Tiering
+--
+-- * Size ratio: 4
+data TableConfig = TableConfig {
+    confMergePolicy       :: !MergePolicy
+    -- Size ratio between the capacities of adjacent levels.
+  , confSizeRatio         :: !SizeRatio
+    -- | Total number of bytes that the write buffer can use.
+    --
+    -- The maximum is 4GiB, which should be more than enough for realistic
+    -- applications.
+  , confWriteBufferAlloc  :: !WriteBufferAlloc
+  , confBloomFilterAlloc  :: !BloomFilterAlloc
+  , confFencePointerIndex :: !FencePointerIndex
+    -- | The policy for caching key\/value data from disk in memory.
+  , confDiskCachePolicy   :: !DiskCachePolicy
+  }
+  deriving stock (Show, Eq)
+
+instance NFData TableConfig where
+  rnf (TableConfig a b c d e f) =
+      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f
+
+-- | TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+deriving stock instance Read TableConfig
+
+-- | A reasonable default 'TableConfig'.
+--
+-- This uses a write buffer with up to 20,000 elements and a generous amount of
+-- memory for Bloom filters (FPR of 2%).
+--
+defaultTableConfig :: TableConfig
+defaultTableConfig =
+    TableConfig
+      { confMergePolicy      = MergePolicyLazyLevelling
+      , confSizeRatio        = Four
+      , confWriteBufferAlloc = AllocNumEntries (NumEntries 20_000)
+      , confBloomFilterAlloc = defaultBloomFilterAlloc
+      , confFencePointerIndex = CompactIndex
+      , confDiskCachePolicy  = DiskCacheAll
+      }
+
+{-------------------------------------------------------------------------------
+  Table configuration override
+-------------------------------------------------------------------------------}
+
+-- | Override configuration options in 'TableConfig' that can be changed dynamically.
+--
+-- Some parts of the 'TableConfig' are considered fixed after a table is
+-- created. That is, these options should (i) should stay the same over the
+-- lifetime of a table, and (ii) these options should not be changed when a
+-- snapshot is created or loaded. Other options can be changed dynamically
+-- without sacrificing correctness.
+--
+-- This type has 'Semigroup' and 'Monoid' instances for composing override
+-- options.
+data TableConfigOverride = TableConfigOverride {
+      -- | Override for 'confDiskCachePolicy'
+      confOverrideDiskCachePolicy  :: Last DiskCachePolicy
+    }
+    deriving stock Show
+
+-- | Behaves like a point-wise 'Last' instance
+instance Semigroup TableConfigOverride where
+  override1 <> override2 = TableConfigOverride {
+        confOverrideDiskCachePolicy =
+          confOverrideDiskCachePolicy override1 <>
+          confOverrideDiskCachePolicy override2
+      }
+
+-- | Behaves like a point-wise 'Last' instance
+instance Monoid TableConfigOverride where
+  mempty = configNoOverride
+
+applyOverride :: TableConfigOverride -> TableConfig -> TableConfig
+applyOverride TableConfigOverride{..} conf = conf {
+      confDiskCachePolicy =
+        fromMaybe (confDiskCachePolicy conf) (getLast confOverrideDiskCachePolicy)
+    }
+
+configNoOverride :: TableConfigOverride
+configNoOverride = TableConfigOverride {
+      confOverrideDiskCachePolicy = Last Nothing
+    }
+
+configOverrideDiskCachePolicy :: DiskCachePolicy -> TableConfigOverride
+configOverrideDiskCachePolicy pol = TableConfigOverride {
+      confOverrideDiskCachePolicy = Last (Just pol)
+    }
+
+{-------------------------------------------------------------------------------
+  Merge policy
+-------------------------------------------------------------------------------}
+
+data MergePolicy =
+    -- | Use tiering on intermediate levels, and levelling on the last level.
+    -- This makes it easier for delete operations to disappear on the last
+    -- level.
+    MergePolicyLazyLevelling
+{- TODO: disabled for now. Would we ever want to provide pure tiering?
+  | MergePolicyTiering
+-}
+{- TODO: disabled for now
+  | MergePolicyLevelling
+-}
+  deriving stock (Show, Eq)
+
+instance NFData MergePolicy where
+  rnf MergePolicyLazyLevelling = ()
+
+-- | TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+deriving stock instance Read MergePolicy
+
+{-------------------------------------------------------------------------------
+  Size ratio
+-------------------------------------------------------------------------------}
+
+data SizeRatio = Four
+  deriving stock (Show, Eq)
+
+instance NFData SizeRatio where
+  rnf Four = ()
+
+-- | TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+deriving stock instance Read SizeRatio
+
+sizeRatioInt :: SizeRatio -> Int
+sizeRatioInt = \case Four -> 4
+
+{-------------------------------------------------------------------------------
+  Write buffer allocation
+-------------------------------------------------------------------------------}
+
+-- | Allocation method for the write buffer.
+data WriteBufferAlloc =
+    -- | Total number of key\/value pairs that can be present in the write
+    -- buffer before flushing the write buffer to disk.
+    --
+    -- NOTE: if the sizes of values vary greatly, this can lead to wonky runs on
+    -- disk, and therefore unpredictable performance.
+    AllocNumEntries !NumEntries
+{- TODO: disabled for now
+  | -- | Total number of bytes that the write buffer can use.
+    --
+    -- The maximum is 4GiB, which should be more than enough for realistic
+    -- applications.
+    AllocTotalBytes !Word32
+-}
+  deriving stock (Show, Eq)
+
+instance NFData WriteBufferAlloc where
+  rnf (AllocNumEntries n) = rnf n
+
+-- | TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+deriving stock instance Read WriteBufferAlloc
+
+-- | TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+deriving stock instance Read NumEntries
+
+{-------------------------------------------------------------------------------
+  Bloom filter allocation
+-------------------------------------------------------------------------------}
+
+-- | Allocation method for bloom filters.
+--
+-- NOTE: a __physical__ database entry is a key\/operation pair that exists in a
+-- file, i.e., a run. Multiple physical entries that have the same key
+-- constitute a __logical__ database entry.
+data BloomFilterAlloc =
+    -- | Allocate a fixed number of bits per physical entry in each bloom
+    -- filter.
+    AllocFixed
+      Word64 -- ^ Bits per physical entry.
+  | -- | Allocate as many bits as required per physical entry to get the requested
+    -- false-positive rate. Do this for each bloom filter.
+    AllocRequestFPR
+      Double -- ^ Requested FPR.
+  | -- | Allocate bits amongst all bloom filters according to the Monkey algorithm.
+    --
+    -- The allocation algorithm will never go over the memory budget. If more
+    -- levels are added that the algorithm did not account for, then bloom
+    -- filters on those levels will be empty. This can happen for a number of
+    -- reasons:
+    --
+    -- * The number of budgeted physical entries is exceeded
+    -- * Underfull runs causes levels to be underfull, which causes entries to
+    --   reside in larger levels
+    --
+    -- To combat this, make sure to budget for a generous number of physical
+    -- entries.
+    AllocMonkey
+      Word64 -- ^ Total number of bytes that bloom filters can use collectively.
+      NumEntries -- ^ Total number of /physical/ entries expected to be in the database.
+  deriving stock (Show, Eq)
+
+instance NFData BloomFilterAlloc where
+  rnf (AllocFixed n)        = rnf n
+  rnf (AllocRequestFPR fpr) = rnf fpr
+  rnf (AllocMonkey a b)     = rnf a `seq` rnf b
+
+-- | TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+deriving stock instance Read BloomFilterAlloc
+
+defaultBloomFilterAlloc :: BloomFilterAlloc
+defaultBloomFilterAlloc = AllocFixed 10
+
+bloomFilterAllocForLevel :: TableConfig -> LevelNo -> RunBloomFilterAlloc
+bloomFilterAllocForLevel conf (LevelNo l) =
+    assert (l > 0) $
+    case confBloomFilterAlloc conf of
+      AllocFixed n -> RunAllocFixed n
+      AllocRequestFPR fpr -> RunAllocRequestFPR fpr
+      AllocMonkey totalBits (NumEntries n) ->
+        let !sr = sizeRatioInt (confSizeRatio conf)
+            !m = case confWriteBufferAlloc conf of
+                    AllocNumEntries (NumEntries x) -> x
+            !levelCount = Monkey.numLevels (fromIntegral n) (fromIntegral m) (fromIntegral sr)
+            !allocPerLevel = Monkey.monkeyBits
+                                (fromIntegralChecked totalBits)
+                                (fromIntegralChecked n)
+                                (fromIntegralChecked sr)
+                                levelCount
+        in  case allocPerLevel !? (l - 1) of
+              -- Default to an empty bloom filter in case the level wasn't
+              -- accounted for. See 'AllocMonkey'.
+              Nothing     -> RunAllocMonkey 0
+              Just (_, x) -> RunAllocMonkey (fromIntegralChecked x)
+  where
+    -- Copied from "Data.List"
+    {-# INLINABLE (!?) #-}
+    (!?) :: [a] -> Int -> Maybe a
+    xs !? n
+      | n < 0     = Nothing
+      | otherwise = foldr (\x r k -> case k of
+                                      0 -> Just x
+                                      _ -> r (k-1)) (const Nothing) xs n
+
+{-------------------------------------------------------------------------------
+  Fence pointer index
+-------------------------------------------------------------------------------}
+
+-- | Configure the type of fence pointer index.
+--
+-- TODO: this configuration option currently has no effect: 'CompactIndex' is
+-- always used.
+data FencePointerIndex =
+    -- | Use a compact fence pointer index.
+    --
+    -- The compact index type is designed to work with keys that are large
+    -- cryptographic hashes, e.g. 32 bytes.
+    --
+    -- When using the 'IndexCompact', additional constraints apply to the
+    -- 'Database.LSMTree.Internal.Serialise.Class.serialiseKey' function. The
+    -- __Minimal size__ law should be satisfied:
+    --
+    -- [Minimal size] @'Database.LSMTree.Internal.RawBytes.size'
+    --   ('Database.LSMTree.Internal.Serialise.Class.serialiseKey' x) >= 8@
+    --
+    -- Use 'Database.LSMTree.Internal.Serialise.Class.serialiseKeyMinimalSize'
+    -- to test this law.
+    CompactIndex
+    -- | Use an ordinary fence pointer index, without any constraints on
+    -- serialised keys.
+  | OrdinaryIndex
+  deriving stock (Show, Eq)
+
+instance NFData FencePointerIndex where
+  rnf CompactIndex  = ()
+  rnf OrdinaryIndex = ()
+
+-- | TODO: this should be removed once we have proper snapshotting with proper
+-- persistence of the config to disk.
+deriving stock instance Read FencePointerIndex
+
+{-------------------------------------------------------------------------------
+  Disk cache policy
+-------------------------------------------------------------------------------}
+
+-- | The policy for caching data from disk in memory (using the OS page cache).
+--
+-- Caching data in memory can improve performance if the access pattern has
+-- good access locality or if the overall data size fits within memory. On the
+-- other hand, caching is determental to performance and wastes memory if the
+-- access pattern has poor spatial or temporal locality.
+--
+-- This implementation is designed to have good performance using a cacheless
+-- policy, where main memory is used only to cache Bloom filters and indexes,
+-- but none of the key\/value data itself. Nevertheless, some use cases will be
+-- faster if some or all of the key\/value data is also cached in memory. This
+-- implementation does not do any custom caching of key\/value data, relying
+-- simply on the OS page cache. Thus caching is done in units of 4kb disk pages
+-- (as opposed to individual key\/value pairs for example).
+--
+data DiskCachePolicy =
+
+       -- | Use the OS page cache to cache any\/all key\/value data in the
+       -- table.
+       --
+       -- Use this policy if the expected access pattern for the table
+       -- has a good spatial or temporal locality.
+       DiskCacheAll
+
+       -- | Use the OS page cache to cache data in all LSMT levels at or below
+       -- a given level number. For example, use 1 to cache the first level.
+       -- (The write buffer is considered to be level 0.)
+       --
+       -- Use this policy if the expected access pattern for the table
+       -- has good temporal locality for recently inserted keys.
+     | DiskCacheLevelsAtOrBelow Int
+
+       --TODO: Add a policy based on size in bytes rather than internal details
+       -- like levels. An easy use policy would be to say: "cache the first 10
+       -- Mb" and have everything worked out from that.
+
+       -- | Do not cache any key\/value data in any level (except the write
+       -- buffer).
+       --
+       -- Use this policy if expected access pattern for the table has poor
+       -- spatial or temporal locality, such as uniform random access.
+     | DiskCacheNone
+  deriving stock (Eq, Show, Read)
+
+instance NFData DiskCachePolicy where
+  rnf DiskCacheAll                 = ()
+  rnf (DiskCacheLevelsAtOrBelow l) = rnf l
+  rnf DiskCacheNone                = ()
+
+-- | Interpret the 'DiskCachePolicy' for a level: should we cache data in runs
+-- at this level.
+--
+diskCachePolicyForLevel :: DiskCachePolicy -> LevelNo -> RunDataCaching
+diskCachePolicyForLevel policy (LevelNo ln) =
+  case policy of
+    DiskCacheAll               -> CacheRunData
+    DiskCacheNone              -> NoCacheRunData
+    DiskCacheLevelsAtOrBelow n
+      | ln <= n                -> CacheRunData
+      | otherwise              -> NoCacheRunData

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -40,16 +40,16 @@ module Database.LSMTree.Monoidal (
 
     -- * Table handles
   , TableHandle
-  , Internal.TableConfig (..)
-  , Internal.defaultTableConfig
-  , Internal.SizeRatio (..)
-  , Internal.MergePolicy (..)
-  , Internal.WriteBufferAlloc (..)
-  , Internal.NumEntries (..)
-  , Internal.BloomFilterAlloc (..)
-  , Internal.defaultBloomFilterAlloc
-  , Internal.FencePointerIndex (..)
-  , Internal.DiskCachePolicy (..)
+  , Common.TableConfig (..)
+  , Common.defaultTableConfig
+  , Common.SizeRatio (..)
+  , Common.MergePolicy (..)
+  , Common.WriteBufferAlloc (..)
+  , Common.NumEntries (..)
+  , Common.BloomFilterAlloc (..)
+  , Common.defaultBloomFilterAlloc
+  , Common.FencePointerIndex (..)
+  , Common.DiskCachePolicy (..)
   , withTable
   , new
   , close
@@ -80,9 +80,9 @@ module Database.LSMTree.Monoidal (
   , Common.Labellable (..)
   , snapshot
   , open
-  , Internal.TableConfigOverride
-  , Internal.configNoOverride
-  , Internal.configOverrideDiskCachePolicy
+  , Common.TableConfigOverride
+  , Common.configNoOverride
+  , Common.configOverrideDiskCachePolicy
   , deleteSnapshot
   , listSnapshots
 
@@ -157,7 +157,7 @@ data TableHandle m k v = forall h. Typeable h =>
 instance NFData (TableHandle m k v) where
   rnf (TableHandle th) = rnf th
 
-{-# SPECIALISE withTable :: Session IO -> Internal.TableConfig -> (TableHandle IO k v -> IO a) -> IO a #-}
+{-# SPECIALISE withTable :: Session IO -> Common.TableConfig -> (TableHandle IO k v -> IO a) -> IO a #-}
 -- | (Asynchronous) exception-safe, bracketed opening and closing of a table.
 --
 -- If possible, it is recommended to use this function instead of 'new' and
@@ -165,14 +165,14 @@ instance NFData (TableHandle m k v) where
 withTable ::
      IOLike m
   => Session m
-  -> Internal.TableConfig
+  -> Common.TableConfig
   -> (TableHandle m k v -> m a)
   -> m a
 withTable (Session sesh) conf action =
     Internal.withTable sesh conf $
       action . TableHandle
 
-{-# SPECIALISE new :: Session IO -> Internal.TableConfig -> IO (TableHandle IO k v) #-}
+{-# SPECIALISE new :: Session IO -> Common.TableConfig -> IO (TableHandle IO k v) #-}
 -- | Create a new empty table, returning a fresh table handle.
 --
 -- NOTE: table handles hold open resources (such as open files) and should be
@@ -181,7 +181,7 @@ withTable (Session sesh) conf action =
 new ::
      IOLike m
   => Session m
-  -> Internal.TableConfig
+  -> Common.TableConfig
   -> m (TableHandle m k v)
 new (Session sesh) conf = TableHandle <$> Internal.new sesh conf
 
@@ -334,7 +334,7 @@ snapshot snap (TableHandle th) =
     -- to ensure we don't open a monoidal table as normal later
     label = Common.makeSnapshotLabel (Proxy @(k, v)) <> " (monoidal)"
 
-{-# SPECIALISE open :: (SerialiseKey k, SerialiseValue v, Common.Labellable (k, v)) => Session IO -> Internal.TableConfigOverride -> SnapshotName -> IO (TableHandle IO k v) #-}
+{-# SPECIALISE open :: (SerialiseKey k, SerialiseValue v, Common.Labellable (k, v)) => Session IO -> Common.TableConfigOverride -> SnapshotName -> IO (TableHandle IO k v) #-}
 -- | Open a table from a named snapshot, returning a new table handle.
 --
 -- NOTE: close table handles using 'close' as soon as they are
@@ -363,7 +363,7 @@ open ::
      , Common.Labellable (k, v)
      )
   => Session m
-  -> Internal.TableConfigOverride -- ^ Optional config override
+  -> Common.TableConfigOverride -- ^ Optional config override
   -> SnapshotName
   -> m (TableHandle m k v)
 open (Session sesh) override snap =

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -39,16 +39,16 @@ module Database.LSMTree.Normal (
 
     -- * Table handles
   , TableHandle
-  , Internal.TableConfig (..)
-  , Internal.defaultTableConfig
-  , Internal.SizeRatio (..)
-  , Internal.MergePolicy (..)
-  , Internal.WriteBufferAlloc (..)
-  , Internal.NumEntries (..)
-  , Internal.BloomFilterAlloc (..)
-  , Internal.defaultBloomFilterAlloc
-  , Internal.FencePointerIndex (..)
-  , Internal.DiskCachePolicy (..)
+  , Common.TableConfig (..)
+  , Common.defaultTableConfig
+  , Common.SizeRatio (..)
+  , Common.MergePolicy (..)
+  , Common.WriteBufferAlloc (..)
+  , Common.NumEntries (..)
+  , Common.BloomFilterAlloc (..)
+  , Common.defaultBloomFilterAlloc
+  , Common.FencePointerIndex (..)
+  , Common.DiskCachePolicy (..)
   , withTable
   , new
   , close
@@ -81,9 +81,9 @@ module Database.LSMTree.Normal (
   , Common.Labellable (..)
   , snapshot
   , open
-  , Internal.TableConfigOverride
-  , Internal.configNoOverride
-  , Internal.configOverrideDiskCachePolicy
+  , Common.TableConfigOverride
+  , Common.configNoOverride
+  , Common.configOverrideDiskCachePolicy
   , deleteSnapshot
   , listSnapshots
 
@@ -220,7 +220,7 @@ data TableHandle m k v blob = forall h. Typeable h =>
 instance NFData (TableHandle m k v blob) where
   rnf (TableHandle th) = rnf th
 
-{-# SPECIALISE withTable :: Session IO -> Internal.TableConfig -> (TableHandle IO k v blob -> IO a) -> IO a #-}
+{-# SPECIALISE withTable :: Session IO -> Common.TableConfig -> (TableHandle IO k v blob -> IO a) -> IO a #-}
 -- | (Asynchronous) exception-safe, bracketed opening and closing of a table.
 --
 -- If possible, it is recommended to use this function instead of 'new' and
@@ -228,13 +228,13 @@ instance NFData (TableHandle m k v blob) where
 withTable ::
      IOLike m
   => Session m
-  -> Internal.TableConfig
+  -> Common.TableConfig
   -> (TableHandle m k v blob -> m a)
   -> m a
 withTable (Session sesh) conf action =
     Internal.withTable sesh conf (action . TableHandle)
 
-{-# SPECIALISE new :: Session IO -> Internal.TableConfig -> IO (TableHandle IO k v blob) #-}
+{-# SPECIALISE new :: Session IO -> Common.TableConfig -> IO (TableHandle IO k v blob) #-}
 -- | Create a new empty table, returning a fresh table handle.
 --
 -- NOTE: table handles hold open resources (such as open files) and should be
@@ -243,7 +243,7 @@ withTable (Session sesh) conf action =
 new ::
      IOLike m
   => Session m
-  -> Internal.TableConfig
+  -> Common.TableConfig
   -> m (TableHandle m k v blob)
 new (Session sesh) conf = TableHandle <$> Internal.new sesh conf
 
@@ -404,7 +404,7 @@ snapshot snap (TableHandle th) = void $ Internal.snapshot const snap label th
     -- to ensure we don't open a normal table as monoidal later
     label = Common.makeSnapshotLabel (Proxy @(k, v, blob)) <> " (normal)"
 
-{-# SPECIALISE open :: (SerialiseKey k, SerialiseValue v, SerialiseValue blob, Common.Labellable (k, v, blob)) => Session IO -> Internal.TableConfigOverride -> SnapshotName -> IO (TableHandle IO k v blob ) #-}
+{-# SPECIALISE open :: (SerialiseKey k, SerialiseValue v, SerialiseValue blob, Common.Labellable (k, v, blob)) => Session IO -> Common.TableConfigOverride -> SnapshotName -> IO (TableHandle IO k v blob ) #-}
 -- | Open a table from a named snapshot, returning a new table handle.
 --
 -- NOTE: close table handles using 'close' as soon as they are
@@ -432,7 +432,7 @@ open ::
      , Common.Labellable (k, v, blob)
      )
   => Session m
-  -> Internal.TableConfigOverride -- ^ Optional config override
+  -> Common.TableConfigOverride -- ^ Optional config override
   -> SnapshotName
   -> m (TableHandle m k v blob)
 open (Session sesh) override snap =

--- a/test/Test/Database/LSMTree/Internal.hs
+++ b/test/Test/Database/LSMTree/Internal.hs
@@ -18,6 +18,7 @@ import qualified Data.Vector as V
 import           Data.Word (Word64)
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Internal
+import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Paths (mkSnapshotName)
 import           Database.LSMTree.Internal.Serialise


### PR DESCRIPTION
# Description

The `Internal` module is growing rather large, so I am planning on moving functionality related to merge scheduling to a new module in preparation for the implementation of scheduled merges. For that, we first need to move the config types to prevent cyclic dependencies.

# Checklist

- [x] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

