### PR TITLE
Start using the new `RefCounter` datatype

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -168,7 +168,7 @@ lookupsInBatchesEnv ::
         , ArenaManager RealWorld
         , FS.HasFS IO FS.HandleIO
         , FS.HasBlockIO IO FS.HandleIO
-        , V.Vector (Run RealWorld (FS.Handle FS.HandleIO))
+        , V.Vector (Run IO (FS.Handle FS.HandleIO))
         , V.Vector SerialisedKey
         )
 lookupsInBatchesEnv Config {..} = do
@@ -199,13 +199,13 @@ lookupsInBatchesCleanup ::
      , ArenaManager RealWorld
      , FS.HasFS IO FS.HandleIO
      , FS.HasBlockIO IO FS.HandleIO
-     , V.Vector (Run RealWorld (FS.Handle FS.HandleIO))
+     , V.Vector (Run IO (FS.Handle FS.HandleIO))
      , V.Vector SerialisedKey
      )
   -> IO ()
-lookupsInBatchesCleanup (tmpDir, _arenaManager, hasFS, hasBlockIO, rs, _) = do
+lookupsInBatchesCleanup (tmpDir, _arenaManager, _hasFS, hasBlockIO, rs, _) = do
     FS.close hasBlockIO
-    forM_ rs $ Run.removeReference hasFS hasBlockIO
+    forM_ rs Run.removeReference
     removeDirectoryRecursive tmpDir
 
 -- | Generate keys to store and keys to lookup

--- a/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
@@ -1,7 +1,6 @@
 module Bench.Database.LSMTree.Internal.WriteBuffer (benchmarks) where
 
 import           Control.DeepSeq (NFData (..))
-import           Control.Monad.Primitive
 import           Criterion.Main (Benchmark, bench, bgroup)
 import qualified Criterion.Main as Cr
 import           Data.Bifunctor (first)
@@ -120,7 +119,7 @@ benchWriteBuffer conf@Config{name} =
             bench "flush" $
               Cr.perRunEnvWithCleanup (getPaths hasFS) (const (cleanupPaths hasFS)) $ \p -> do
                 !run <- flush hasFS hasBlockIO p wb
-                Run.removeReference hasFS hasBlockIO run
+                Run.removeReference run
         , bench "insert+flush" $
             -- To make sure the WriteBuffer really gets recomputed on every run,
             -- we'd like to do: `whnfAppIO (kops' -> ...) kops`.
@@ -138,7 +137,7 @@ benchWriteBuffer conf@Config{name} =
                 -- Make sure to immediately close runs so we don't run out of
                 -- file handles. Ideally this would not be measured, but at
                 -- least it's pretty cheap.
-                Run.removeReference hasFS hasBlockIO run
+                Run.removeReference run
         ]
   where
     withEnv =
@@ -168,7 +167,7 @@ flush :: FS.HasFS IO FS.HandleIO
       -> FS.HasBlockIO IO FS.HandleIO
       -> RunFsPaths
       -> WriteBuffer
-      -> IO (Run RealWorld (FS.Handle (FS.HandleIO)))
+      -> IO (Run IO (FS.Handle (FS.HandleIO)))
 flush hfs hbio = Run.fromWriteBuffer hfs hbio Run.CacheRunData (RunAllocFixed 10)
 
 data InputKOps

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -465,6 +465,7 @@ benchmark lsm-tree-bench-lookups
     , lsm-tree
     , lsm-tree:blockio-api
     , lsm-tree:bloomfilter
+    , lsm-tree:control
     , primitive
     , QuickCheck
     , random

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -50,7 +50,6 @@ import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.Concurrent.Class.MonadSTM (MonadSTM, STM)
 import           Control.DeepSeq
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Primitive (PrimMonad (..))
 import           Control.Tracer (Tracer)
 import           Data.Kind (Type)
 import           Data.Typeable (Proxy, Typeable)
@@ -244,4 +243,4 @@ listSnapshots (Session sesh) = Internal.listSnapshots sesh
 -- TODO: get rid of the @m@ parameter?
 type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal
-data BlobRef m blob = forall h. Typeable h => BlobRef (Internal.BlobRef (Internal.Run (PrimState m) h))
+data BlobRef m blob = forall h. Typeable h => BlobRef (Internal.BlobRef (Internal.Run m h))

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -13,7 +13,7 @@ module Database.LSMTree.Internal.RunReader (
 
 import           Control.Exception (assert, handleJust)
 import           Control.Monad (guard, when)
-import           Control.Monad.Primitive (RealWorld)
+import           Control.Monad.Primitive (PrimMonad (..))
 import           Data.Bifunctor (first)
 import           Data.IORef
 import           Data.Maybe (fromMaybe)
@@ -48,24 +48,24 @@ import           System.FS.BlockIO.API (HasBlockIO)
 --
 -- TODO(optimise): Reuse page buffers using some kind of allocator. However,
 -- deciding how long a page needs to stay around is not trivial.
-data RunReader s fhandle = RunReader {
+data RunReader m fhandle = RunReader {
       readerCurrentPage    :: !(IORef RawPage)
       -- | The index of the entry to be returned by the next call to 'next'.
-    , readerCurrentEntryNo :: !(PrimVar s Word16)
+    , readerCurrentEntryNo :: !(PrimVar (PrimState m) Word16)
       -- | Read mode file handle into the run's k\/ops file. We rely on it to
       -- track the position of the next disk page to read, instead of keeping
       -- a counter ourselves. Also, the run's handle is supposed to be opened
       -- with @O_DIRECT@, which is counterproductive here.
     , readerKOpsHandle     :: !fhandle
       -- | The run this reader is reading from.
-    , readerRun            :: !(Run.Run s fhandle)
+    , readerRun            :: !(Run.Run m fhandle)
     }
 
 new ::
      HasFS IO h
   -> HasBlockIO IO h
-  -> Run.Run RealWorld (FS.Handle h)
-  -> IO (RunReader RealWorld (FS.Handle h))
+  -> Run.Run IO (FS.Handle h)
+  -> IO (RunReader IO (FS.Handle h))
 new fs hbio readerRun = do
     readerKOpsHandle <-
       FS.hOpen fs (runKOpsPath (Run.runRunFsPaths readerRun)) FS.ReadMode
@@ -83,7 +83,7 @@ new fs hbio readerRun = do
 close ::
      HasFS IO h
   -> HasBlockIO IO h
-  -> RunReader s (FS.Handle h)
+  -> RunReader m (FS.Handle h)
   -> IO ()
 close fs hbio RunReader {..} = do
     when (Run.runRunDataCaching readerRun == Run.NoCacheRunData) $
@@ -94,18 +94,18 @@ close fs hbio RunReader {..} = do
 -- | The 'SerialisedKey' and 'SerialisedValue' point into the in-memory disk
 -- page. Keeping them alive will also prevent garbage collection of the 4k byte
 -- array, so if they're long-lived, consider making a copy!
-data Result s fhandle
+data Result m fhandle
   = Empty
-  | ReadEntry !SerialisedKey !(Entry s fhandle)
+  | ReadEntry !SerialisedKey !(Entry m fhandle)
 
-data Entry s fhandle =
+data Entry m fhandle =
     Entry
-      !(E.Entry SerialisedValue (BlobRef (Run s fhandle)))
+      !(E.Entry SerialisedValue (BlobRef (Run m fhandle)))
   | -- | A large entry. The caller might be interested in various different
     -- (redundant) representation, so we return all of them.
     EntryOverflow
       -- | The value is just a prefix, with the remainder in the overflow pages.
-      !(E.Entry SerialisedValue (BlobRef (Run s fhandle)))
+      !(E.Entry SerialisedValue (BlobRef (Run m fhandle)))
       -- | A page containing the single entry (or rather its prefix).
       !RawPage
       -- | Non-zero length of the overflow in bytes.
@@ -119,11 +119,11 @@ data Entry s fhandle =
       ![RawOverflowPage]
 
 mkEntryOverflow ::
-     E.Entry SerialisedValue (BlobRef (Run s fhandle))
+     E.Entry SerialisedValue (BlobRef (Run m fhandle))
   -> RawPage
   -> Word32
   -> [RawOverflowPage]
-  -> Entry s fhandle
+  -> Entry m fhandle
 mkEntryOverflow entryPrefix page len overflowPages =
     assert (len > 0) $
     assert (rawPageOverflowPages page == ceilDivPageSize (fromIntegral len)) $
@@ -131,7 +131,7 @@ mkEntryOverflow entryPrefix page len overflowPages =
       EntryOverflow entryPrefix page len overflowPages
 
 {-# INLINE toFullEntry #-}
-toFullEntry :: Entry s fhandle -> E.Entry SerialisedValue (BlobRef (Run s fhandle))
+toFullEntry :: Entry m fhandle -> E.Entry SerialisedValue (BlobRef (Run m fhandle))
 toFullEntry = \case
     Entry e ->
       e
@@ -150,8 +150,8 @@ appendOverflow len overflowPages (SerialisedValue prefix) =
 next ::
      HasFS IO h
   -> HasBlockIO IO h
-  -> RunReader RealWorld (FS.Handle h)
-  -> IO (Result RealWorld (FS.Handle h))
+  -> RunReader IO (FS.Handle h)
+  -> IO (Result IO (FS.Handle h))
 next fs hbio reader@RunReader {..} = do
     entryNo <- readPrimVar readerCurrentEntryNo
     page <- readIORef readerCurrentPage

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -303,7 +303,7 @@ prop_roundtripFromWriteBufferLookupIO dats =
               (V.map Run.runKOpsFile runs)
               lookupss
     let model = WB.lookups wbAll lookupss
-    V.mapM_ (Run.removeReference hasFS hasBlockIO) runs
+    V.mapM_ Run.removeReference runs
     FS.close hasBlockIO
     -- TODO: we don't compare blobs, because we haven't implemented blob
     -- retrieval yet.


### PR DESCRIPTION
# Description

This replaces the reference counting functionality on `Run`s. Other uses, such as adding reference counting to merging runs, will be added later

# Checklist

- [x] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

