### PR TITLE
Adding functionality to initialise RunReaders at offset

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
@@ -23,11 +23,22 @@ import           Test.QuickCheck.Random (mkQCGen)
 
 benchmarks :: Benchmark
 benchmarks = rawpage `deepseq` bgroup "Bench.Database.LSMTree.Internal.RawPage"
-    [ bench "missing" $ whnf (rawPageLookup rawpage) missing
-    , bench "existing-head" $ whnf (rawPageLookup rawpage) existingHead
-    , bench "existing-last" $ whnf (rawPageLookup rawpage) existingLast
+    [ bRawPageFindKey
+    , bRawPageLookup
     ]
   where
+    bRawPageFindKey = bgroup "rawPageFindKey"
+      [ bench "missing"       $ whnf (rawPageFindKey rawpage) missing
+      , bench "existing-head" $ whnf (rawPageFindKey rawpage) existingHead
+      , bench "existing-last" $ whnf (rawPageFindKey rawpage) existingLast
+      ]
+
+    bRawPageLookup = bgroup "rawPageLookup"
+      [ bench "missing"       $ whnf (rawPageLookup rawpage) missing
+      , bench "existing-head" $ whnf (rawPageLookup rawpage) existingHead
+      , bench "existing-last" $ whnf (rawPageLookup rawpage) existingLast
+      ]
+
     kops :: [(Key, Operation)]
     kops = unGen genPage (mkQCGen 42) 200
       where

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -340,6 +340,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Run
     Test.Database.LSMTree.Internal.RunAcc
     Test.Database.LSMTree.Internal.RunBuilder
+    Test.Database.LSMTree.Internal.RunReader
     Test.Database.LSMTree.Internal.RunReaders
     Test.Database.LSMTree.Internal.Serialise
     Test.Database.LSMTree.Internal.Serialise.Class
@@ -371,9 +372,9 @@ test-suite lsm-tree-test
     , directory
     , filepath
     , fs-api
-    , fs-sim
-    , io-classes
-    , io-sim
+    , fs-sim                   ^>=0.3
+    , io-classes               ^>=1.5
+    , io-sim                   ^>=1.5
     , lsm-tree
     , lsm-tree:blockio-api
     , lsm-tree:blockio-sim

--- a/src/Database/LSMTree/Internal/IndexCompact.hs
+++ b/src/Database/LSMTree/Internal/IndexCompact.hs
@@ -6,6 +6,7 @@ module Database.LSMTree.Internal.IndexCompact (
     -- $compact
     IndexCompact (..)
   , PageNo (..)
+  , nextPageNo
   , NumPages
   , getNumPages
     -- * Queries
@@ -386,6 +387,13 @@ newtype PageNo = PageNo { unPageNo :: Int }
   deriving stock (Show, Eq, Ord)
   deriving newtype NFData
 
+-- | Increment the page number.
+--
+-- Note: This does not encure that the incremented page number exists within a given page span.
+{-# INLINE nextPageNo #-}
+nextPageNo :: PageNo -> PageNo
+nextPageNo = PageNo . succ . unPageNo
+
 -- | The number of pages contained by an index or other paging data-structure.
 --
 -- Note: This is a 0-based number; take care to ensure arithmetic underflow
@@ -405,6 +413,8 @@ getNumPages (NumPages w) = fromIntegral w
 -------------------------------------------------------------------------------}
 
 -- | A span of pages, representing an inclusive interval of page numbers.
+--
+-- Typlically used to denote the contiguous page span for a database entry.
 data PageSpan = PageSpan {
     pageSpanStart :: {-# UNPACK #-} !PageNo
   , pageSpanEnd   :: {-# UNPACK #-} !PageNo
@@ -470,6 +480,7 @@ countClashes = Map.size . icTieBreaker
 hasClashes :: IndexCompact -> Bool
 hasClashes = not . Map.null . icTieBreaker
 
+-- | The number of pages within the index.
 sizeInPages :: IndexCompact -> NumPages
 sizeInPages = NumPages . toEnum . VU.length . icPrimary
 

--- a/src/Database/LSMTree/Internal/PageAcc.hs
+++ b/src/Database/LSMTree/Internal/PageAcc.hs
@@ -132,7 +132,7 @@ maxBlobRefsMap = 12 -- 768 / 64
 -- Checking entry size allows us to use 'Word16' arithmetic, we don't need to
 -- worry about overflows.
 --
-sizeofEntry :: SerialisedKey -> Entry SerialisedValue BlobSpan -> Int
+sizeofEntry :: SerialisedKey -> Entry SerialisedValue blob -> Int
 sizeofEntry k Delete               = sizeofKey k
 sizeofEntry k (Mupdate v)          = sizeofKey k + sizeofValue v
 sizeofEntry k (Insert v)           = sizeofKey k + sizeofValue v
@@ -145,7 +145,7 @@ sizeofEntry k (InsertWithBlob v _) = sizeofKey k + sizeofValue v + 12
 -- If 'entryWouldFitInPage' is @True@ and the 'PageAcc' is empty (i.e. using
 --'resetPageAcc') then 'pageAccAddElem' is guaranteed to succeed.
 --
-entryWouldFitInPage :: SerialisedKey -> Entry SerialisedValue BlobSpan -> Bool
+entryWouldFitInPage :: SerialisedKey -> Entry SerialisedValue blob -> Bool
 entryWouldFitInPage k e = sizeofEntry k e + 32 <= pageSize
 
 -- | Whether 'Entry' adds a blob reference

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns   #-}
 {-# LANGUAGE DeriveFunctor  #-}
 {-# LANGUAGE NamedFieldPuns #-}
+
 module Database.LSMTree.Internal.RawPage (
     RawPage (..),
     emptyRawPage,
@@ -12,8 +13,10 @@ module Database.LSMTree.Internal.RawPage (
     rawPageLookup,
     RawPageLookup(..),
     rawPageOverflowPages,
+    rawPageFindKey,
     rawPageIndex,
     RawPageIndex(..),
+    getRawPageIndexKey,
     -- * Test and debug
     rawPageKeyOffsets,
     rawPageValueOffsets,
@@ -133,13 +136,21 @@ data RawPageLookup entry =
      | LookupEntryOverflow !entry !Word32
   deriving stock (Eq, Functor, Show)
 
+-- |
+-- __Time:__ \( \mathcal{O}\left( \log_2 n \right) \)
+-- where \( n \) is the number of entries in the 'RawPage'.
+--
+-- Return the 'Entry' corresponding to the supplied 'SerialisedKey' if it exists
+-- within the 'RawPage'.
 rawPageLookup
     :: RawPage
     -> SerialisedKey
     -> RawPageLookup (Entry SerialisedValue BlobSpan)
 rawPageLookup !page !key
   | dirNumKeys == 1 = lookup1
-  | otherwise       = bisect 0 (fromIntegral dirNumKeys)
+  | otherwise       = case bisectPageToKey (fromIntegral dirNumKeys) page key of
+    KeyWasFoundAt i -> LookupEntry $ rawPageEntryAt page i
+    _               -> LookupEntryNotPresent
   where
     !dirNumKeys = rawPageNumKeys page
 
@@ -153,26 +164,71 @@ rawPageLookup !page !key
       | otherwise
       = LookupEntryNotPresent
 
-    -- when to switch to linear scan
-    -- this a tuning knob
-    -- can be set to zero.
-    threshold = 3
+-- |
+-- __Time:__ \( \mathcal{O}\left( \log_2 n \right) \)
+-- where \( n \) is the number of entries in the 'RawPage'.
+--
+-- Return the least entry number in the 'RawPage' (if it exists)
+-- which is greater than or equal to the supplied 'SerialisedKey'.
+--
+-- The following law always holds \( \forall \mathtt{key} \mathtt{page} \):
+--
+--   * maybe True (key <=) (getRawPageIndexKey . rawPageIndex page . id   =<< rawPageFindKey page key)
+--
+--   * maybe True (key > ) (getRawPageIndexKey . rawPageIndex page . pred =<< rawPageFindKey page key)
+--
+--   * maybe (maximum (rawPageKeys page) < key) (rawPageFindKey page key)
+rawPageFindKey
+    :: RawPage
+    -> SerialisedKey
+    -> Maybe Word16  -- ^ entry number of first entry greater or equal to the key
+rawPageFindKey !page !key
+  | dirNumKeys == 1 = lookup1
+  | otherwise       = case bisectPageToKey (fromIntegral dirNumKeys) page key of
+    KeyNotFoundExceedsPage   -> Nothing
+    KeyNotFoundNearestIsAt i -> Just $ fromIntegral i
+    KeyWasFoundAt          i -> Just $ fromIntegral i
 
-    bisect :: Int -> Int -> RawPageLookup (Entry SerialisedValue BlobSpan)
-    bisect !i !j
-        | j - i < threshold = linear i j
-        | otherwise = case compare key (rawPageKeyAt page k) of
-            EQ -> LookupEntry (rawPageEntryAt page k)
-            GT -> bisect (k + 1) j
-            LT -> bisect i k
-      where
-        k = i + div2 (j - i)
+  where
+    !dirNumKeys = rawPageNumKeys page
 
-    linear :: Int -> Int -> RawPageLookup (Entry SerialisedValue BlobSpan)
-    linear !i !j
-        | i >= j                     = LookupEntryNotPresent
-        | key == rawPageKeyAt page i = LookupEntry (rawPageEntryAt page i)
-        | otherwise                  = linear (i + 1) j
+    lookup1
+      | key <= rawPageKeyAt page 0 = Just 0
+      | otherwise                  = Nothing
+
+-- | This data-type facilitates the code reuse of 'bisectPageToKey' between the
+-- and 'rawPageLookup' and 'rawPageFindKey'.
+data BinarySearchResult
+  = KeyNotFoundExceedsPage
+  | KeyNotFoundNearestIsAt {-# UNPACK #-} !Int
+  | KeyWasFoundAt {-# UNPACK #-} !Int
+
+-- | Binary search procedure shared between 'rawPageLookup' and 'rawPageFindKey'.
+{-# INLINE bisectPageToKey #-}
+bisectPageToKey
+  :: Int
+  -> RawPage
+  -> SerialisedKey
+  -> BinarySearchResult
+bisectPageToKey !numKeys !page !key = go 0 numKeys
+  where
+    -- Binary search for within the range [i, j)
+    -- for the index k corresponding to key.
+    --
+    -- If k > key, search [ k + 1, j )
+    -- If k < key, search [     i, j )
+    go :: Int -> Int -> BinarySearchResult
+    go !i !j
+      | i >= j =
+        if i == numKeys
+        then KeyNotFoundExceedsPage
+        else KeyNotFoundNearestIsAt j
+      | otherwise =
+        let !k = i + div2 (j - i)
+        in  case key `compare` rawPageKeyAt page k of
+          GT -> go (k + 1) j
+          EQ -> KeyWasFoundAt k
+          LT -> go i k
 
 data RawPageIndex entry =
        IndexNotPresent
@@ -185,6 +241,18 @@ data RawPageIndex entry =
        -- The caller can copy the full serialised pages themselves.
      | IndexEntryOverflow !SerialisedKey !entry !Word32
   deriving stock (Eq, Functor, Show)
+
+-- |
+-- __Time:__ \( \mathcal{O}\left( 1 \right) \)
+--
+-- Conveniently access the 'SerialisedKey' of a 'RawPageIndex'.
+{-# INLINE getRawPageIndexKey #-}
+getRawPageIndexKey :: RawPageIndex e -> Maybe SerialisedKey
+getRawPageIndexKey = \case
+  IndexEntry k _ -> Just k
+  IndexEntryOverflow k _ _ -> Just k
+  IndexNotPresent -> Nothing
+
 
 {-# INLINE rawPageIndex #-}
 rawPageIndex
@@ -210,6 +278,8 @@ rawPageIndex !page !ix
 -- | for non-single key page case
 rawPageEntryAt :: RawPage -> Int -> Entry SerialisedValue BlobSpan
 rawPageEntryAt page i =
+    assert (i < fromIntegral (rawPageNumKeys page)) $
+    assert (rawPageNumKeys page > 1) $
     case rawPageOpAt page i of
       0 -> if rawPageHasBlobSpanAt page i == 0
            then Insert (rawPageValueAt page i)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -22,6 +22,7 @@ import qualified Test.Database.LSMTree.Internal.RawPage
 import qualified Test.Database.LSMTree.Internal.Run
 import qualified Test.Database.LSMTree.Internal.RunAcc
 import qualified Test.Database.LSMTree.Internal.RunBuilder
+import qualified Test.Database.LSMTree.Internal.RunReader
 import qualified Test.Database.LSMTree.Internal.RunReaders
 import qualified Test.Database.LSMTree.Internal.Serialise
 import qualified Test.Database.LSMTree.Internal.Serialise.Class
@@ -54,6 +55,7 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Internal.Run.tests
     , Test.Database.LSMTree.Internal.RunAcc.tests
     , Test.Database.LSMTree.Internal.RunBuilder.tests
+    , Test.Database.LSMTree.Internal.RunReader.tests
     , Test.Database.LSMTree.Internal.RunReaders.tests
     , Test.Database.LSMTree.Internal.IndexCompact.tests
     , Test.Database.LSMTree.Internal.Serialise.tests

--- a/test/Test/Database/LSMTree/Internal/RunReader.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReader.hs
@@ -1,0 +1,215 @@
+module Test.Database.LSMTree.Internal.RunReader (
+    -- * Main test tree
+    tests,
+    -- * Utilities
+    readKOps,
+) where
+
+import           Data.Bifoldable (bifoldMap)
+import           Data.Coerce (coerce)
+import           Database.LSMTree.Extras (showPowersOf10)
+import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..),
+                     TypedWriteBuffer (..))
+import           Database.LSMTree.Internal.BlobRef (readBlob)
+import           Database.LSMTree.Internal.Entry (Entry)
+import           Database.LSMTree.Internal.PageAcc (entryWouldFitInPage)
+import qualified Database.LSMTree.Internal.Paths as Paths
+import           Database.LSMTree.Internal.Run (Run)
+import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..))
+import           Database.LSMTree.Internal.RunNumber
+import qualified Database.LSMTree.Internal.RunReader as Reader
+import           Database.LSMTree.Internal.Serialise
+import qualified Database.LSMTree.Internal.WriteBuffer as WB
+import qualified System.FS.API as FS
+import qualified System.FS.BlockIO.API as FS
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck
+import           Test.Util.FS (noOpenHandles, withSimHasBlockIO,
+                     withTempIOHasBlockIO)
+import           Test.Util.Orphans ()
+
+tests :: TestTree
+tests = testGroup "Database.LSMTree.Internal.RunReader"
+    [ testGroup "MockFS"
+        [ testProperty "prop_read" $ \wb ->
+            ioProperty $ withSimHasBlockIO noOpenHandles $ \hfs hbio -> do
+              prop_readAtOffset hfs hbio wb Nothing
+        , testProperty "prop_readAtOffset" $ \wb offset ->
+            ioProperty $ withSimHasBlockIO noOpenHandles $ \hfs hbio -> do
+              prop_readAtOffset hfs hbio wb (Just offset)
+        , testProperty "prop_readAtOffsetExisting" $ \wb i ->
+            ioProperty $ withSimHasBlockIO noOpenHandles $ \hfs hbio -> do
+              prop_readAtOffsetExisting hfs hbio wb i
+        , testProperty "prop_readAtOffsetIdempotence" $ \wb i ->
+            ioProperty $ withSimHasBlockIO noOpenHandles $ \hfs hbio -> do
+              prop_readAtOffsetIdempotence hfs hbio wb i
+        , testProperty "prop_readAtOffsetReadHead" $ \wb ->
+            ioProperty $ withSimHasBlockIO noOpenHandles $ \hfs hbio -> do
+              prop_readAtOffsetReadHead hfs hbio wb
+        ]
+    , testGroup "RealFS"
+        [ testProperty "prop_read" $ \wb ->
+            ioProperty $ withTempIOHasBlockIO "tmp_RunReader" $ \hfs hbio -> do
+              prop_readAtOffset hfs hbio wb Nothing
+        , testProperty "prop_readAtOffset" $ \wb offset ->
+            ioProperty $ withTempIOHasBlockIO "tmp_RunReader" $ \hfs hbio -> do
+              prop_readAtOffset hfs hbio wb (Just offset)
+        , testProperty "prop_readAtOffsetExisting" $ \wb i ->
+            ioProperty $ withTempIOHasBlockIO "tmp_RunReader" $ \hfs hbio -> do
+              prop_readAtOffsetExisting hfs hbio wb i
+        , testProperty "prop_readAtOffsetIdempotence" $ \wb i ->
+            ioProperty $ withTempIOHasBlockIO "tmp_RunReader" $ \hfs hbio -> do
+              prop_readAtOffsetIdempotence hfs hbio wb i
+        , testProperty "prop_readAtOffsetReadHead" $ \wb ->
+            ioProperty $ withTempIOHasBlockIO "tmp_RunReader" $ \hfs hbio -> do
+              prop_readAtOffsetReadHead hfs hbio wb
+        ]
+    ]
+
+-- | Creating a run from a write buffer and reading from the run yields the
+-- original elements.
+--
+-- @id === read . new . flush@
+--
+-- If there is an offset:
+--
+-- @dropWhile ((< offset) . key) === read . newAtOffset offset . flush@
+--
+prop_readAtOffset ::
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> TypedWriteBuffer KeyForIndexCompact SerialisedValue SerialisedBlob
+  -> Maybe KeyForIndexCompact
+  -> IO Property
+prop_readAtOffset fs hbio (TypedWriteBuffer wb) offsetKey = do
+    run <- flush (RunNumber 42) wb
+    rhs <- readKOps fs hbio (coerce offsetKey) run
+
+    -- make sure run gets closed again
+    Run.removeReference run
+
+    return . genStats kops $
+      counterexample ("entries expected: " <> show (length lhs)) $
+      counterexample ("entries found: " <> show (length rhs)) $
+        lhs === rhs
+  where
+    kops = WB.toList wb
+    lhs = case offsetKey of
+        Nothing -> kops
+        Just k  -> dropWhile ((< coerce k) . fst) kops
+
+    flush n =
+        Run.fromWriteBuffer fs hbio Run.CacheRunData (RunAllocFixed 10)
+          (Paths.RunFsPaths (FS.mkFsPath []) n)
+
+-- | A version of 'prop_readAtOffset' where the offset key is always one
+-- of the keys that exist in the run.
+prop_readAtOffsetExisting ::
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> TypedWriteBuffer KeyForIndexCompact SerialisedValue SerialisedBlob
+  -> NonNegative Int
+  -> IO Property
+prop_readAtOffsetExisting fs hbio wb (NonNegative index)
+  | null kops = pure discard
+  | otherwise =
+      prop_readAtOffset fs hbio wb (Just (keys !! (index `mod` length keys)))
+  where
+    keys :: [KeyForIndexCompact]
+    keys = coerce (fst <$> kops)
+    kops = WB.toList (unTypedWriteBuffer wb)
+
+-- | Idempotence of 'readAtOffset'.
+-- Reading at an offset should not perform any stateful effects which alter
+-- the result of a subsequent read at the same offset.
+--
+-- @readAtOffset offset *> readAtOffset offset === readAtOffset offset@
+--
+prop_readAtOffsetIdempotence ::
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> TypedWriteBuffer KeyForIndexCompact SerialisedValue SerialisedBlob
+  -> Maybe KeyForIndexCompact
+  -> IO Property
+prop_readAtOffsetIdempotence fs hbio (TypedWriteBuffer wb) offsetKey = do
+    run <- flush (RunNumber 42) wb
+    lhs <- readKOps fs hbio (coerce offsetKey) run
+    rhs <- readKOps fs hbio (coerce offsetKey) run
+
+    -- make sure run gets closed again
+    Run.removeReference run
+
+    return . genStats kops $
+      counterexample ("entries expected: " <> show (length lhs)) $
+      counterexample ("entries found: " <> show (length rhs)) $
+        lhs === rhs
+  where
+    kops = WB.toList wb
+    flush n =
+        Run.fromWriteBuffer fs hbio Run.CacheRunData (RunAllocFixed 10)
+          (Paths.RunFsPaths (FS.mkFsPath []) n)
+
+-- | Head of 'read' equals 'readAtOffset' of head of 'read'.
+-- Reading the first key from the run initialized without an offset
+-- should be the same as reading from a run initialized at the first key.
+-- the result of a subsequent read at the same offset.
+--
+-- @read === readAtOffset (head read)@
+--
+prop_readAtOffsetReadHead ::
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> TypedWriteBuffer KeyForIndexCompact SerialisedValue SerialisedBlob
+  -> IO Property
+prop_readAtOffsetReadHead fs hbio (TypedWriteBuffer wb) = do
+    run <- flush (RunNumber 42) wb
+    lhs <- readKOps fs hbio Nothing run
+    rhs <- case lhs of
+      []        -> return []
+      (key,_):_ -> readKOps fs hbio (Just key) run
+
+    -- make sure run gets closed again
+    Run.removeReference run
+
+    return . genStats kops $
+      counterexample ("entries expected: " <> show (length lhs)) $
+      counterexample ("entries found: " <> show (length rhs)) $
+        lhs === rhs
+  where
+    kops = WB.toList wb
+    flush n =
+        Run.fromWriteBuffer fs hbio Run.CacheRunData (RunAllocFixed 10)
+          (Paths.RunFsPaths (FS.mkFsPath []) n)
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+type SerialisedEntry = Entry SerialisedValue SerialisedBlob
+type SerialisedKOp = (SerialisedKey, SerialisedEntry)
+
+readKOps ::
+     FS.HasFS IO h -> FS.HasBlockIO IO h
+  -> Maybe (SerialisedKey)  -- ^ offset
+  -> Run IO (FS.Handle h)
+  -> IO [SerialisedKOp]
+readKOps fs hbio offset run = do
+    reader <- Reader.new fs hbio offset run
+    go reader
+  where
+    go reader = do
+      Reader.next fs hbio reader >>= \case
+        Reader.Empty -> return []
+        Reader.ReadEntry key e -> do
+          e' <- traverse (readBlob fs) $ Reader.toFullEntry e
+          ((key, e') :) <$> go reader
+
+genStats :: (Testable a, Foldable t) => t SerialisedKOp -> a -> Property
+genStats kops = tabulate "value size" size . label note
+  where
+    size = map (showPowersOf10 . sizeofValue) vals
+    vals = concatMap (bifoldMap pure mempty . snd) kops
+    note
+      | any (uncurry entryWouldFitInPage) kops = "has large k/op"
+      | otherwise = "no large k/op"


### PR DESCRIPTION
# Description

First part of Work Product 12, adding the functionality to start `RunReaders` at an offset.

The new `rawPageFindKey` function has the same performance characteristics as `rawPageLookup` but facilitates starting the `RunReaders` at an give page offset from the returned index. `RunReader.new` now takes an optional offset as an argument.