### PR TITLE
Change BlobRef representation to not be specific to Run

### DIFF
--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -27,6 +27,12 @@ data RefCounter m = RefCounter {
   , finaliser :: !(Maybe (m ()))
   }
 
+instance Eq (RefCounter m) where
+  a == b = countVar a == countVar b
+
+instance Show (RefCounter m) where
+  show _ = "<RefCounter>"
+
 -- | NOTE: Only strict in the variable and not the referenced value.
 instance NFData (RefCounter m) where
   rnf RefCounter{countVar, finaliser} =

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -275,8 +275,8 @@ deriving anyclass instance NoThunks RawOverflowPage
   BlobRef
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (BlobRef r)
-deriving anyclass instance NoThunks r => NoThunks (BlobRef r)
+deriving stock instance Generic (BlobRef m h)
+deriving anyclass instance NoThunks h => NoThunks (BlobRef m h)
 
 deriving stock instance Generic BlobSpan
 deriving anyclass instance NoThunks BlobSpan

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -59,7 +59,6 @@ import qualified Database.LSMTree.Internal.Entry as Internal
 import qualified Database.LSMTree.Internal.MergeSchedule as Internal
 import qualified Database.LSMTree.Internal.Paths as Internal
 import qualified Database.LSMTree.Internal.Range as Internal
-import qualified Database.LSMTree.Internal.Run as Internal
 import           Database.LSMTree.Internal.Serialise.Class
 import           System.FS.API (FsPath, Handle, HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
@@ -239,4 +238,5 @@ listSnapshots (Internal.Session' sesh) = Internal.listSnapshots sesh
 -- TODO: get rid of the @m@ parameter?
 type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal
-data BlobRef m blob = forall h. Typeable h => BlobRef (Internal.BlobRef (Internal.Run m (Handle h)))
+data BlobRef m blob where
+    BlobRef :: Typeable h => Internal.BlobRef m (Handle h) -> BlobRef m blob

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -78,7 +78,8 @@ import qualified Data.Set as Set
 import           Data.Typeable
 import qualified Data.Vector as V
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.BlobRef
+import           Database.LSMTree.Internal.BlobRef (BlobRef (..), BlobSpan (..))
+import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry (Entry, combineMaybe)
 import           Database.LSMTree.Internal.Lookup (ByteCountDiscrepancy,
@@ -720,7 +721,7 @@ retrieveBlobs sesh refs =
             bufOffs :: V.Vector Int
             bufOffs = V.scanl (+) 0 (V.map blobRefSpanSize refs)
         buf <- P.newPinnedByteArray bufSize
-        let ioops = V.zipWith (Run.readBlobIOOp buf) bufOffs refs
+        let ioops = V.zipWith (BlobRef.readBlobIOOp buf) bufOffs refs
             hbio  = sessionHasBlockIO seshEnv
 
         -- Submit the IOOps all in one go:

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -5,6 +5,7 @@
 module Database.LSMTree.Internal.BlobRef (
     BlobRef (..)
   , BlobSpan (..)
+  , blobRefSpanSize
   , readBlob
   , readBlobIOOp
   ) where
@@ -43,6 +44,9 @@ data BlobSpan = BlobSpan {
 
 instance NFData BlobSpan where
   rnf (BlobSpan a b) = rnf a `seq` rnf b
+
+blobRefSpanSize :: BlobRef m h -> Int
+blobRefSpanSize = fromIntegral . blobSpanSize . blobRefSpan
 
 -- | The 'BlobSpan' to read must come from this run!
 readBlob :: HasFS IO h -> BlobRef m (FS.Handle h) -> IO SerialisedBlob

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -8,20 +8,22 @@ module Database.LSMTree.Internal.BlobRef (
   ) where
 
 import           Control.DeepSeq (NFData (..))
+import           Control.RefCount (RefCounter)
 import           Data.Word (Word32, Word64)
 
 -- | A handle-like reference to an on-disk blob. The blob can be retrieved based
 -- on the reference.
 --
 -- See 'Database.LSMTree.Common.BlobRef' for more info.
-data BlobRef run = BlobRef {
-      blobRefRun  :: !run
-    , blobRefSpan :: {-# UNPACK #-} !BlobSpan
+data BlobRef m h = BlobRef {
+      blobRefFile  :: !h
+    , blobRefCount :: {-# UNPACK #-} !(RefCounter m)
+    , blobRefSpan  :: {-# UNPACK #-} !BlobSpan
     }
   deriving stock (Eq, Show)
 
-instance NFData run => NFData (BlobRef run) where
-  rnf (BlobRef a b) = rnf a `seq` rnf b
+instance NFData h => NFData (BlobRef m h) where
+  rnf (BlobRef a b c) = rnf a `seq` rnf b `seq` rnf c
 
 -- | Location of a blob inside a blob file.
 data BlobSpan = BlobSpan {

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -215,7 +215,7 @@ writeSerialisedEntry ::
   -> Level
   -> RunBuilder RealWorld (FS.Handle h)
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef (Run IO (FS.Handle h)))
+  -> Entry SerialisedValue (BlobRef IO (FS.Handle h))
   -> IO ()
 writeSerialisedEntry fs level builder key entry =
     when (shouldWriteEntry level entry) $

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -14,7 +14,8 @@ import           Control.Monad.Primitive (RealWorld)
 import           Control.RefCount (RefCount (..))
 import           Data.Coerce (coerce)
 import           Data.Traversable (for)
-import           Database.LSMTree.Internal.BlobRef (BlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (BlobRef)
+import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Run (Run, RunDataCaching)
 import qualified Database.LSMTree.Internal.Run as Run
@@ -199,7 +200,7 @@ writeReaderEntry fs level builder key entry@(Reader.EntryOverflow prefix page _ 
         -- has blob, we can't just copy the first page, fall back
         -- we simply append the overflow pages to the value
         Builder.addKeyOp fs builder key
-          =<< traverse (Run.readBlob fs) (Reader.toFullEntry entry)
+          =<< traverse (BlobRef.readBlob fs) (Reader.toFullEntry entry)
         -- TODO(optimise): This copies the overflow pages unnecessarily.
         -- We could extend the RunBuilder API to allow to either:
         -- 1. write an Entry (containing the value prefix) + [RawOverflowPage]
@@ -219,7 +220,7 @@ writeSerialisedEntry ::
   -> IO ()
 writeSerialisedEntry fs level builder key entry =
     when (shouldWriteEntry level entry) $
-      Builder.addKeyOp fs builder key =<< traverse (Run.readBlob fs) entry
+      Builder.addKeyOp fs builder key =<< traverse (BlobRef.readBlob fs) entry
 
 -- One the last level we could also turn Mupdate into Insert,
 -- but no need to complicate things.

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -164,7 +164,7 @@ lookups ::
 lookups (WB !m) !ks = V.mapStrict (`Map.lookup` m) ks
 
 -- | TODO: update once blob references are implemented
-lookup :: WriteBuffer -> SerialisedKey -> Maybe (Entry SerialisedValue (BlobRef run))
+lookup :: WriteBuffer -> SerialisedKey -> Maybe (Entry SerialisedValue (BlobRef m h))
 lookup (WB !m) !k = case Map.lookup k m of
     Nothing -> Nothing
     Just x  -> Just $! errOnBlob x
@@ -174,7 +174,7 @@ lookup (WB !m) !k = case Map.lookup k m of
 lookups' ::
      WriteBuffer
   -> V.Vector SerialisedKey
-  -> V.Vector (Maybe (Entry SerialisedValue (BlobRef run)))
+  -> V.Vector (Maybe (Entry SerialisedValue (BlobRef m h)))
 lookups' wb !ks = V.mapStrict (lookup wb) ks
 
 -- | TODO: remove once blob references are implemented

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -36,7 +36,7 @@ import           Control.RefCount (RefCount (..), readRefCount)
 import           Database.LSMTree.Extras (showPowersOf10)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..),
                      TypedWriteBuffer (..))
-import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
+import           Database.LSMTree.Internal.BlobRef (BlobSpan (..), readBlob)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Normal as N

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -16,6 +16,7 @@ import           Data.Word (Word64)
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact,
                      TypedWriteBuffer (..))
+import           Database.LSMTree.Internal.BlobRef (readBlob)
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Paths as Paths
 import qualified Database.LSMTree.Internal.Run as Run
@@ -353,4 +354,4 @@ runIO act lu = case act of
                   return (Right x)
 
     toMockEntry :: FS.HasFS IO MockFS.HandleMock -> Reader.Entry IO Handle -> IO SerialisedEntry
-    toMockEntry hfs = traverse (Run.readBlob hfs) . Reader.toFullEntry
+    toMockEntry hfs = traverse (readBlob hfs) . Reader.toFullEntry


### PR DESCRIPTION
The goal is to have a single representation for BlobRefs whether they're from runs or from the write buffer.
    
The intention is that this representation will also be sufficient to cover BlobRefs for blobs from the write buffer, using an open file handle and a suitable reference count.
    
So rather than containing a run it contains a file handle and a reference count.
```diff
- blobRefRun   :: !run
+ blobRefFile  :: !h
+ blobRefCount :: {-# UNPACK #-} !(RefCounter m)
``` 
When making a BlobRef for a run, we just take the blob file handle and the run's reference count.
