### PR TITLE
Partial implementation of retrieveBlobs in the public API

### DIFF
--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -27,6 +27,12 @@ data RefCounter m = RefCounter {
   , finaliser :: !(Maybe (m ()))
   }
 
+instance Eq (RefCounter m) where
+  a == b = countVar a == countVar b
+
+instance Show (RefCounter m) where
+  show _ = "<RefCounter>"
+
 -- | NOTE: Only strict in the variable and not the referenced value.
 instance NFData (RefCounter m) where
   rnf RefCounter{countVar, finaliser} =

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -8,6 +8,7 @@ module Control.RefCount (
   , mkRefCounter1
   , addReference
   , removeReference
+  , upgradeWeakReference
   , readRefCount
   ) where
 
@@ -65,6 +66,10 @@ mkRefCounter1 finaliser = fromJust <$> mkRefCounterN (RefCount 1) finaliser
 
 {-# SPECIALISE addReference :: RefCounter IO -> IO () #-}
 -- | Increase the reference counter by one.
+--
+-- The count must be known (from context) to be non-zero already. Typically
+-- this will be because the caller has a reference already and is handing out
+-- another reference to some other code.
 addReference :: PrimMonad m => RefCounter m -> m ()
 addReference RefCounter{countVar} = do
     prevCount <- fetchAddInt countVar 1
@@ -72,11 +77,46 @@ addReference RefCounter{countVar} = do
 
 {-# SPECIALISE removeReference :: RefCounter IO -> IO () #-}
 -- | Decrease the reference counter by one.
+--
+-- The count must be known (from context) to be non-zero. Typically this will
+-- be because the caller has a reference already (that they took out themselves
+-- or were given).
 removeReference :: (PrimMonad m, MonadMask m) => RefCounter m -> m ()
 removeReference RefCounter{countVar, finaliser} = mask_ $ do
     prevCount <- fetchSubInt countVar 1
     assert (prevCount > 0) $ pure ()
     when (prevCount == 1) $ sequence_ finaliser
+
+-- | Try to turn a \"weak\" reference on something into a proper reference.
+-- This is by analogy with @deRefWeak :: Weak v -> IO (Maybe v)@, but for
+-- reference counts.
+--
+-- This amounts to trying to increase the reference count, but if it is already
+-- zero then this will fail. And unlike with 'addReference' where such failure
+-- would be a programmer error, this corresponds to the case when the thing the
+-- reference count is tracking has been closed already.
+--
+-- The result is @True@ when a strong reference has been obtained and @False@
+-- when upgrading fails.
+--
+upgradeWeakReference :: PrimMonad m => RefCounter m -> m Bool
+upgradeWeakReference RefCounter{countVar} = do
+    prevCount <- atomicReadInt countVar
+    casLoop prevCount
+  where
+    -- A classic lock-free CAS loop.
+    -- Check the value before is non-zero, return failure or continue.
+    -- Atomically write the new (incremented) value if the old value is
+    -- unchanged, and return the old value (either way).
+    -- If no other thread changed the old value, we succeed.
+    -- Otherwise we go round the loop again.
+    casLoop prevCount
+      | prevCount <= 0 = return False
+      | otherwise      = do
+          prevCount' <- casInt countVar prevCount (prevCount+1)
+          if prevCount' == prevCount
+            then return True
+            else casLoop prevCount'
 
 {-# SPECIALISE readRefCount :: RefCounter IO -> IO RefCount #-}
 -- | Warning: reading the current reference count is inherently racy as there is

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -275,8 +275,8 @@ deriving anyclass instance NoThunks RawOverflowPage
   BlobRef
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (BlobRef r)
-deriving anyclass instance NoThunks r => NoThunks (BlobRef r)
+deriving stock instance Generic (BlobRef m h)
+deriving anyclass instance NoThunks h => NoThunks (BlobRef m h)
 
 deriving stock instance Generic BlobSpan
 deriving anyclass instance NoThunks BlobSpan

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -61,7 +61,7 @@ import qualified Database.LSMTree.Internal.Paths as Internal
 import qualified Database.LSMTree.Internal.Range as Internal
 import qualified Database.LSMTree.Internal.Run as Internal
 import           Database.LSMTree.Internal.Serialise.Class
-import           System.FS.API (FsPath, HasFS)
+import           System.FS.API (FsPath, HasFS, Handle)
 import           System.FS.BlockIO.API (HasBlockIO)
 import           System.FS.IO (HandleIO)
 
@@ -239,4 +239,4 @@ listSnapshots (Internal.Session' sesh) = Internal.listSnapshots sesh
 -- TODO: get rid of the @m@ parameter?
 type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal
-data BlobRef m blob = forall h. Typeable h => BlobRef (Internal.BlobRef (Internal.Run m h))
+data BlobRef m blob = forall h. Typeable h => BlobRef (Internal.BlobRef (Internal.Run m (Handle h)))

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -61,7 +61,7 @@ import qualified Database.LSMTree.Internal.Paths as Internal
 import qualified Database.LSMTree.Internal.Range as Internal
 import qualified Database.LSMTree.Internal.Run as Internal
 import           Database.LSMTree.Internal.Serialise.Class
-import           System.FS.API (FsPath, HasFS, Handle)
+import           System.FS.API (FsPath, Handle, HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
 import           System.FS.IO (HandleIO)
 

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -59,7 +59,6 @@ import qualified Database.LSMTree.Internal.Entry as Internal
 import qualified Database.LSMTree.Internal.MergeSchedule as Internal
 import qualified Database.LSMTree.Internal.Paths as Internal
 import qualified Database.LSMTree.Internal.Range as Internal
-import qualified Database.LSMTree.Internal.Run as Internal
 import           Database.LSMTree.Internal.Serialise.Class
 import           System.FS.API (FsPath, Handle, HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
@@ -239,4 +238,5 @@ listSnapshots (Internal.Session' sesh) = Internal.listSnapshots sesh
 -- TODO: get rid of the @m@ parameter?
 type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal
-data BlobRef m blob = forall h. Typeable h => BlobRef (Internal.BlobRef (Internal.Run m (Handle h)))
+data BlobRef m blob where
+    BlobRef :: Typeable h => Internal.BlobRef m (Handle h) -> BlobRef m blob

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP       #-}
 {-# LANGUAGE DataKinds #-}
+{- HLINT ignore "Use unless" -}
 
 module Database.LSMTree.Internal (
     -- * Existentials
@@ -90,7 +91,7 @@ import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
 import           Database.LSMTree.Internal.RunNumber
 import qualified Database.LSMTree.Internal.RunReaders as Readers
-import           Database.LSMTree.Internal.Serialise (SerialisedBlob(..),
+import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..),
                      SerialisedKey, SerialisedValue)
 import           Database.LSMTree.Internal.UniqCounter
 import qualified Database.LSMTree.Internal.Vector as V

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -5,23 +5,35 @@
 module Database.LSMTree.Internal.BlobRef (
     BlobRef (..)
   , BlobSpan (..)
+  , blobRefSpanSize
+  , readBlob
+  , readBlobIOOp
   ) where
 
 import           Control.DeepSeq (NFData (..))
+import           Control.RefCount (RefCounter)
+import qualified Data.Primitive.ByteArray as P (MutableByteArray,
+                     newPinnedByteArray, unsafeFreezeByteArray)
 import           Data.Word (Word32, Word64)
+import qualified Database.LSMTree.Internal.RawBytes as RB
+import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..))
+import qualified System.FS.API as FS
+import           System.FS.API (HasFS)
+import qualified System.FS.BlockIO.API as FS
 
 -- | A handle-like reference to an on-disk blob. The blob can be retrieved based
 -- on the reference.
 --
 -- See 'Database.LSMTree.Common.BlobRef' for more info.
-data BlobRef run = BlobRef {
-      blobRefRun  :: !run
-    , blobRefSpan :: {-# UNPACK #-} !BlobSpan
+data BlobRef m h = BlobRef {
+      blobRefFile  :: !h
+    , blobRefCount :: {-# UNPACK #-} !(RefCounter m)
+    , blobRefSpan  :: {-# UNPACK #-} !BlobSpan
     }
   deriving stock (Eq, Show)
 
-instance NFData run => NFData (BlobRef run) where
-  rnf (BlobRef a b) = rnf a `seq` rnf b
+instance NFData h => NFData (BlobRef m h) where
+  rnf (BlobRef a b c) = rnf a `seq` rnf b `seq` rnf c
 
 -- | Location of a blob inside a blob file.
 data BlobSpan = BlobSpan {
@@ -32,3 +44,37 @@ data BlobSpan = BlobSpan {
 
 instance NFData BlobSpan where
   rnf (BlobSpan a b) = rnf a `seq` rnf b
+
+blobRefSpanSize :: BlobRef m h -> Int
+blobRefSpanSize = fromIntegral . blobSpanSize . blobRefSpan
+
+-- | The 'BlobSpan' to read must come from this run!
+readBlob :: HasFS IO h -> BlobRef m (FS.Handle h) -> IO SerialisedBlob
+readBlob fs BlobRef {
+              blobRefFile,
+              blobRefSpan = BlobSpan {blobSpanOffset, blobSpanSize}
+            } = do
+    let off = FS.AbsOffset blobSpanOffset
+        len :: Int
+        len = fromIntegral blobSpanSize
+    mba <- P.newPinnedByteArray len
+    _ <- FS.hGetBufExactlyAt fs blobRefFile mba 0
+                             (fromIntegral len :: FS.ByteCount) off
+    ba <- P.unsafeFreezeByteArray mba
+    let !rb = RB.fromByteArray 0 len ba
+    return (SerialisedBlob rb)
+
+readBlobIOOp :: P.MutableByteArray s -> Int
+             -> BlobRef m (FS.Handle h)
+             -> FS.IOOp s h
+readBlobIOOp buf bufoff
+             BlobRef {
+               blobRefFile,
+               blobRefSpan = BlobSpan {blobSpanOffset, blobSpanSize}
+             } =
+    FS.IOOpRead
+      blobRefFile
+      (fromIntegral blobSpanOffset :: FS.FileOffset)
+      buf (FS.BufferOffset bufoff)
+      (fromIntegral blobSpanSize :: FS.ByteCount)
+

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -63,9 +63,9 @@ import qualified Control.RefCount as RC
 import           Data.BloomFilter (Bloom)
 import qualified Data.ByteString.Short as SBS
 import           Data.Foldable (for_)
-import qualified Data.Primitive.ByteArray as P (MutableByteArray, newPinnedByteArray,
-                     unsafeFreezeByteArray)
-import           Database.LSMTree.Internal.BlobRef (BlobRef(..), BlobSpan(..))
+import qualified Data.Primitive.ByteArray as P (MutableByteArray,
+                     newPinnedByteArray, unsafeFreezeByteArray)
+import           Database.LSMTree.Internal.BlobRef (BlobRef (..), BlobSpan (..))
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterFromSBS)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry (NumEntries (..))

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -44,9 +44,7 @@ module Database.LSMTree.Internal.Run (
   , sizeInPages
   , addReference
   , removeReference
-  , upgradeWeakReference
-  , readBlob
-  , readBlobIOOp
+  , mkBlobRefForRun
     -- ** Run creation
   , fromMutable
   , fromWriteBuffer
@@ -63,8 +61,6 @@ import qualified Control.RefCount as RC
 import           Data.BloomFilter (Bloom)
 import qualified Data.ByteString.Short as SBS
 import           Data.Foldable (for_)
-import qualified Data.Primitive.ByteArray as P (MutableByteArray,
-                     newPinnedByteArray, unsafeFreezeByteArray)
 import           Database.LSMTree.Internal.BlobRef (BlobRef (..), BlobSpan (..))
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterFromSBS)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
@@ -72,7 +68,6 @@ import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import           Database.LSMTree.Internal.IndexCompact (IndexCompact, NumPages)
 import qualified Database.LSMTree.Internal.IndexCompact as Index
 import           Database.LSMTree.Internal.Paths
-import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc)
 import           Database.LSMTree.Internal.RunBuilder (RunBuilder)
 import qualified Database.LSMTree.Internal.RunBuilder as Builder
@@ -124,43 +119,18 @@ sizeInPages = Index.sizeInPages . runIndex
 addReference :: PrimMonad m => Run m h -> m ()
 addReference r = RC.addReference (runRefCounter r)
 
-{-# SPECIALISE upgradeWeakReference :: Run IO h -> IO Bool #-}
-upgradeWeakReference :: PrimMonad m => Run m h -> m Bool
-upgradeWeakReference r = RC.upgradeWeakReference (runRefCounter r)
-
 {-# SPECIALISE removeReference :: Run IO h -> IO () #-}
 removeReference :: (PrimMonad m, MonadMask m) => Run m h -> m ()
 removeReference r = RC.removeReference (runRefCounter r)
 
--- | The 'BlobSpan' to read must come from this run!
-readBlob :: HasFS IO h -> BlobRef (Run m (FS.Handle h)) -> IO SerialisedBlob
-readBlob fs BlobRef {
-              blobRefRun  = Run {runBlobFile},
-              blobRefSpan = BlobSpan {blobSpanOffset, blobSpanSize}
-            } = do
-    let off = FS.AbsOffset blobSpanOffset
-        len :: Int
-        len = fromIntegral blobSpanSize
-    mba <- P.newPinnedByteArray len
-    _ <- FS.hGetBufExactlyAt fs runBlobFile mba 0
-                             (fromIntegral len :: FS.ByteCount) off
-    ba <- P.unsafeFreezeByteArray mba
-    let !rb = RB.fromByteArray 0 len ba
-    return (SerialisedBlob rb)
-
-readBlobIOOp :: P.MutableByteArray s -> Int
-             -> BlobRef (Run m (FS.Handle h))
-             -> FS.IOOp s h
-readBlobIOOp buf bufoff
-             BlobRef {
-               blobRefRun  = Run {runBlobFile},
-               blobRefSpan = BlobSpan {blobSpanOffset, blobSpanSize}
-             } =
-    FS.IOOpRead
-      runBlobFile
-      (fromIntegral blobSpanOffset :: FS.FileOffset)
-      buf (FS.BufferOffset bufoff)
-      (fromIntegral blobSpanSize :: FS.ByteCount)
+-- | Helper function to make a 'BlobRef' that points into a 'Run'.
+mkBlobRefForRun :: Run m h -> BlobSpan -> BlobRef m h
+mkBlobRefForRun Run{runBlobFile, runRefCounter} blobRefSpan =
+    BlobRef {
+      blobRefFile  = runBlobFile,
+      blobRefCount = runRefCounter,
+      blobRefSpan
+    }
 
 -- | Close the files used in the run, but do not remove them from disk.
 -- After calling this operation, the run must not be used anymore.

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -44,6 +44,7 @@ module Database.LSMTree.Internal.Run (
   , sizeInPages
   , addReference
   , removeReference
+  , upgradeWeakReference
   , readBlob
     -- ** Run creation
   , fromMutable
@@ -121,6 +122,10 @@ sizeInPages = Index.sizeInPages . runIndex
 {-# SPECIALISE addReference :: Run IO h -> IO () #-}
 addReference :: PrimMonad m => Run m h -> m ()
 addReference r = RC.addReference (runRefCounter r)
+
+{-# SPECIALISE upgradeWeakReference :: Run IO h -> IO Bool #-}
+upgradeWeakReference :: PrimMonad m => Run m h -> m Bool
+upgradeWeakReference r = RC.upgradeWeakReference (runRefCounter r)
 
 {-# SPECIALISE removeReference :: Run IO h -> IO () #-}
 removeReference :: (PrimMonad m, MonadMask m) => Run m h -> m ()

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -164,7 +164,7 @@ lookups ::
 lookups (WB !m) !ks = V.mapStrict (`Map.lookup` m) ks
 
 -- | TODO: update once blob references are implemented
-lookup :: WriteBuffer -> SerialisedKey -> Maybe (Entry SerialisedValue (BlobRef run))
+lookup :: WriteBuffer -> SerialisedKey -> Maybe (Entry SerialisedValue (BlobRef m h))
 lookup (WB !m) !k = case Map.lookup k m of
     Nothing -> Nothing
     Just x  -> Just $! errOnBlob x
@@ -174,7 +174,7 @@ lookup (WB !m) !k = case Map.lookup k m of
 lookups' ::
      WriteBuffer
   -> V.Vector SerialisedKey
-  -> V.Vector (Maybe (Entry SerialisedValue (BlobRef run)))
+  -> V.Vector (Maybe (Entry SerialisedValue (BlobRef m h)))
 lookups' wb !ks = V.mapStrict (lookup wb) ks
 
 -- | TODO: remove once blob references are implemented

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -438,10 +438,10 @@ retrieveBlobs ::
   -> m (V.Vector blob)
 retrieveBlobs (Internal.Session' sesh) refs =
     V.map Internal.deserialiseBlob <$>
-      Internal.retrieveBlobs sesh (V.map checkBlobRefType refs)
+      Internal.retrieveBlobs sesh (V.imap checkBlobRefType refs)
   where
-    checkBlobRefType (BlobRef ref) | Just ref' <- cast ref = ref'
-    checkBlobRefType _ = throw Internal.ErrBlobRefInvalid
+    checkBlobRefType _ (BlobRef ref) | Just ref' <- cast ref = ref'
+    checkBlobRefType i _ = throw (Internal.ErrBlobRefInvalid i)
 
 {-------------------------------------------------------------------------------
   Snapshots

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -36,7 +36,7 @@ import           Control.RefCount (RefCount (..), readRefCount)
 import           Database.LSMTree.Extras (showPowersOf10)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..),
                      TypedWriteBuffer (..))
-import           Database.LSMTree.Internal.BlobRef (BlobRef (..), BlobSpan (..))
+import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Normal as N
@@ -269,7 +269,5 @@ readKOps fs hbio run = do
       Reader.next fs hbio reader >>= \case
         Reader.Empty -> return []
         Reader.ReadEntry key e -> do
-          e' <- traverse resolveBlob $ Reader.toFullEntry e
+          e' <- traverse (readBlob fs) $ Reader.toFullEntry e
           ((key, e') :) <$> go reader
-
-    resolveBlob (BlobRef r s) = readBlob fs r s

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -36,7 +36,7 @@ import           Control.RefCount (RefCount (..), readRefCount)
 import           Database.LSMTree.Extras (showPowersOf10)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..),
                      TypedWriteBuffer (..))
-import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
+import           Database.LSMTree.Internal.BlobRef (BlobSpan (..), readBlob)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Normal as N

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -16,7 +16,6 @@ import           Data.Word (Word64)
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact,
                      TypedWriteBuffer (..))
-import           Database.LSMTree.Internal.BlobRef
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Paths as Paths
 import qualified Database.LSMTree.Internal.Run as Run
@@ -354,8 +353,4 @@ runIO act lu = case act of
                   return (Right x)
 
     toMockEntry :: FS.HasFS IO MockFS.HandleMock -> Reader.Entry IO Handle -> IO SerialisedEntry
-    toMockEntry hfs =
-        traverse loadBlob . Reader.toFullEntry
-      where
-        loadBlob :: BlobRef (Run.Run IO Handle) -> IO SerialisedBlob
-        loadBlob (BlobRef run sp) = Run.readBlob hfs run sp
+    toMockEntry hfs = traverse (Run.readBlob hfs) . Reader.toFullEntry

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -16,6 +16,7 @@ import           Data.Word (Word64)
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact,
                      TypedWriteBuffer (..))
+import           Database.LSMTree.Internal.BlobRef (readBlob)
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Paths as Paths
 import qualified Database.LSMTree.Internal.Run as Run
@@ -353,4 +354,4 @@ runIO act lu = case act of
                   return (Right x)
 
     toMockEntry :: FS.HasFS IO MockFS.HandleMock -> Reader.Entry IO Handle -> IO SerialisedEntry
-    toMockEntry hfs = traverse (Run.readBlob hfs) . Reader.toFullEntry
+    toMockEntry hfs = traverse (readBlob hfs) . Reader.toFullEntry


### PR DESCRIPTION
It is partial because there is no support for BlobRefs in the write buffer yet.

As such it doesn't make a lot of sense to test in this interim state, so this PR does not enable tests for the public API. This can follow once we incorporate WriteBuffer support.