### PR TITLE
Tighten the imports of the chunk testing module

### DIFF
--- a/test/Test/Database/LSMTree/Internal/Chunk.hs
+++ b/test/Test/Database/LSMTree/Internal/Chunk.hs
@@ -4,7 +4,7 @@ module Test.Database.LSMTree.Internal.Chunk (tests) where
 
 import           Prelude hiding (concat, drop, length)
 
-import           Control.Arrow ((>>>))
+import           Control.Category ((>>>))
 import           Control.Monad.ST.Strict (runST)
 import qualified Data.List as List (concat, drop, length)
 import           Data.Maybe (catMaybes, fromJust, isJust, isNothing)


### PR DESCRIPTION
This modifies the import list of the chunk testing module such that `(>>>)` is imported via `Control.Category` instead of `Control.Arrow`, which effectively reduces the number of modules to be imported.
