### PR TITLE
Create proper `NoThunks` instances

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -165,7 +165,6 @@ library
     , lsm-tree:control
     , lsm-tree:kmerge
     , lsm-tree:monkey
-    , nothunks              ^>=0.2
     , primitive             ^>=0.9
     , strict-mvar           ^>=1.5
     , vector                ^>=0.13
@@ -280,6 +279,7 @@ test-suite lsm-tree-test
     Database.LSMTree.Class.Normal
     Database.LSMTree.Extras
     Database.LSMTree.Extras.Generators
+    Database.LSMTree.Extras.NoThunks
     Database.LSMTree.Extras.Orphans
     Database.LSMTree.Extras.Random
     Database.LSMTree.Extras.ReferenceImpl
@@ -341,16 +341,18 @@ test-suite lsm-tree-test
     , filepath
     , fs-api
     , fs-sim
-    , io-classes               >=1.5
-    , io-sim                   >=1.5
+    , io-classes
+    , io-sim
     , lsm-tree
     , lsm-tree:blockio-api
     , lsm-tree:blockio-sim
     , lsm-tree:bloomfilter
     , lsm-tree:control
+    , lsm-tree:kmerge
     , lsm-tree:monkey
     , lsm-tree:prototypes
     , mtl
+    , nothunks
     , primitive
     , QuickCheck
     , quickcheck-classes-base
@@ -361,6 +363,7 @@ test-suite lsm-tree-test
     , semialign
     , split
     , stm
+    , strict-mvar
     , strict-stm
     , tasty
     , tasty-hunit

--- a/src-control/Control/Concurrent/Class/MonadSTM/RWVar.hs
+++ b/src-control/Control/Concurrent/Class/MonadSTM/RWVar.hs
@@ -7,7 +7,8 @@
 --   import qualified Control.Concurrent.Class.MonadSTM.RWVar as RW
 -- @
 module Control.Concurrent.Class.MonadSTM.RWVar (
-    RWVar
+    RWVar (..)
+  , RWState (..)
   , new
   , unsafeAcquireReadAccess
   , unsafeReleaseReadAccess

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MagicHash #-}
 
 module Control.RefCount (
-    RefCounter
+    RefCounter (..)
   , RefCount (..)
   , unsafeMkRefCounterN
   , mkRefCounterN

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -27,9 +27,9 @@ import           Data.Proxy
 import           Data.Typeable
 import qualified Data.Vector.Primitive as VP
 import           Data.Word
-import           Database.LSMTree.Common as Common hiding (BlobRef)
 import           Database.LSMTree.Internal as Internal
 import           Database.LSMTree.Internal.BlobRef
+import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.IndexCompact
 import           Database.LSMTree.Internal.MergeSchedule
@@ -46,7 +46,6 @@ import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.UniqCounter
 import           Database.LSMTree.Internal.Unsliced
 import           Database.LSMTree.Internal.WriteBuffer
-import qualified Database.LSMTree.Normal as Normal
 import           GHC.Generics
 import           KMerge.Heap
 import           NoThunks.Class
@@ -67,16 +66,16 @@ assertNoThunks x = assert p
 -- | Also checks 'NoThunks' for the 'Normal.TableHandle's that are known to be
 -- open in the 'Common.Session'.
 instance (NoThunksIOLike m, Typeable m)
-      => NoThunks (Common.Session m ) where
-  showTypeOf (_ :: Proxy (Common.Session m)) = "Common.Session"
-  wNoThunks ctx (Common.Session s) = wNoThunks ctx s
+      => NoThunks (Session' m ) where
+  showTypeOf (_ :: Proxy (Session' m)) = "Session'"
+  wNoThunks ctx (Session' s) = wNoThunks ctx s
 
 -- | Does not check 'NoThunks' for the 'Common.Session' that this
 -- 'Normal.TableHandle' belongs to.
 instance (NoThunksIOLike m, Typeable m)
-      => NoThunks (Normal.TableHandle m k v blob) where
-  showTypeOf (_ :: Proxy (Normal.TableHandle m k v blob)) = "Normal.TableHandle"
-  wNoThunks ctx (Normal.TableHandle th) = wNoThunks ctx th
+      => NoThunks (NormalTable m k v blob) where
+  showTypeOf (_ :: Proxy (NormalTable m k v blob)) = "NormalTable"
+  wNoThunks ctx (NormalTable th) = wNoThunks ctx th
 
 {-------------------------------------------------------------------------------
   Internal

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -1,0 +1,466 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | 'NoThunks' orphan instances
+module Database.LSMTree.Extras.NoThunks (
+    assertNoThunks
+  , NoThunksIOLike
+  ) where
+
+import           Control.Concurrent.Class.MonadMVar.Strict
+import           Control.Concurrent.Class.MonadSTM.RWVar
+import           Control.Concurrent.Class.MonadSTM.Strict
+import           Control.Exception
+import           Control.Monad.Primitive
+import           Control.Monad.ST.Unsafe (unsafeSTToIO)
+import           Control.RefCount
+import           Control.Tracer
+import           Data.Arena
+import           Data.BloomFilter
+import           Data.Map.Strict
+import           Data.Primitive
+import           Data.Primitive.PrimVar
+import           Data.Proxy
+import           Data.Typeable
+import qualified Data.Vector.Primitive as VP
+import           Data.Word
+import           Database.LSMTree.Common as Common hiding (BlobRef)
+import           Database.LSMTree.Internal as Internal
+import           Database.LSMTree.Internal.BlobRef
+import           Database.LSMTree.Internal.Entry
+import           Database.LSMTree.Internal.IndexCompact
+import           Database.LSMTree.Internal.MergeSchedule
+import           Database.LSMTree.Internal.Paths
+import           Database.LSMTree.Internal.RawBytes
+import           Database.LSMTree.Internal.RawOverflowPage
+import           Database.LSMTree.Internal.RawPage
+import           Database.LSMTree.Internal.Run
+import           Database.LSMTree.Internal.RunNumber
+import           Database.LSMTree.Internal.RunReader hiding (Entry)
+import qualified Database.LSMTree.Internal.RunReader as Reader
+import           Database.LSMTree.Internal.RunReaders
+import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.UniqCounter
+import           Database.LSMTree.Internal.Unsliced
+import           Database.LSMTree.Internal.WriteBuffer
+import qualified Database.LSMTree.Normal as Normal
+import           GHC.Generics
+import           KMerge.Heap
+import           NoThunks.Class
+import           System.FS.API
+import           System.FS.BlockIO.API
+import           Unsafe.Coerce
+
+assertNoThunks :: NoThunks a => a -> b -> b
+assertNoThunks x = assert p
+  where p = case unsafeNoThunks x of
+              Nothing -> True
+              Just thunkInfo -> error $ "Assertion failed: found thunk" <> show thunkInfo
+
+{-------------------------------------------------------------------------------
+  Public API
+-------------------------------------------------------------------------------}
+
+-- | Also checks 'NoThunks' for the 'Normal.TableHandle's that are known to be
+-- open in the 'Common.Session'.
+instance (NoThunksIOLike m, Typeable m)
+      => NoThunks (Common.Session m ) where
+  showTypeOf (_ :: Proxy (Common.Session m)) = "Common.Session"
+  wNoThunks ctx (Common.Session s) = wNoThunks ctx s
+
+-- | Does not check 'NoThunks' for the 'Common.Session' that this
+-- 'Normal.TableHandle' belongs to.
+instance (NoThunksIOLike m, Typeable m)
+      => NoThunks (Normal.TableHandle m k v blob) where
+  showTypeOf (_ :: Proxy (Normal.TableHandle m k v blob)) = "Normal.TableHandle"
+  wNoThunks ctx (Normal.TableHandle th) = wNoThunks ctx th
+
+{-------------------------------------------------------------------------------
+  Internal
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (Internal.Session m h)
+-- | Also checks 'NoThunks' for the 'Internal.TableHandle's that are known to be
+-- open in the 'Internal.Session'.
+deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h)
+                        => NoThunks (Internal.Session m h)
+
+deriving stock instance Generic (SessionState m h)
+deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h)
+                        => NoThunks (SessionState m h)
+
+deriving stock instance Generic (SessionEnv m h)
+deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h)
+                        => NoThunks (SessionEnv m h)
+
+deriving stock instance Generic (Internal.TableHandle m h)
+-- | Does not check 'NoThunks' for the 'Internal.Session' that this
+-- 'Internal.TableHandle' belongs to.
+deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h)
+                        => NoThunks (Internal.TableHandle m h)
+
+deriving stock instance Generic (TableHandleState m h)
+deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h)
+                        => NoThunks (TableHandleState m h)
+
+deriving stock instance Generic (TableHandleEnv m h)
+deriving via AllowThunksIn ["tableSession", "tableSessionEnv"] (TableHandleEnv m h)
+    instance (NoThunksIOLike m, Typeable m, Typeable h) => NoThunks (TableHandleEnv m h)
+
+-- | Does not check 'NoThunks' for the 'Internal.Session' that this
+-- 'Internal.Cursor' belongs to.
+deriving stock instance Generic (Internal.Cursor m h)
+deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h)
+                        => NoThunks (Internal.Cursor m h)
+
+deriving stock instance Generic (CursorState m h)
+deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h)
+                        => NoThunks (CursorState m h)
+
+deriving stock instance Generic (CursorEnv m h)
+deriving via AllowThunksIn ["cursorSession", "cursorSessionEnv"] (CursorEnv m h)
+    instance (Typeable m, Typeable h) => NoThunks (CursorEnv m h)
+
+{-------------------------------------------------------------------------------
+  UniqCounter
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (UniqCounter m)
+deriving anyclass instance NoThunks (StrictMVar m Word64)
+                        => NoThunks (UniqCounter m)
+
+{-------------------------------------------------------------------------------
+  Serialise
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic RawBytes
+deriving anyclass instance NoThunks RawBytes
+
+deriving stock instance Generic SerialisedKey
+deriving anyclass instance NoThunks SerialisedKey
+
+deriving stock instance Generic SerialisedValue
+deriving anyclass instance NoThunks SerialisedValue
+
+deriving stock instance Generic SerialisedBlob
+deriving anyclass instance NoThunks SerialisedBlob
+
+instance NoThunks (Unsliced a) where
+  showTypeOf (_ :: Proxy (Unsliced a)) = "Unsliced"
+  wNoThunks ctx (x :: Unsliced a) = noThunks ctx y
+    where
+      -- Unsliced is a newtype around a ByteArray, so we can unsafeCoerce
+      -- safely. The bang pattern will only evaluate the coercion, because the
+      -- byte array is already in WHNF.
+      y :: ByteArray
+      !y = unsafeCoerce x
+
+{-------------------------------------------------------------------------------
+  Run
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (Run m (Handle h))
+deriving anyclass instance NoThunks (Run m (Handle h))
+
+deriving stock instance Generic RunDataCaching
+deriving anyclass instance NoThunks RunDataCaching
+
+{-------------------------------------------------------------------------------
+  Paths
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic RunNumber
+deriving anyclass instance NoThunks RunNumber
+
+deriving stock instance Generic SessionRoot
+deriving anyclass instance NoThunks SessionRoot
+
+deriving stock instance Generic RunFsPaths
+deriving anyclass instance NoThunks RunFsPaths
+
+{-------------------------------------------------------------------------------
+  WriteBuffer
+-------------------------------------------------------------------------------}
+
+instance NoThunks WriteBuffer where
+  showTypeOf (_ :: Proxy WriteBuffer) = "WriteBuffer"
+  wNoThunks ctx (x :: WriteBuffer) = noThunks ctx y
+    where
+      -- toMap simply unwraps the WriteBuffer newtype wrapper. The bang pattern
+      -- will only evaluate the coercion, because the inner Map is already in
+      -- WHNF.
+      y :: Map SerialisedKey (Entry SerialisedValue SerialisedBlob)
+      !y = toMap x
+
+{-------------------------------------------------------------------------------
+  IndexCompact
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic IndexCompact
+deriving anyclass instance NoThunks IndexCompact
+
+deriving stock instance Generic PageNo
+deriving anyclass instance NoThunks PageNo
+
+{-------------------------------------------------------------------------------
+  MergeSchedule
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (TableContent m h)
+deriving anyclass instance NoThunks (TableContent m h)
+
+deriving stock instance Generic (LevelsCache m (Handle h))
+deriving anyclass instance NoThunks (LevelsCache m (Handle h))
+
+deriving stock instance Generic (Level m (Handle h))
+deriving anyclass instance NoThunks (Level m (Handle h))
+
+deriving stock instance Generic (MergingRun m (Handle h))
+deriving anyclass instance NoThunks (MergingRun m (Handle h))
+
+deriving stock instance Generic (MergingRunState m (Handle h))
+deriving anyclass instance NoThunks (MergingRunState m (Handle h))
+
+{-------------------------------------------------------------------------------
+  Entry
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (Entry v b)
+deriving anyclass instance (NoThunks v, NoThunks b)
+                        => NoThunks (Entry v b)
+
+deriving stock instance Generic NumEntries
+deriving anyclass instance NoThunks NumEntries
+
+{-------------------------------------------------------------------------------
+  Readers
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (Readers s (Handle h))
+deriving anyclass instance NoThunks (Readers s (Handle h))
+
+deriving stock instance Generic ReaderNumber
+deriving anyclass instance NoThunks ReaderNumber
+
+deriving stock instance Generic (ReadCtx (Handle h))
+deriving anyclass instance NoThunks (ReadCtx (Handle h))
+
+{-------------------------------------------------------------------------------
+  Reader
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (RunReader m (Handle h))
+deriving anyclass instance NoThunks (RunReader m (Handle h))
+
+deriving stock instance Generic (Reader.Entry m (Handle h))
+deriving anyclass instance NoThunks (Reader.Entry m (Handle h))
+
+{-------------------------------------------------------------------------------
+  RawPage
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic RawPage
+deriving anyclass instance NoThunks RawPage
+
+{-------------------------------------------------------------------------------
+  RawPage
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic RawOverflowPage
+deriving anyclass instance NoThunks RawOverflowPage
+
+{-------------------------------------------------------------------------------
+  BlobRef
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (BlobRef r)
+deriving anyclass instance NoThunks r => NoThunks (BlobRef r)
+
+deriving stock instance Generic BlobSpan
+deriving anyclass instance NoThunks BlobSpan
+
+{-------------------------------------------------------------------------------
+  Arena
+-------------------------------------------------------------------------------}
+
+-- TODO: proper instance
+deriving via OnlyCheckWhnfNamed "ArenaManager" (ArenaManager m)
+    instance NoThunks (ArenaManager m)
+
+{-------------------------------------------------------------------------------
+  Config
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic TableConfig
+deriving anyclass instance NoThunks TableConfig
+
+deriving stock instance Generic MergePolicy
+deriving anyclass instance NoThunks MergePolicy
+
+deriving stock instance Generic SizeRatio
+deriving anyclass instance NoThunks SizeRatio
+
+deriving stock instance Generic WriteBufferAlloc
+deriving anyclass instance NoThunks WriteBufferAlloc
+
+deriving stock instance Generic BloomFilterAlloc
+deriving anyclass instance NoThunks BloomFilterAlloc
+
+deriving stock instance Generic FencePointerIndex
+deriving anyclass instance NoThunks FencePointerIndex
+
+deriving stock instance Generic DiskCachePolicy
+deriving anyclass instance NoThunks DiskCachePolicy
+
+deriving stock instance Generic MergeSchedule
+deriving anyclass instance NoThunks MergeSchedule
+
+{-------------------------------------------------------------------------------
+  RWVar
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (RWVar m a)
+deriving anyclass instance NoThunks (StrictTVar m (RWState a)) => NoThunks (RWVar m a)
+
+deriving stock instance Generic (RWState a)
+deriving anyclass instance NoThunks a => NoThunks (RWState a)
+
+{-------------------------------------------------------------------------------
+  RefCount
+-------------------------------------------------------------------------------}
+
+instance NoThunks (RefCounter m) where
+  showTypeOf (_ :: Proxy (RefCounter m)) = "RefCounter"
+  wNoThunks ctx
+    (RefCounter (a :: PrimVar (PrimState m) Int) (b :: Maybe (m ())))
+    = allNoThunks [
+          noThunks ctx a
+          -- it is okay to use @$!@ because @b :: Maybe _@ was already in WHNF
+        , noThunks ctx $! (OnlyCheckWhnfNamed <$> b :: Maybe (OnlyCheckWhnfNamed "finaliser" (m ())))
+        ]
+
+deriving stock instance Generic RefCount
+deriving anyclass instance NoThunks RefCount
+
+{-------------------------------------------------------------------------------
+  kmerge
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (MutableHeap s a)
+deriving anyclass instance NoThunks a => NoThunks (MutableHeap s a)
+
+{-------------------------------------------------------------------------------
+  IOLike
+-------------------------------------------------------------------------------}
+
+-- | 'NoThunks' constraints for IO-like monads
+--
+-- Some constraints, like @NoThunks (MutVar s a)@ and @NoThunks (StrictTVar m
+-- a)@, can not be satisfied for arbitrary @m@\/@s@, and must be instantiated
+-- for a concrete @m@\/@s@, like @IO@\/@RealWorld@.
+class ( forall a. NoThunks a => NoThunks (StrictTVar m a)
+      , forall a. NoThunks a => NoThunks (StrictMVar m a)
+      ) => NoThunksIOLike' m s
+
+instance NoThunksIOLike' IO RealWorld
+
+type NoThunksIOLike m = NoThunksIOLike' m (PrimState m)
+
+instance NoThunks a => NoThunks (StrictTVar IO a) where
+  showTypeOf (_ :: Proxy (StrictTVar IO a)) = "StrictTVar IO"
+  wNoThunks ctx var = do
+      x <- readTVarIO var
+      noThunks ctx x
+
+instance NoThunks a => NoThunks (StrictMVar IO a) where
+  showTypeOf (_ :: Proxy (StrictMVar IO a)) = "StrictMVar IO"
+  wNoThunks ctx var = do
+      x <- readMVar var
+      noThunks ctx x
+
+{-------------------------------------------------------------------------------
+  vector
+-------------------------------------------------------------------------------}
+
+-- TODO: https://github.com/input-output-hk/nothunks/issues/57
+deriving via OnlyCheckWhnfNamed "Primitive.Vector" (VP.Vector a)
+    instance NoThunks (VP.Vector a)
+
+{-------------------------------------------------------------------------------
+  primitive
+-------------------------------------------------------------------------------}
+
+-- TODO: https://github.com/input-output-hk/nothunks/issues/56
+instance NoThunks a => NoThunks (MutVar s a) where
+  showTypeOf (_ :: Proxy (MutVar s a)) = "MutVar"
+  wNoThunks ctx var = do
+      x <- unsafeSTToIO $ readMutVar var
+      noThunks ctx (AllowThunk x) -- TODO: atomicModifyMutVar' is not strict enough
+
+-- TODO: https://github.com/input-output-hk/nothunks/issues/56
+instance (NoThunks a, Prim a) => NoThunks (PrimVar s a) where
+  showTypeOf (_ :: Proxy (PrimVar s a)) = "PrimVar"
+  wNoThunks ctx var = do
+      x <- unsafeSTToIO $ readPrimVar var
+      noThunks ctx x
+
+-- TODO: https://github.com/input-output-hk/nothunks/issues/56
+instance NoThunks a => NoThunks (SmallMutableArray s a) where
+  showTypeOf (_ :: Proxy (SmallMutableArray s a)) = "SmallMutableArray"
+  wNoThunks ctx arr = do
+      n <- unsafeSTToIO $ getSizeofSmallMutableArray arr
+      allNoThunks [
+          unsafeSTToIO (readSmallArray arr i) >>= \x -> noThunks ctx x
+        | i <- [0..n-1]
+        ]
+
+-- TODO: https://github.com/input-output-hk/nothunks/issues/56
+deriving via OnlyCheckWhnfNamed "ByteArray" ByteArray
+    instance NoThunks ByteArray
+
+{-------------------------------------------------------------------------------
+  bloomfilter
+-------------------------------------------------------------------------------}
+
+-- TODO: check heap?
+deriving via OnlyCheckWhnfNamed "Bloom" (Bloom a)
+    instance NoThunks (Bloom a)
+
+{-------------------------------------------------------------------------------
+  fs-api and fs-sim
+-------------------------------------------------------------------------------}
+
+-- TODO: check heap?
+deriving via OnlyCheckWhnfNamed "HasFS" (HasFS m h)
+    instance NoThunks (HasFS m h)
+
+-- TODO: check heap?
+deriving via OnlyCheckWhnfNamed "Handle" (Handle h)
+    instance NoThunks (Handle h)
+
+-- TODO: check heap?
+deriving via OnlyCheckWhnfNamed "FsPath" FsPath
+    instance NoThunks FsPath
+
+{-------------------------------------------------------------------------------
+  blockio-api and blockio-sim
+-------------------------------------------------------------------------------}
+
+-- TODO: check heap?
+deriving via OnlyCheckWhnfNamed "HasBlockIO" (HasBlockIO m h)
+    instance NoThunks (HasBlockIO m h)
+
+-- TODO: check heap?
+deriving via OnlyCheckWhnfNamed "LockFileHandle" (LockFileHandle m)
+    instance NoThunks (LockFileHandle m)
+
+{-------------------------------------------------------------------------------
+  contra-tracer
+-------------------------------------------------------------------------------}
+
+-- TODO: check heap?
+deriving via OnlyCheckWhnfNamed "Tracer" (Tracer m a)
+    instance NoThunks (Tracer m a)

--- a/src-kmerge/KMerge/Heap.hs
+++ b/src-kmerge/KMerge/Heap.hs
@@ -13,7 +13,7 @@
 -- However, as the 'MutableHeap' always represents a heap with its root (minimum value)
 -- extracted, *extract-min* is "fused" to other operations.
 module KMerge.Heap (
-    MutableHeap,
+    MutableHeap (..),
     newMutableHeap,
     replaceRoot,
     extract,

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -2,8 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 
 module Database.LSMTree.Internal (
+    -- * Existentials
+    Session' (..)
+  , NormalTable (..)
+  , NormalCursor (..)
+  , MonoidalTable (..)
+  , MonoidalCursor (..)
     -- * Exceptions
-    LSMTreeError (..)
+  , LSMTreeError (..)
     -- * Tracing
   , LSMTreeTrace (..)
   , TableTrace (..)
@@ -60,10 +66,12 @@ import qualified Data.ByteString.Char8 as BSC
 import           Data.Char (isNumber)
 import           Data.Foldable
 import           Data.Functor.Compose (Compose (..))
+import           Data.Kind
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes)
 import qualified Data.Set as Set
+import           Data.Typeable
 import qualified Data.Vector as V
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.BlobRef
@@ -92,6 +100,44 @@ import qualified System.FS.API.Lazy as FS
 import qualified System.FS.API.Strict as FS
 import qualified System.FS.BlockIO.API as FS
 import           System.FS.BlockIO.API (HasBlockIO)
+
+{-------------------------------------------------------------------------------
+  Existentials
+-------------------------------------------------------------------------------}
+
+type Session' :: (Type -> Type) -> Type
+data Session' m = forall h. Typeable h => Session' !(Session m h)
+
+instance NFData (Session' m) where
+  rnf (Session' s) = rnf s
+
+type NormalTable :: (Type -> Type) -> Type -> Type -> Type -> Type
+data NormalTable m k v b = forall h. Typeable h =>
+    NormalTable !(TableHandle m h)
+
+instance NFData (NormalTable m k v b) where
+  rnf (NormalTable th) = rnf th
+
+type NormalCursor :: (Type -> Type) -> Type -> Type -> Type -> Type
+data NormalCursor m k v blob = forall h. Typeable h =>
+    NormalCursor !(Cursor m h)
+
+instance NFData (NormalCursor m k v b) where
+  rnf (NormalCursor c) = rnf c
+
+type MonoidalTable :: (Type -> Type) -> Type -> Type -> Type
+data MonoidalTable m k v = forall h. Typeable h =>
+    MonoidalTable !(TableHandle m h)
+
+instance NFData (MonoidalTable m k v) where
+  rnf (MonoidalTable th) = rnf th
+
+type MonoidalCursor :: (Type -> Type) -> Type -> Type -> Type
+data MonoidalCursor m k v = forall h. Typeable h =>
+    MonoidalCursor !(Cursor m h)
+
+instance NFData (MonoidalCursor m k v) where
+  rnf (MonoidalCursor c) = rnf c
 
 {-------------------------------------------------------------------------------
   Exceptions
@@ -643,6 +689,9 @@ data Cursor m h = Cursor {
       -- given time.
       cursorState :: !(StrictMVar m (CursorState m h))
     }
+
+instance NFData (Cursor m h) where
+  rnf (Cursor a) = rwhnf a
 
 data CursorState m h =
     CursorOpen !(CursorEnv m h)

--- a/src/Database/LSMTree/Internal/Assertions.hs
+++ b/src/Database/LSMTree/Internal/Assertions.hs
@@ -4,7 +4,6 @@ module Database.LSMTree.Internal.Assertions (
     assert,
     isValidSlice,
     sameByteArray,
-    assertNoThunks,
     fromIntegralChecked,
 ) where
 
@@ -18,7 +17,6 @@ import           GHC.Exts (ByteArray#, MutableByteArray#, isTrue#,
 import           Control.Exception (assert)
 import           Data.Primitive.ByteArray (ByteArray (..), sizeofByteArray)
 import           GHC.Stack (HasCallStack)
-import           NoThunks.Class (NoThunks, unsafeNoThunks)
 import           Text.Printf
 
 isValidSlice :: Int -> Int -> ByteArray -> Bool
@@ -39,12 +37,6 @@ sameByteArray (ByteArray ba1#) (ByteArray ba2#) =
     unsafeCoerceByteArray# :: ByteArray# -> MutableByteArray# s
     unsafeCoerceByteArray# = unsafeCoerce#
 #endif
-
-assertNoThunks :: NoThunks a => a -> b -> b
-assertNoThunks x = assert p
-  where p = case unsafeNoThunks x of
-              Nothing -> True
-              Just thunkInfo -> error $ "Assertion failed: found thunk" <> show thunkInfo
 
 {-# INLINABLE fromIntegralChecked #-}
 -- | Like 'fromIntegral', but throws an error when @(x :: a) /= fromIntegral

--- a/src/Database/LSMTree/Internal/Config.hs
+++ b/src/Database/LSMTree/Internal/Config.hs
@@ -235,11 +235,11 @@ data BloomFilterAlloc =
     -- | Allocate a fixed number of bits per physical entry in each bloom
     -- filter.
     AllocFixed
-      Word64 -- ^ Bits per physical entry.
+      !Word64 -- ^ Bits per physical entry.
   | -- | Allocate as many bits as required per physical entry to get the requested
     -- false-positive rate. Do this for each bloom filter.
     AllocRequestFPR
-      Double -- ^ Requested FPR.
+      !Double -- ^ Requested FPR.
   | -- | Allocate bits amongst all bloom filters according to the Monkey algorithm.
     --
     -- The allocation algorithm will never go over the memory budget. If more
@@ -254,8 +254,8 @@ data BloomFilterAlloc =
     -- To combat this, make sure to budget for a generous number of physical
     -- entries.
     AllocMonkey
-      Word64 -- ^ Total number of bytes that bloom filters can use collectively.
-      NumEntries -- ^ Total number of /physical/ entries expected to be in the database.
+      !Word64 -- ^ Total number of bytes that bloom filters can use collectively.
+      !NumEntries -- ^ Total number of /physical/ entries expected to be in the database.
   deriving stock (Show, Eq)
 
 instance NFData BloomFilterAlloc where
@@ -372,7 +372,7 @@ data DiskCachePolicy =
        --
        -- Use this policy if the expected access pattern for the table
        -- has good temporal locality for recently inserted keys.
-     | DiskCacheLevelsAtOrBelow Int
+     | DiskCacheLevelsAtOrBelow !Int
 
        --TODO: Add a policy based on size in bytes rather than internal details
        -- like levels. An easy use policy would be to say: "cache the first 10

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -55,7 +55,6 @@ import           Database.LSMTree.Internal.Serialise (SerialisedBlob,
 import           Database.LSMTree.Internal.UniqCounter
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
-import           NoThunks.Class
 import           System.FS.API (Handle, HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
 
@@ -153,9 +152,6 @@ data Level m h = Level {
     incomingRuns :: !(MergingRun m h)
   , residentRuns :: !(V.Vector (Run m h))
   }
-
--- TODO: proper instance
-deriving via OnlyCheckWhnfNamed "Level" (Level m h) instance NoThunks (Level m h)
 
 -- | A merging run is either a single run, or some ongoing merge.
 data MergingRun m h =

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -53,6 +53,7 @@ import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Serialise (SerialisedBlob,
                      SerialisedKey, SerialisedValue)
 import           Database.LSMTree.Internal.UniqCounter
+import           Database.LSMTree.Internal.Vector (mapStrict)
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import           System.FS.API (Handle, HasFS)
@@ -134,9 +135,9 @@ data LevelsCache m h = LevelsCache_ {
 mkLevelsCache :: Levels m h -> LevelsCache m h
 mkLevelsCache lvls = LevelsCache_ {
       cachedRuns      = rs
-    , cachedFilters   = V.map Run.runFilter rs
-    , cachedIndexes   = V.map Run.runIndex rs
-    , cachedKOpsFiles = V.map Run.runKOpsFile rs
+    , cachedFilters   = mapStrict Run.runFilter rs
+    , cachedIndexes   = mapStrict Run.runIndex rs
+    , cachedKOpsFiles = mapStrict Run.runKOpsFile rs
     }
   where
     rs = runsInLevels lvls

--- a/src/Database/LSMTree/Internal/RawOverflowPage.hs
+++ b/src/Database/LSMTree/Internal/RawOverflowPage.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveFunctor  #-}
 {-# LANGUAGE NamedFieldPuns #-}
 module Database.LSMTree.Internal.RawOverflowPage (
-    RawOverflowPage,
+    RawOverflowPage (..),
     makeRawOverflowPage,
     unsafeMakeRawOverflowPage,
     rawOverflowPageRawBytes,

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveFunctor  #-}
 {-# LANGUAGE NamedFieldPuns #-}
 module Database.LSMTree.Internal.RawPage (
-    RawPage,
+    RawPage (..),
     emptyRawPage,
     makeRawPage,
     unsafeMakeRawPage,

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -77,7 +77,6 @@ import qualified Database.LSMTree.Internal.RunBuilder as Builder
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
-import           NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS)
 import qualified System.FS.BlockIO.API as FS
@@ -110,9 +109,6 @@ data Run m fhandle = Run {
     , runBlobFile       :: !fhandle
     , runRunDataCaching :: !RunDataCaching
     }
-
--- TODO: provide a proper instance that checks NoThunks for each field.
-deriving via OnlyCheckWhnfNamed "Run" (Run m h) instance NoThunks (Run m h)
 
 instance NFData fhandle => NFData (Run m fhandle) where
   rnf (Run a b c d e f g h) =

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -1,7 +1,7 @@
 -- | A run that is being read incrementally.
 --
 module Database.LSMTree.Internal.RunReader (
-    RunReader
+    RunReader (..)
   , new
   , next
   , close

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -1,5 +1,7 @@
 module Database.LSMTree.Internal.RunReaders (
     Readers (..)
+  , ReaderNumber (..)
+  , ReadCtx (..)
   , new
   , close
   , peekKey

--- a/src/Database/LSMTree/Internal/UniqCounter.hs
+++ b/src/Database/LSMTree/Internal/UniqCounter.hs
@@ -1,5 +1,5 @@
 module Database.LSMTree.Internal.UniqCounter (
-  UniqCounter,
+  UniqCounter (..),
   newUniqCounter,
   incrUniqCounter,
   Unique,

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -33,13 +33,13 @@ module Database.LSMTree.Monoidal (
   , Common.MergeTrace (..)
 
     -- * Table sessions
-  , Session
+  , Session (..)
   , withSession
   , openSession
   , closeSession
 
     -- * Table handles
-  , TableHandle
+  , TableHandle (..)
   , Common.TableConfig (..)
   , Common.defaultTableConfig
   , Common.SizeRatio (..)

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -33,13 +33,13 @@ module Database.LSMTree.Monoidal (
   , Common.MergeTrace (..)
 
     -- * Table sessions
-  , Session (..)
+  , Session
   , withSession
   , openSession
   , closeSession
 
     -- * Table handles
-  , TableHandle (..)
+  , TableHandle
   , Common.TableConfig (..)
   , Common.defaultTableConfig
   , Common.SizeRatio (..)
@@ -127,9 +127,8 @@ import           Data.Monoid (Sum (..))
 import           Data.Proxy (Proxy (Proxy))
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (IOLike, Range (..), SerialiseKey,
-                     SerialiseValue (..), Session (..), SnapshotName,
-                     closeSession, deleteSnapshot, listSnapshots, openSession,
-                     withSession)
+                     SerialiseValue (..), Session, SnapshotName, closeSession,
+                     deleteSnapshot, listSnapshots, openSession, withSession)
 import qualified Database.LSMTree.Common as Common
 import qualified Database.LSMTree.Internal as Internal
 import qualified Database.LSMTree.Internal.Entry as Entry
@@ -158,11 +157,7 @@ import qualified Database.LSMTree.Internal.Vector as V
 -- will be operated upon. In this API it identifies a single mutable instance of
 -- an LSM table. The multiple-handles feature allows for there to may be many
 -- such instances in use at once.
-type TableHandle :: (Type -> Type) -> Type -> Type -> Type
-data TableHandle m k v = forall h. TableHandle !(Internal.TableHandle m h)
-
-instance NFData (TableHandle m k v) where
-  rnf (TableHandle th) = rnf th
+type TableHandle = Internal.MonoidalTable
 
 {-# SPECIALISE withTable :: Session IO -> Common.TableConfig -> (TableHandle IO k v -> IO a) -> IO a #-}
 -- | (Asynchronous) exception-safe, bracketed opening and closing of a table.
@@ -175,9 +170,9 @@ withTable ::
   -> Common.TableConfig
   -> (TableHandle m k v -> m a)
   -> m a
-withTable (Session sesh) conf action =
+withTable (Internal.Session' sesh) conf action =
     Internal.withTable sesh conf $
-      action . TableHandle
+      action . Internal.MonoidalTable
 
 {-# SPECIALISE new :: Session IO -> Common.TableConfig -> IO (TableHandle IO k v) #-}
 -- | Create a new empty table, returning a fresh table handle.
@@ -190,7 +185,7 @@ new ::
   => Session m
   -> Common.TableConfig
   -> m (TableHandle m k v)
-new (Session sesh) conf = TableHandle <$> Internal.new sesh conf
+new (Internal.Session' sesh) conf = Internal.MonoidalTable <$> Internal.new sesh conf
 
 {-# SPECIALISE close :: TableHandle IO k v -> IO () #-}
 -- | Close a table handle. 'close' is idempotent. All operations on a closed
@@ -203,7 +198,7 @@ close ::
      IOLike m
   => TableHandle m k v
   -> m ()
-close (TableHandle th) = Internal.close th
+close (Internal.MonoidalTable th) = Internal.close th
 
 {-------------------------------------------------------------------------------
   Table queries
@@ -218,7 +213,7 @@ lookups ::
   => V.Vector k
   -> TableHandle m k v
   -> m (V.Vector (LookupResult v))
-lookups ks (TableHandle th) =
+lookups ks (Internal.MonoidalTable th) =
     V.mapStrict (fmap Internal.deserialiseValue) <$!>
     Internal.lookups
       (resolve @v Proxy)
@@ -258,7 +253,7 @@ rangeLookup = undefined
 -- Once a cursor has been created, updates to the referenced table don't affect
 -- the cursor.
 type Cursor :: (Type -> Type) -> Type -> Type -> Type
-data Cursor m k v = forall h. Cursor !(Internal.Cursor m h)
+type Cursor = Internal.MonoidalCursor
 
 {-# SPECIALISE withCursor :: TableHandle IO k v -> (Cursor IO k v -> IO a) -> IO a #-}
 -- | (Asynchronous) exception-safe, bracketed opening and closing of a cursor.
@@ -285,7 +280,7 @@ newCursor ::
      IOLike m
   => TableHandle m k v
   -> m (Cursor m k v)
-newCursor (TableHandle th) = Cursor <$> Internal.newCursor th
+newCursor (Internal.MonoidalTable th) = Internal.MonoidalCursor <$> Internal.newCursor th
 
 {-# SPECIALISE closeCursor :: Cursor IO k v -> IO () #-}
 -- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed
@@ -294,7 +289,7 @@ closeCursor ::
      IOLike m
   => Cursor m k v
   -> m ()
-closeCursor (Cursor c) = Internal.closeCursor c
+closeCursor (Internal.MonoidalCursor c) = Internal.closeCursor c
 
 {-# SPECIALISE readCursor :: (SerialiseKey k, SerialiseValue v, ResolveValue v) => Int -> Cursor IO k v -> IO (V.Vector (QueryResult k v)) #-}
 -- | Read the next @n@ entries from the cursor. The resulting vector is shorter
@@ -329,7 +324,7 @@ updates ::
   => V.Vector (k, Update v)
   -> TableHandle m k v
   -> m ()
-updates es (TableHandle th) = do
+updates es (Internal.MonoidalTable th) = do
     Internal.updates
       (resolve @v Proxy)
       (V.mapStrict serialiseEntry es)
@@ -406,7 +401,7 @@ snapshot ::
   => SnapshotName
   -> TableHandle m k v
   -> m ()
-snapshot snap (TableHandle th) =
+snapshot snap (Internal.MonoidalTable th) =
     void $ Internal.snapshot (resolve @v Proxy) snap label th
   where
     -- to ensure we don't open a monoidal table as normal later
@@ -444,8 +439,8 @@ open ::
   -> Common.TableConfigOverride -- ^ Optional config override
   -> SnapshotName
   -> m (TableHandle m k v)
-open (Session sesh) override snap =
-    TableHandle <$> Internal.open sesh label override snap
+open (Internal.Session' sesh) override snap =
+    Internal.MonoidalTable <$> Internal.open sesh label override snap
   where
     -- to ensure that the table is really a monoidal table
     label = Common.makeSnapshotLabel (Proxy @(k, v)) <> " (monoidal)"
@@ -490,7 +485,7 @@ duplicate ::
      IOLike m
   => TableHandle m k v
   -> m (TableHandle m k v)
-duplicate (TableHandle th) = TableHandle <$> Internal.duplicate th
+duplicate (Internal.MonoidalTable th) = Internal.MonoidalTable <$> Internal.duplicate th
 
 {-------------------------------------------------------------------------------
   Merging tables

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -356,7 +356,7 @@ newCursor ::
      IOLike m
   => TableHandle m k v blob
   -> m (Cursor m k v blob)
-newCursor (TableHandle th) = Cursor <$> Internal.newCursor th
+newCursor (TableHandle th) = Cursor <$!> Internal.newCursor th
 
 {-# SPECIALISE closeCursor :: Cursor IO k v blob -> IO () #-}
 -- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed
@@ -527,7 +527,7 @@ open ::
   -> SnapshotName
   -> m (TableHandle m k v blob)
 open (Session sesh) override snap =
-    TableHandle <$> Internal.open sesh label override snap
+    TableHandle <$!> Internal.open sesh label override snap
   where
     -- to ensure that the table is really a normal table
     label = Common.makeSnapshotLabel (Proxy @(k, v, blob)) <> " (normal)"
@@ -571,4 +571,4 @@ duplicate ::
      IOLike m
   => TableHandle m k v blob
   -> m (TableHandle m k v blob)
-duplicate (TableHandle th) = TableHandle <$> Internal.duplicate th
+duplicate (TableHandle th) = TableHandle <$!> Internal.duplicate th

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -32,13 +32,13 @@ module Database.LSMTree.Normal (
   , Common.MergeTrace (..)
 
     -- * Table sessions
-  , Session
+  , Session (..)
   , withSession
   , openSession
   , closeSession
 
     -- * Table handles
-  , TableHandle
+  , TableHandle (..)
   , Common.TableConfig (..)
   , Common.defaultTableConfig
   , Common.SizeRatio (..)

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -32,13 +32,13 @@ module Database.LSMTree.Normal (
   , Common.MergeTrace (..)
 
     -- * Table sessions
-  , Session (..)
+  , Session
   , withSession
   , openSession
   , closeSession
 
     -- * Table handles
-  , TableHandle (..)
+  , TableHandle
   , Common.TableConfig (..)
   , Common.defaultTableConfig
   , Common.SizeRatio (..)
@@ -109,14 +109,13 @@ module Database.LSMTree.Normal (
   , IOLike
   ) where
 
-import           Control.DeepSeq (NFData (..))
 import           Control.Monad
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Kind (Type)
-import           Data.Typeable (Proxy (..), Typeable)
+import           Data.Typeable (Proxy (..))
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (BlobRef (BlobRef), IOLike, Range (..),
-                     SerialiseKey, SerialiseValue, Session (..), SnapshotName,
+                     SerialiseKey, SerialiseValue, Session, SnapshotName,
                      closeSession, deleteSnapshot, listSnapshots, openSession,
                      withSession)
 import qualified Database.LSMTree.Common as Common
@@ -231,12 +230,7 @@ import qualified Database.LSMTree.Internal.Vector as V
 -- will be operated upon. In this API it identifies a single mutable instance of
 -- an LSM table. The multiple-handles feature allows for there to may be many
 -- such instances in use at once.
-type TableHandle :: (Type -> Type) -> Type -> Type -> Type -> Type
-data TableHandle m k v blob = forall h. Typeable h =>
-    TableHandle !(Internal.TableHandle m h)
-
-instance NFData (TableHandle m k v blob) where
-  rnf (TableHandle th) = rnf th
+type TableHandle = Internal.NormalTable
 
 {-# SPECIALISE withTable :: Session IO -> Common.TableConfig -> (TableHandle IO k v blob -> IO a) -> IO a #-}
 -- | (Asynchronous) exception-safe, bracketed opening and closing of a table.
@@ -249,8 +243,8 @@ withTable ::
   -> Common.TableConfig
   -> (TableHandle m k v blob -> m a)
   -> m a
-withTable (Session sesh) conf action =
-    Internal.withTable sesh conf (action . TableHandle)
+withTable (Internal.Session' sesh) conf action =
+    Internal.withTable sesh conf (action . Internal.NormalTable)
 
 {-# SPECIALISE new :: Session IO -> Common.TableConfig -> IO (TableHandle IO k v blob) #-}
 -- | Create a new empty table, returning a fresh table handle.
@@ -263,7 +257,7 @@ new ::
   => Session m
   -> Common.TableConfig
   -> m (TableHandle m k v blob)
-new (Session sesh) conf = TableHandle <$> Internal.new sesh conf
+new (Internal.Session' sesh) conf = Internal.NormalTable <$> Internal.new sesh conf
 
 {-# SPECIALISE close :: TableHandle IO k v blob -> IO () #-}
 -- | Close a table handle. 'close' is idempotent. All operations on a closed
@@ -276,7 +270,7 @@ close ::
      IOLike m
   => TableHandle m k v blob
   -> m ()
-close (TableHandle th) = Internal.close th
+close (Internal.NormalTable th) = Internal.close th
 
 {-------------------------------------------------------------------------------
   Table queries
@@ -291,7 +285,7 @@ lookups ::
   => V.Vector k
   -> TableHandle m k v blob
   -> m (V.Vector (LookupResult v (BlobRef m blob)))
-lookups ks (TableHandle th) =
+lookups ks (Internal.NormalTable th) =
     V.mapStrict (bimap Internal.deserialiseValue BlobRef) <$!>
     Internal.lookups const (V.map Internal.serialiseKey ks) th toNormalLookupResult
 
@@ -328,8 +322,7 @@ rangeLookup = undefined
 -- Once a cursor has been created, updates to the referenced table don't affect
 -- the cursor.
 type Cursor :: (Type -> Type) -> Type -> Type -> Type -> Type
-data Cursor m k v blob = forall h. Typeable h =>
-    Cursor !(Internal.Cursor m h)
+type Cursor = Internal.NormalCursor
 
 {-# SPECIALISE withCursor :: TableHandle IO k v blob -> (Cursor IO k v blob -> IO a) -> IO a #-}
 -- | (Asynchronous) exception-safe, bracketed opening and closing of a cursor.
@@ -341,7 +334,7 @@ withCursor ::
   => TableHandle m k v blob
   -> (Cursor m k v blob -> m a)
   -> m a
-withCursor (TableHandle th) action = Internal.withCursor th (action . Cursor)
+withCursor (Internal.NormalTable th) action = Internal.withCursor th (action . Internal.NormalCursor)
 
 {-# SPECIALISE newCursor :: TableHandle IO k v blob -> IO (Cursor IO k v blob) #-}
 -- | Create a new cursor to read from a given table. Future updates to the table
@@ -356,7 +349,7 @@ newCursor ::
      IOLike m
   => TableHandle m k v blob
   -> m (Cursor m k v blob)
-newCursor (TableHandle th) = Cursor <$!> Internal.newCursor th
+newCursor (Internal.NormalTable th) = Internal.NormalCursor <$!> Internal.newCursor th
 
 {-# SPECIALISE closeCursor :: Cursor IO k v blob -> IO () #-}
 -- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed
@@ -365,7 +358,7 @@ closeCursor ::
      IOLike m
   => Cursor m k v blob
   -> m ()
-closeCursor (Cursor c) = Internal.closeCursor c
+closeCursor (Internal.NormalCursor c) = Internal.closeCursor c
 
 {-# SPECIALISE readCursor :: (SerialiseKey k, SerialiseValue v) => Int -> Cursor IO k v blob -> IO (V.Vector (QueryResult k v (BlobRef IO blob))) #-}
 -- | Read the next @n@ entries from the cursor. The resulting vector is shorter
@@ -400,7 +393,7 @@ updates ::
   => V.Vector (k, Update v blob)
   -> TableHandle m k v blob
   -> m ()
-updates es (TableHandle th) = do
+updates es (Internal.NormalTable th) = do
     Internal.updates const (V.mapStrict serialiseEntry es) th
   where
     serialiseEntry = bimap Internal.serialiseKey serialiseOp
@@ -490,7 +483,7 @@ snapshot ::
   => SnapshotName
   -> TableHandle m k v blob
   -> m ()
-snapshot snap (TableHandle th) = void $ Internal.snapshot const snap label th
+snapshot snap (Internal.NormalTable th) = void $ Internal.snapshot const snap label th
   where
     -- to ensure we don't open a normal table as monoidal later
     label = Common.makeSnapshotLabel (Proxy @(k, v, blob)) <> " (normal)"
@@ -526,8 +519,8 @@ open ::
   -> Common.TableConfigOverride -- ^ Optional config override
   -> SnapshotName
   -> m (TableHandle m k v blob)
-open (Session sesh) override snap =
-    TableHandle <$!> Internal.open sesh label override snap
+open (Internal.Session' sesh) override snap =
+    Internal.NormalTable <$!> Internal.open sesh label override snap
   where
     -- to ensure that the table is really a normal table
     label = Common.makeSnapshotLabel (Proxy @(k, v, blob)) <> " (normal)"
@@ -571,4 +564,4 @@ duplicate ::
      IOLike m
   => TableHandle m k v blob
   -> m (TableHandle m k v blob)
-duplicate (TableHandle th) = TableHandle <$!> Internal.duplicate th
+duplicate (Internal.NormalTable th) = Internal.NormalTable <$!> Internal.duplicate th


### PR DESCRIPTION
# Description

This PR adds proper `NoThunks` instances for most of the datatypes in our library as orphans in the `extras` sub-library. *Only* the `StateMachine` tests will now check for `NoThunks`, and the PR includes some fixes for failing `NoThunks` assertions.

# Checklist

- [ ] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

