### PR TITLE
Add a configuration option for the merge schedule

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Monoidal.hs
+++ b/bench/micro/Bench/Database/LSMTree/Monoidal.hs
@@ -8,6 +8,7 @@ import           Criterion.Main
 import qualified Data.Vector as V
 import           Data.Void
 import           Data.Word
+import qualified Database.LSMTree.Common as Common
 import           Database.LSMTree.Extras
 import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Internal.Serialise
@@ -52,14 +53,9 @@ resolve = (+)
 instance Monoidal.ResolveValue V where
   resolveValue = resolveDeserialised resolve
 
-benchConfig :: Normal.TableConfig -- or, equivalently, Monoidal.TableConfig
-benchConfig = Normal.TableConfig {
-      confMergePolicy = Normal.MergePolicyLazyLevelling
-    , confSizeRatio = Normal.Four
-    , confWriteBufferAlloc = Normal.AllocNumEntries (Normal.NumEntries 20000)
-    , confBloomFilterAlloc = Normal.AllocFixed 10
-    , confFencePointerIndex = Normal.CompactIndex
-    , confDiskCachePolicy = Normal.DiskCacheAll
+benchConfig :: Common.TableConfig
+benchConfig = Common.defaultTableConfig {
+      Common.confWriteBufferAlloc = Common.AllocNumEntries (Common.NumEntries 20000)
     }
 
 {-------------------------------------------------------------------------------

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -38,6 +38,8 @@ module Database.LSMTree.Common (
   , Internal.defaultBloomFilterAlloc
   , Internal.FencePointerIndex (..)
   , Internal.DiskCachePolicy (..)
+  , Internal.MergeSchedule (..)
+  , Internal.defaultMergeSchedule
     -- * Table configuration override
   , Internal.TableConfigOverride
   , Internal.configNoOverride

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -50,6 +50,8 @@ module Database.LSMTree.Monoidal (
   , Common.defaultBloomFilterAlloc
   , Common.FencePointerIndex (..)
   , Common.DiskCachePolicy (..)
+  , Common.MergeSchedule (..)
+  , Common.defaultMergeSchedule
   , withTable
   , new
   , close

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -49,6 +49,8 @@ module Database.LSMTree.Normal (
   , Common.defaultBloomFilterAlloc
   , Common.FencePointerIndex (..)
   , Common.DiskCachePolicy (..)
+  , Common.MergeSchedule (..)
+  , Common.defaultMergeSchedule
   , withTable
   , new
   , close

--- a/test/Test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Test/Database/LSMTree/Class/Monoidal.hs
@@ -41,13 +41,8 @@ tests = testGroup "Test.Database.LSMTree.Class.Monoidal"
 
     tbl2 :: Proxy R.TableHandle
     tbl2 = Setup {
-          testTableConfig = R.TableConfig {
-              R.confMergePolicy = R.MergePolicyLazyLevelling
-            , R.confSizeRatio = R.Four
-            , R.confWriteBufferAlloc = R.AllocNumEntries (R.NumEntries 3)
-            , R.confBloomFilterAlloc = R.AllocFixed 10
-            , R.confFencePointerIndex = R.CompactIndex
-            , R.confDiskCachePolicy = R.DiskCacheNone
+          testTableConfig = R.defaultTableConfig {
+              R.confWriteBufferAlloc = R.AllocNumEntries (R.NumEntries 3)
             }
         , testWithSessionArgs = \action ->
             FS.withTempIOHasBlockIO "R" $ \hfs hbio ->

--- a/test/Test/Database/LSMTree/Class/Normal.hs
+++ b/test/Test/Database/LSMTree/Class/Normal.hs
@@ -47,13 +47,8 @@ tests = testGroup "Test.Database.LSMTree.Class.Normal"
 
     tbl2 :: Proxy R.TableHandle
     tbl2 = Setup {
-          testTableConfig = R.TableConfig {
-              R.confMergePolicy = R.MergePolicyLazyLevelling
-            , R.confSizeRatio = R.Four
-            , R.confWriteBufferAlloc = R.AllocNumEntries (R.NumEntries 3)
-            , R.confBloomFilterAlloc = R.AllocFixed 10
-            , R.confFencePointerIndex = R.CompactIndex
-            , R.confDiskCachePolicy = R.DiskCacheNone
+          testTableConfig = R.defaultTableConfig {
+              R.confWriteBufferAlloc = R.AllocNumEntries (R.NumEntries 3)
             }
         , testWithSessionArgs = \action ->
             FS.withTempIOHasBlockIO "R" $ \hfs hbio ->

--- a/test/Test/Database/LSMTree/Internal.hs
+++ b/test/Test/Database/LSMTree/Internal.hs
@@ -55,17 +55,11 @@ tests = testGroup "Test.Database.LSMTree.Internal" [
     ]
 
 testTableConfig :: TableConfig
-testTableConfig =
-    TableConfig {
-        confMergePolicy = MergePolicyLazyLevelling
-      , confSizeRatio = Four
-        -- Write buffer size is small on purpose, so that the test actually
-        -- flushes and merges.
-      , confWriteBufferAlloc = AllocNumEntries (NumEntries 3)
-      , confBloomFilterAlloc = AllocFixed 10
-      , confFencePointerIndex = CompactIndex
-      , confDiskCachePolicy = DiskCacheNone
-      }
+testTableConfig = defaultTableConfig {
+      -- Write buffer size is small on purpose, so that the test actually
+      -- flushes and merges.
+      confWriteBufferAlloc = AllocNumEntries (NumEntries 3)
+    }
 
 newSession :: Assertion
 newSession = withTempIOHasBlockIO "newSession" $ \hfs hbio ->

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -234,6 +234,7 @@ instance Arbitrary R.TableConfig where
       , R.confBloomFilterAlloc  = R.AllocFixed 10
       , R.confFencePointerIndex = R.CompactIndex
       , R.confDiskCachePolicy   = R.DiskCacheNone
+      , R.confMergeSchedule       = R.OneShot
       }
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

The merge schedule can either be `OneShot` or `Incremental`. Having this configuration option will allow us to test and benchmark the two versions of the merge algorithm separately. We can remove the `OneShot` option later when/if we decide that the incremental version should be the default.
# Checklist

- [x] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

