### PR TITLE
Define cursor API

### DIFF
--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -146,9 +146,9 @@ openSession tr hfs hbio dir = Session <$> Internal.openSession tr hfs hbio dir
 -- | Close the table session. 'closeSession' is idempotent. All subsequent
 -- operations on the session or the tables within it will throw an exception.
 --
--- This also closes any open table handles in the session. It would typically
--- be good practice however to close all table handles first rather than
--- relying on this for cleanup.
+-- This also closes any open table handles and cursors in the session. It would
+-- typically be good practice however to close all table handles first rather
+-- than relying on this for cleanup.
 --
 -- Closing a table session allows the session to be opened again elsewhere, for
 -- example in a different process. Note that the session will be closed

--- a/src/Database/LSMTree/Internal/Monoidal.hs
+++ b/src/Database/LSMTree/Internal/Monoidal.hs
@@ -1,6 +1,6 @@
 module Database.LSMTree.Internal.Monoidal (
     LookupResult (..),
-    RangeLookupResult (..),
+    QueryResult (..),
     Update (..),
 ) where
 
@@ -12,11 +12,10 @@ data LookupResult v =
   | Found !v
   deriving stock (Eq, Show, Functor, Foldable, Traversable)
 
-
--- | A result for one point in a range lookup.
-data RangeLookupResult k v =
-    FoundInRange         !k !v
-  deriving stock (Eq, Show)
+-- | A result for one point in a cursor read or range query.
+data QueryResult k v =
+    FoundInQuery !k !v
+  deriving stock (Eq, Show, Functor, Foldable, Traversable)
 
 -- | Monoidal tables support insert, delete and monoidal upsert operations.
 --

--- a/src/Database/LSMTree/Internal/Normal.hs
+++ b/src/Database/LSMTree/Internal/Normal.hs
@@ -1,6 +1,6 @@
 module Database.LSMTree.Internal.Normal (
     LookupResult (..),
-    RangeLookupResult (..),
+    QueryResult (..),
     Update (..),
 ) where
 
@@ -25,11 +25,16 @@ instance Bifunctor LookupResult where
       Found v           -> Found v
       FoundWithBlob v b -> FoundWithBlob v (g b)
 
--- | A result for one point in a range lookup.
-data RangeLookupResult k v blobref =
-    FoundInRange         !k !v
-  | FoundInRangeWithBlob !k !v !blobref
+-- | A result for one point in a cursor read or range lookup.
+data QueryResult k v blobref =
+    FoundInQuery         !k !v
+  | FoundInQueryWithBlob !k !v !blobref
   deriving stock (Eq, Show, Functor, Foldable, Traversable)
+
+instance Bifunctor (QueryResult k) where
+  bimap f g = \case
+      FoundInQuery k v           -> FoundInQuery k (f v)
+      FoundInQueryWithBlob k v b -> FoundInQueryWithBlob k (f v) (g b)
 
 -- | Normal tables support insert and delete operations.
 --

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -188,7 +188,7 @@ errOnBlob Delete               = Delete
   RangeQueries
 -------------------------------------------------------------------------------}
 
--- | We return 'Entry' instead of either @RangeLookupResult@,
+-- | We return 'Entry' instead of either @QueryResult@,
 -- so we can properly combine lookup results.
 --
 -- Note: 'Delete's are not filtered out.

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -66,6 +66,12 @@ module Database.LSMTree.Monoidal (
   , rangeLookup
   , Range (..)
   , QueryResult (..)
+    -- ** Cursor
+  , Cursor
+  , withCursor
+  , newCursor
+  , closeCursor
+  , readCursor
     -- ** Updates
   , inserts
   , deletes
@@ -199,7 +205,7 @@ close ::
 close (TableHandle th) = Internal.close th
 
 {-------------------------------------------------------------------------------
-  Table querying and updates
+  Table queries
 -------------------------------------------------------------------------------}
 
 {-# SPECIALISE lookups :: (SerialiseKey k, SerialiseValue v, ResolveValue v) => V.Vector k -> TableHandle IO k v -> IO (V.Vector (LookupResult v)) #-}
@@ -238,6 +244,77 @@ rangeLookup ::
   -> TableHandle m k v
   -> m (V.Vector (QueryResult k v))
 rangeLookup = undefined
+
+{-------------------------------------------------------------------------------
+  Cursor
+-------------------------------------------------------------------------------}
+
+-- | A read-only view into a table.
+--
+-- A cursor allows reading from a table sequentially (according to serialised
+-- key ordering) in an incremental fashion. For example, this allows doing a
+-- table scan in small chunks.
+-- Once a cursor has been created, updates to the referenced table don't affect
+-- the cursor.
+type Cursor :: (Type -> Type) -> Type -> Type -> Type
+data Cursor m k v
+
+{-# SPECIALISE withCursor :: TableHandle IO k v -> (Cursor IO k v -> IO a) -> IO a #-}
+-- | (Asynchronous) exception-safe, bracketed opening and closing of a cursor.
+--
+-- If possible, it is recommended to use this function instead of 'newCursor'
+-- and 'closeCursor'.
+withCursor ::
+     IOLike m
+  => TableHandle m k v
+  -> (Cursor m k v -> m a)
+  -> m a
+withCursor = undefined
+
+{-# SPECIALISE newCursor :: TableHandle IO k v -> IO (Cursor IO k v) #-}
+-- | Create a new cursor to read from a given table. Future updates to the table
+-- will not be reflected in the cursor. The cursor starts at the beginning, i.e.
+-- the minimum key of the table.
+--
+-- Consider using 'withCursor' instead.
+--
+-- NOTE: cursors hold open resources (such as open files) and should be closed
+-- using 'close' as soon as they are no longer used.
+newCursor ::
+     IOLike m
+  => TableHandle m k v
+  -> m (Cursor m k v)
+newCursor = undefined
+
+{-# SPECIALISE closeCursor :: Cursor IO k v -> IO () #-}
+-- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed
+-- cursor will throw an exception.
+closeCursor ::
+     IOLike m
+  => Cursor m k v
+  -> m ()
+closeCursor = undefined
+
+{-# SPECIALISE readCursor :: (SerialiseKey k, SerialiseValue v, ResolveValue v) => Int -> Cursor IO k v -> IO (V.Vector (QueryResult k v)) #-}
+-- | Read the next @n@ entries from the cursor. The resulting vector is shorter
+-- than @n@ if the end of the table has been reached. The cursor state is
+-- updated, so the next read will continue where this one ended.
+--
+-- The cursor gets locked for the duration of the call, preventing concurrent
+-- reads.
+--
+-- NOTE: entries are returned in order of the serialised keys, which might not
+-- agree with @Ord k@. See 'SerialiseKey' for more information.
+readCursor ::
+     (IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v)
+  => Int
+  -> Cursor m k v
+  -> m (V.Vector (QueryResult k v))
+readCursor = undefined
+
+{-------------------------------------------------------------------------------
+  Table updates
+-------------------------------------------------------------------------------}
 
 {-# SPECIALISE updates :: (SerialiseKey k, SerialiseValue v, ResolveValue v) => V.Vector (k, Update v) -> TableHandle IO k v -> IO () #-}
 -- | Perform a mixed batch of inserts, deletes and monoidal upserts.

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -65,7 +65,7 @@ module Database.LSMTree.Monoidal (
   , LookupResult (..)
   , rangeLookup
   , Range (..)
-  , RangeLookupResult (..)
+  , QueryResult (..)
     -- ** Updates
   , inserts
   , deletes
@@ -228,7 +228,7 @@ toMonoidalLookupResult = \case
       Entry.Delete             -> NotFound
     Nothing -> NotFound
 
-{-# SPECIALISE rangeLookup :: (SerialiseKey k, SerialiseValue v, ResolveValue v) => Range k -> TableHandle IO k v -> IO (V.Vector (RangeLookupResult k v)) #-}
+{-# SPECIALISE rangeLookup :: (SerialiseKey k, SerialiseValue v, ResolveValue v) => Range k -> TableHandle IO k v -> IO (V.Vector (QueryResult k v)) #-}
 -- | Perform a range lookup.
 --
 -- Range lookups can be performed concurrently from multiple Haskell threads.
@@ -236,7 +236,7 @@ rangeLookup ::
      (IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v)
   => Range k
   -> TableHandle m k v
-  -> m (V.Vector (RangeLookupResult k v))
+  -> m (V.Vector (QueryResult k v))
 rangeLookup = undefined
 
 {-# SPECIALISE updates :: (SerialiseKey k, SerialiseValue v, ResolveValue v) => V.Vector (k, Update v) -> TableHandle IO k v -> IO () #-}

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -64,7 +64,7 @@ module Database.LSMTree.Normal (
   , LookupResult (..)
   , rangeLookup
   , Range (..)
-  , RangeLookupResult (..)
+  , QueryResult (..)
     -- ** Updates
   , inserts
   , deletes
@@ -261,7 +261,7 @@ close ::
 close (TableHandle th) = Internal.close th
 
 {-------------------------------------------------------------------------------
-  Table querying and updates
+  Table queries and updates
 -------------------------------------------------------------------------------}
 
 {-# SPECIALISE lookups :: (SerialiseKey k, SerialiseValue v) => V.Vector k -> TableHandle IO k v blob -> IO (V.Vector (LookupResult v (BlobRef IO blob))) #-}
@@ -286,7 +286,7 @@ toNormalLookupResult = \case
       Entry.Delete              -> NotFound
     Nothing -> NotFound
 
-{-# SPECIALISE rangeLookup :: (SerialiseKey k, SerialiseValue v) => Range k -> TableHandle IO k v blob -> IO (V.Vector (RangeLookupResult k v (BlobRef IO blob))) #-}
+{-# SPECIALISE rangeLookup :: (SerialiseKey k, SerialiseValue v) => Range k -> TableHandle IO k v blob -> IO (V.Vector (QueryResult k v (BlobRef IO blob))) #-}
 -- | Perform a range lookup.
 --
 -- Range lookups can be performed concurrently from multiple Haskell threads.
@@ -294,7 +294,7 @@ rangeLookup ::
      (IOLike m, SerialiseKey k, SerialiseValue v)
   => Range k
   -> TableHandle m k v blob
-  -> m (V.Vector (RangeLookupResult k v (BlobRef m blob)))
+  -> m (V.Vector (QueryResult k v (BlobRef m blob)))
 rangeLookup = undefined
 
 {-# SPECIALISE updates :: (SerialiseKey k, SerialiseValue v, SerialiseValue blob) => V.Vector (k, Update v blob) -> TableHandle IO k v blob -> IO () #-}

--- a/test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Database/LSMTree/Class/Monoidal.hs
@@ -20,8 +20,8 @@ import           Database.LSMTree.Class.Normal (IsSession (..),
 import           Database.LSMTree.Common (IOLike, Labellable (..), Range (..),
                      SerialiseKey, SerialiseValue, SnapshotName)
 import qualified Database.LSMTree.ModelIO.Monoidal as M
-import           Database.LSMTree.Monoidal (LookupResult (..),
-                     RangeLookupResult (..), ResolveValue, Update (..))
+import           Database.LSMTree.Monoidal (LookupResult (..), QueryResult (..),
+                     ResolveValue, Update (..))
 import qualified Database.LSMTree.Monoidal as R
 
 
@@ -53,7 +53,7 @@ class (IsSession (Session h)) => IsTableHandle h where
             (IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v)
         => h m k v
         -> Range k
-        -> m (V.Vector (RangeLookupResult k v))
+        -> m (V.Vector (QueryResult k v))
 
     updates ::
         ( IOLike m

--- a/test/Database/LSMTree/Class/Normal.hs
+++ b/test/Database/LSMTree/Class/Normal.hs
@@ -18,8 +18,8 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Common (IOLike, Labellable (..), Range (..),
                      SerialiseKey, SerialiseValue, SnapshotName)
 import qualified Database.LSMTree.ModelIO.Normal as M
-import           Database.LSMTree.Normal (LookupResult (..),
-                     RangeLookupResult (..), Update (..))
+import           Database.LSMTree.Normal (LookupResult (..), QueryResult (..),
+                     Update (..))
 import qualified Database.LSMTree.Normal as R
 import           System.FS.API (FsPath, HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
@@ -75,7 +75,7 @@ class (IsSession (Session h)) => IsTableHandle h where
            (IOLike m, SerialiseKey k, SerialiseValue v)
         => h m k v blob
         -> Range k
-        -> m (V.Vector (RangeLookupResult k v (BlobRef h m blob)))
+        -> m (V.Vector (QueryResult k v (BlobRef h m blob)))
 
     retrieveBlobs ::
            (IOLike m, SerialiseValue blob)

--- a/test/Database/LSMTree/Model/Monoidal.hs
+++ b/test/Database/LSMTree/Model/Monoidal.hs
@@ -20,7 +20,7 @@ module Database.LSMTree.Model.Monoidal (
   , Range
   , LookupResult (..)
   , lookups
-  , RangeLookupResult (..)
+  , QueryResult (..)
   , rangeLookup
     -- ** Updates
   , Update (..)
@@ -46,9 +46,8 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Common (Range (..), SerialiseKey (..),
                      SerialiseValue (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes)
-import           Database.LSMTree.Monoidal (LookupResult (..),
-                     RangeLookupResult (..), ResolveValue (..), Update (..),
-                     resolveDeserialised)
+import           Database.LSMTree.Monoidal (LookupResult (..), QueryResult (..),
+                     ResolveValue (..), Update (..), resolveDeserialised)
 import           GHC.Exts (IsList (..))
 
 {-------------------------------------------------------------------------------
@@ -111,9 +110,9 @@ rangeLookup :: forall k v.
      (SerialiseKey k, SerialiseValue v)
   => Range k
   -> Table k v
-  -> V.Vector (RangeLookupResult k v)
+  -> V.Vector (QueryResult k v)
 rangeLookup r tbl = V.fromList
-    [ FoundInRange (deserialiseKey k) (deserialiseValue v)
+    [ FoundInQuery (deserialiseKey k) (deserialiseValue v)
     | let (lb, ub) = convertRange r
     , (k, v) <- Map.R.rangeLookup lb ub (_values tbl)
     ]

--- a/test/Database/LSMTree/Model/Normal.hs
+++ b/test/Database/LSMTree/Model/Normal.hs
@@ -12,7 +12,7 @@ module Database.LSMTree.Model.Normal (
   , Range (..)
   , LookupResult (..)
   , lookups
-  , RangeLookupResult (..)
+  , QueryResult (..)
   , rangeLookup
     -- ** Updates
   , Update (..)
@@ -38,8 +38,8 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Common (Range (..), SerialiseKey (..),
                      SerialiseValue (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes)
-import           Database.LSMTree.Normal (LookupResult (..),
-                     RangeLookupResult (..), Update (..))
+import           Database.LSMTree.Normal (LookupResult (..), QueryResult (..),
+                     Update (..))
 import           GHC.Exts (IsList (..))
 
 {-------------------------------------------------------------------------------
@@ -110,11 +110,11 @@ rangeLookup :: forall k v blob.
      (SerialiseKey k, SerialiseValue v)
   => Range k
   -> Table k v blob
-  -> V.Vector (RangeLookupResult k v (BlobRef blob))
+  -> V.Vector (QueryResult k v (BlobRef blob))
 rangeLookup r tbl = V.fromList
     [ case v of
-        (v', Nothing) -> FoundInRange (deserialiseKey k) (deserialiseValue v')
-        (v', Just br) -> FoundInRangeWithBlob (deserialiseKey k) (deserialiseValue v') br
+        (v', Nothing) -> FoundInQuery (deserialiseKey k) (deserialiseValue v')
+        (v', Just br) -> FoundInQueryWithBlob (deserialiseKey k) (deserialiseValue v') br
     | let (lb, ub) = convertRange r
     , (k, v) <- Map.R.rangeLookup lb ub (_values tbl)
     ]

--- a/test/Database/LSMTree/Model/Normal/Session.hs
+++ b/test/Database/LSMTree/Model/Normal/Session.hs
@@ -46,7 +46,7 @@ module Database.LSMTree.Model.Normal.Session (
   , Model.Range (..)
   , Model.LookupResult (..)
   , lookups
-  , Model.RangeLookupResult (..)
+  , Model.QueryResult (..)
   , rangeLookup
     -- ** Updates
   , Model.Update (..)
@@ -285,7 +285,7 @@ lookups ks th = do
     (updc, table) <- guardTableHandleIsOpen th
     pure $ liftBlobRefs th updc $ Model.lookups ks table
 
-type RangeLookupResult k v blobref = Model.RangeLookupResult k v blobref
+type QueryResult k v blobref = Model.QueryResult k v blobref
 
 rangeLookup ::
      ( MonadState Model m
@@ -296,7 +296,7 @@ rangeLookup ::
      )
   => Model.Range k
   -> TableHandle k v blob
-  -> m (V.Vector (RangeLookupResult k v (BlobRef blob)))
+  -> m (V.Vector (QueryResult k v (BlobRef blob)))
 rangeLookup r th = do
     (updc, table) <- guardTableHandleIsOpen th
     pure $ liftBlobRefs th updc $ Model.rangeLookup r table

--- a/test/Database/LSMTree/ModelIO/Monoidal.hs
+++ b/test/Database/LSMTree/ModelIO/Monoidal.hs
@@ -20,7 +20,7 @@ module Database.LSMTree.ModelIO.Monoidal (
   , Range (..)
   , LookupResult (..)
   , lookups
-  , RangeLookupResult (..)
+  , QueryResult (..)
   , rangeLookup
     -- ** Updates
   , Update (..)
@@ -53,8 +53,8 @@ import           Database.LSMTree.Common (IOLike, Range (..), SerialiseKey,
 import           Database.LSMTree.Model.Monoidal (ResolveValue)
 import qualified Database.LSMTree.Model.Monoidal as Model
 import           Database.LSMTree.ModelIO.Session
-import           Database.LSMTree.Monoidal (LookupResult (..),
-                     RangeLookupResult (..), Update (..))
+import           Database.LSMTree.Monoidal (LookupResult (..), QueryResult (..),
+                     Update (..))
 import           GHC.IO.Exception (IOErrorType (..), IOException (..))
 
 {-------------------------------------------------------------------------------
@@ -114,7 +114,7 @@ rangeLookup ::
      (IOLike m, SerialiseKey k, SerialiseValue v)
   => Range k
   -> TableHandle m k v
-  -> m (V.Vector (RangeLookupResult k v))
+  -> m (V.Vector (QueryResult k v))
 rangeLookup r TableHandle {..} = atomically $
     withModel "rangeLookup" thSession thRef $ \tbl ->
         return $ Model.rangeLookup r tbl

--- a/test/Database/LSMTree/ModelIO/Normal.hs
+++ b/test/Database/LSMTree/ModelIO/Normal.hs
@@ -26,7 +26,7 @@ module Database.LSMTree.ModelIO.Normal (
   , Model.Range (..)
   , Model.LookupResult (..)
   , lookups
-  , Model.RangeLookupResult (..)
+  , Model.QueryResult (..)
   , rangeLookup
     -- ** Updates
   , Model.Update (..)
@@ -58,8 +58,8 @@ import           Database.LSMTree.Common (IOLike, SerialiseKey, SerialiseValue,
 import qualified Database.LSMTree.Model.Normal as Model
 import           Database.LSMTree.Model.Normal.Session (UpdateCounter)
 import           Database.LSMTree.ModelIO.Session
-import           Database.LSMTree.Normal (LookupResult (..),
-                     RangeLookupResult (..), Update (..))
+import           Database.LSMTree.Normal (LookupResult (..), QueryResult (..),
+                     Update (..))
 import           GHC.IO.Exception (IOErrorType (..), IOException (..))
 import           System.IO.Error (alreadyExistsErrorType)
 
@@ -121,7 +121,7 @@ rangeLookup ::
      (IOLike m, SerialiseKey k, SerialiseValue v)
   => Model.Range k
   -> TableHandle m k v blob
-  -> m (V.Vector (RangeLookupResult k v (BlobRef m blob)))
+  -> m (V.Vector (QueryResult k v (BlobRef m blob)))
 rangeLookup r th@TableHandle {..} = atomically $
     withModel "rangeLookup" thSession thRef $ \(updc, tbl) ->
         return $ liftBlobRefs th updc $ Model.rangeLookup r tbl

--- a/test/Test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Test/Database/LSMTree/Class/Monoidal.hs
@@ -217,8 +217,8 @@ evalRange :: Ord k => Range k -> k -> Bool
 evalRange (FromToExcluding lo hi) x = lo <= x && x < hi
 evalRange (FromToIncluding lo hi) x = lo <= x && x <= hi
 
-rangeLookupResultKey :: QueryResult k v -> k
-rangeLookupResultKey (FoundInQuery k _) = k
+queryResultKey :: QueryResult k v -> k
+queryResultKey (FoundInQuery k _) = k
 
 -- | Last insert wins.
 prop_insertLookupRange ::
@@ -235,10 +235,10 @@ prop_insertLookupRange h ups k v r = ioProperty $ do
       res' <- rangeLookup hdl r
 
       let p :: QueryResult Key Value -> Bool
-          p rlr = rangeLookupResultKey rlr /= k
+          p rlr = queryResultKey rlr /= k
 
       if evalRange r k
-      then return $ vsortOn rangeLookupResultKey (V.cons (FoundInQuery k v) (V.filter p res)) === res'
+      then return $ vsortOn queryResultKey (V.cons (FoundInQuery k v) (V.filter p res)) === res'
       else return $ res === res'
 
   where

--- a/test/Test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Test/Database/LSMTree/Class/Monoidal.hs
@@ -14,7 +14,7 @@ import qualified Database.LSMTree.Class.Monoidal as Class
 import           Database.LSMTree.Common (Labellable (..), mkSnapshotName)
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.ModelIO.Monoidal (IOLike, LookupResult (..),
-                     Range (..), RangeLookupResult (..), Update (..))
+                     QueryResult (..), Range (..), Update (..))
 import qualified Database.LSMTree.ModelIO.Monoidal as M
 import           Database.LSMTree.Monoidal (ResolveValue (..),
                      resolveDeserialised)
@@ -217,8 +217,8 @@ evalRange :: Ord k => Range k -> k -> Bool
 evalRange (FromToExcluding lo hi) x = lo <= x && x < hi
 evalRange (FromToIncluding lo hi) x = lo <= x && x <= hi
 
-rangeLookupResultKey :: RangeLookupResult k v -> k
-rangeLookupResultKey (FoundInRange k _)             = k
+rangeLookupResultKey :: QueryResult k v -> k
+rangeLookupResultKey (FoundInQuery k _) = k
 
 -- | Last insert wins.
 prop_insertLookupRange ::
@@ -234,11 +234,11 @@ prop_insertLookupRange h ups k v r = ioProperty $ do
 
       res' <- rangeLookup hdl r
 
-      let p :: RangeLookupResult Key Value -> Bool
+      let p :: QueryResult Key Value -> Bool
           p rlr = rangeLookupResultKey rlr /= k
 
       if evalRange r k
-      then return $ vsortOn rangeLookupResultKey (V.cons (FoundInRange k v) (V.filter p res)) === res'
+      then return $ vsortOn rangeLookupResultKey (V.cons (FoundInQuery k v) (V.filter p res)) === res'
       else return $ res === res'
 
   where

--- a/test/Test/Database/LSMTree/Class/Normal.hs
+++ b/test/Test/Database/LSMTree/Class/Normal.hs
@@ -258,9 +258,9 @@ evalRange :: Ord k => Range k -> k -> Bool
 evalRange (FromToExcluding lo hi) x = lo <= x && x < hi
 evalRange (FromToIncluding lo hi) x = lo <= x && x <= hi
 
-rangeLookupResultKey :: QueryResult k v b -> k
-rangeLookupResultKey (FoundInQuery k _)             = k
-rangeLookupResultKey (FoundInQueryWithBlob k _ _  ) = k
+queryResultKey :: QueryResult k v b -> k
+queryResultKey (FoundInQuery k _)             = k
+queryResultKey (FoundInQueryWithBlob k _ _  ) = k
 
 -- | Last insert wins.
 prop_insertLookupRange ::
@@ -277,10 +277,10 @@ prop_insertLookupRange h ups k v r = ioProperty $ do
       res' <- rangeLookupWithBlobs hdl ses r
 
       let p :: QueryResult Key Value b -> Bool
-          p rlr = rangeLookupResultKey rlr /= k
+          p rlr = queryResultKey rlr /= k
 
       if evalRange r k
-      then return $ vsortOn rangeLookupResultKey (V.cons (FoundInQuery k v) (V.filter p res)) === res'
+      then return $ vsortOn queryResultKey (V.cons (FoundInQuery k v) (V.filter p res)) === res'
       else return $ res === res'
 
   where

--- a/test/Test/Database/LSMTree/Class/Normal.hs
+++ b/test/Test/Database/LSMTree/Class/Normal.hs
@@ -21,8 +21,8 @@ import qualified Database.LSMTree.Class.Normal as Class
 import           Database.LSMTree.Common (Labellable (..), mkSnapshotName)
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.ModelIO.Normal (IOLike, LookupResult (..),
-                     Range (..), RangeLookupResult (..), SerialiseKey,
-                     SerialiseValue, Update (..))
+                     QueryResult (..), Range (..), SerialiseKey, SerialiseValue,
+                     Update (..))
 import qualified Database.LSMTree.ModelIO.Normal as M
 import qualified Database.LSMTree.Normal as R
 import qualified System.FS.API as FS
@@ -163,7 +163,7 @@ rangeLookupWithBlobs ::
      forall h m k v blob. ( IsTableHandle h, IOLike m
      , SerialiseKey k, SerialiseValue v, SerialiseValue blob
      )
-  => h m k v blob -> Session h m -> Range k -> m (V.Vector (RangeLookupResult k v blob))
+  => h m k v blob -> Session h m -> Range k -> m (V.Vector (QueryResult k v blob))
 rangeLookupWithBlobs hdl ses r = do
     res <- rangeLookup hdl r
     getCompose <$> retrieveBlobsTrav (Proxy.Proxy @h) ses (Compose res)
@@ -258,9 +258,9 @@ evalRange :: Ord k => Range k -> k -> Bool
 evalRange (FromToExcluding lo hi) x = lo <= x && x < hi
 evalRange (FromToIncluding lo hi) x = lo <= x && x <= hi
 
-rangeLookupResultKey :: RangeLookupResult k v b -> k
-rangeLookupResultKey (FoundInRange k _)             = k
-rangeLookupResultKey (FoundInRangeWithBlob k _ _  ) = k
+rangeLookupResultKey :: QueryResult k v b -> k
+rangeLookupResultKey (FoundInQuery k _)             = k
+rangeLookupResultKey (FoundInQueryWithBlob k _ _  ) = k
 
 -- | Last insert wins.
 prop_insertLookupRange ::
@@ -276,11 +276,11 @@ prop_insertLookupRange h ups k v r = ioProperty $ do
 
       res' <- rangeLookupWithBlobs hdl ses r
 
-      let p :: RangeLookupResult Key Value b -> Bool
+      let p :: QueryResult Key Value b -> Bool
           p rlr = rangeLookupResultKey rlr /= k
 
       if evalRange r k
-      then return $ vsortOn rangeLookupResultKey (V.cons (FoundInRange k v) (V.filter p res)) === res'
+      then return $ vsortOn rangeLookupResultKey (V.cons (FoundInQuery k v) (V.filter p res)) === res'
       else return $ res === res'
 
   where

--- a/test/Test/Util/Orphans.hs
+++ b/test/Test/Util/Orphans.hs
@@ -21,7 +21,7 @@ import           Control.Monad.IOSim (IOSim)
 import           Data.Kind (Type)
 import           Database.LSMTree.Common (BlobRef, SerialiseValue)
 import           Database.LSMTree.Internal.Serialise (SerialiseKey)
-import           Database.LSMTree.Normal (LookupResult, RangeLookupResult,
+import           Database.LSMTree.Normal (LookupResult, QueryResult,
                      TableHandle)
 import           Test.QuickCheck.Modifiers (Small (..))
 import           Test.QuickCheck.StateModel (Realized)
@@ -50,7 +50,7 @@ type family RealizeIOSim s a where
   -- lsm-tree
   RealizeIOSim s (TableHandle IO k v blob)       = TableHandle (IOSim s) k v blob
   RealizeIOSim s (LookupResult v blobref)        = LookupResult v (RealizeIOSim s blobref)
-  RealizeIOSim s (RangeLookupResult k v blobref) = RangeLookupResult k v (RealizeIOSim s blobref)
+  RealizeIOSim s (QueryResult k v blobref)       = QueryResult k v (RealizeIOSim s blobref)
   RealizeIOSim s (BlobRef IO blob)               = BlobRef (IOSim s) blob
   -- Type family wrappers
   RealizeIOSim s (WrapTableHandle h IO k v blob) = WrapTableHandle h (IOSim s) k v blob


### PR DESCRIPTION
# Description

Defines the public API for cursors. The implementation will follow soon, but I decided to split the work into small PRs, so individual aspects can be reviewed and merged separately. For example, based on this PR, one could already start integrating the new cursor API into the quickcheck-lockstep tests.

I decided to rename RangeLookupResult, since it will be used for cursor reads, too. Generally it is useful for returning entries when their keys are not already known, which is everything except for (point) lookups.

# Checklist

- [x] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

