### PR TITLE
Introduce `byteVectorFromPrim`

### DIFF
--- a/src/Database/LSMTree/Internal/IndexOrdinaryAcc.hs
+++ b/src/Database/LSMTree/Internal/IndexOrdinaryAcc.hs
@@ -16,9 +16,7 @@ where
 import           Prelude hiding (take)
 
 import           Control.Exception (assert)
-import           Control.Monad.ST.Strict (ST, runST)
-import           Data.Primitive.ByteArray (newByteArray, unsafeFreezeByteArray,
-                     writeByteArray)
+import           Control.Monad.ST.Strict (ST)
 import           Data.Primitive.PrimVar (PrimVar, newPrimVar, readPrimVar,
                      writePrimVar)
 import           Data.Vector (force, take, unsafeFreeze)
@@ -34,7 +32,7 @@ import           Database.LSMTree.Internal.IndexOrdinary
                      (IndexOrdinary (IndexOrdinary))
 import           Database.LSMTree.Internal.Serialise
                      (SerialisedKey (SerialisedKey'))
-import           Database.LSMTree.Internal.Vector (mkPrimVector)
+import           Database.LSMTree.Internal.Vector (byteVectorFromPrim)
 
 {-|
     A general-purpose fence pointer index under incremental construction.
@@ -105,11 +103,7 @@ append instruction (IndexOrdinaryAcc buffer keyCountRef baler)
                            fromIntegral keySize
 
         keySizeBytes :: Primitive.Vector Word8
-        !keySizeBytes = mkPrimVector 0 2 $
-                        runST $ do
-                            rep <- newByteArray 2
-                            writeByteArray rep 0 keySizeAsWord16
-                            unsafeFreezeByteArray rep
+        !keySizeBytes = byteVectorFromPrim keySizeAsWord16
 
 {-|
     Returns the constructed index, along with a final chunk in case the

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -149,21 +149,13 @@ requireBytesExactly tyName expected actual x
 -------------------------------------------------------------------------------}
 
 instance SerialiseKey Word64 where
-  serialiseKey x =
-    RB.RawBytes $ mkPrimVector 0 8 $ P.runByteArray $ do
-      ba <- P.newByteArray 8
-      P.writeByteArray ba 0 $ byteSwap64 x
-      return ba
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwap64 x
 
   deserialiseKey (RawBytes (VP.Vector off len ba)) =
     requireBytesExactly "Word64" 8 len $ byteSwap64 (indexWord8ArrayAsWord64 ba off)
 
 instance SerialiseValue Word64 where
-  serialiseValue x =
-    RB.RawBytes $ mkPrimVector 0 8 $ P.runByteArray $ do
-      ba <- P.newByteArray 8
-      P.writeByteArray ba 0 x
-      return ba
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
 
   deserialiseValue (RawBytes (VP.Vector off len ba)) =
     requireBytesExactly "Word64" 8 len $ indexWord8ArrayAsWord64 ba off


### PR DESCRIPTION
This pull request adds a function `byteVectorFromPrim`, which converts a value of a primitive type into a primitive vector of bytes that contains the value’s representation. Furthermore, this pull request changes existing code to use this function.

It is expected that `byteVectorFromPrim` will be useful in more places; in particular, the tests for the ordinary index will likely benefit from it. All in all, the conversion from primitive values to byte vectors seems common enough to warrant the introduction of a dedicated function.
