### PR TITLE
Clarify distinction between weak and strong BlobRefs

### DIFF
--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -241,7 +241,9 @@ listSnapshots (Internal.Session' sesh) = Internal.listSnapshots sesh
 type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal
 data BlobRef m blob where
-    BlobRef :: Typeable h => Internal.BlobRef m (Handle h) -> BlobRef m blob
+    BlobRef :: Typeable h
+            => Internal.WeakBlobRef m (Handle h)
+            -> BlobRef m blob
 
 instance Show (BlobRef m blob) where
     showsPrec d (BlobRef b) = showsPrec d b

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP       #-}
 {-# LANGUAGE DataKinds #-}
-{- HLINT ignore "Use unless" -}
 
 module Database.LSMTree.Internal (
     -- * Existentials
@@ -60,7 +59,6 @@ import           Control.DeepSeq
 import           Control.Monad (unless, void, when)
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive
-import qualified Control.RefCount as RC
 import           Control.TempRegistry
 import           Control.Tracer
 import           Data.Arena (ArenaManager, newArenaManager)
@@ -78,7 +76,7 @@ import qualified Data.Set as Set
 import           Data.Typeable
 import qualified Data.Vector as V
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.BlobRef (BlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (WeakBlobRef)
 import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry (Entry, combineMaybe)
@@ -638,14 +636,14 @@ close th = do
           pure lvls
         pure TableHandleClosed
 
-{-# SPECIALISE lookups :: ResolveSerialisedValue -> V.Vector SerialisedKey -> TableHandle IO h -> (Maybe (Entry SerialisedValue (BlobRef IO (Handle h))) -> lookupResult) -> IO (V.Vector lookupResult) #-}
+{-# SPECIALISE lookups :: ResolveSerialisedValue -> V.Vector SerialisedKey -> TableHandle IO h -> (Maybe (Entry SerialisedValue (WeakBlobRef IO (Handle h))) -> lookupResult) -> IO (V.Vector lookupResult) #-}
 -- | See 'Database.LSMTree.Normal.lookups'.
 lookups ::
      m ~ IO -- TODO: replace by @io-classes@ constraints for IO simulation.
   => ResolveSerialisedValue
   -> V.Vector SerialisedKey
   -> TableHandle m h
-  -> (Maybe (Entry SerialisedValue (BlobRef m (Handle h))) -> lookupResult)
+  -> (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h))) -> lookupResult)
      -- ^ How to map from an entry to a lookup result.
   -> m (V.Vector lookupResult)
 lookups resolve ks th fromEntry = do
@@ -705,11 +703,12 @@ updates resolve es th = do
 retrieveBlobs ::
      m ~ IO  -- TODO: replace by @io-classes@ constraints for IO simulation.
   => Session m h
-  -> V.Vector (BlobRef m (FS.Handle h))
+  -> V.Vector (WeakBlobRef m (FS.Handle h))
   -> m (V.Vector SerialisedBlob)
-retrieveBlobs sesh refs =
+retrieveBlobs sesh wrefs =
     withOpenSession sesh $ \seshEnv ->
-      bracket_ upgradeWeakReferences removeReferences $ do
+      handle (\(BlobRef.WeakBlobRefInvalid i) -> throwIO (ErrBlobRefInvalid i)) $
+      BlobRef.withWeakBlobRefs wrefs $ \refs -> do
 
         -- Prepare the IOOps:
         -- We use a single large memory buffer, with appropriate offsets within
@@ -737,22 +736,6 @@ retrieveBlobs sesh refs =
                   (\off len -> SerialisedBlob (RB.fromByteArray off len ba))
                   bufOffs
                   (V.map BlobRef.blobRefSpanSize refs)
-  where
-    -- The BlobRef is a weak reference to a blob file. It does not keep the
-    -- file open using a reference count. So we have to upgrade our weak
-    -- reference to a (normal) strong reference while we read the blob, to
-    -- ensure it is not closed under our feet.
-    upgradeWeakReferences =
-      V.imapM_ (\i ref -> do
-                  ok <- RC.upgradeWeakReference (blobRefCount ref)
-                  when (not ok) $ do
-                    -- drop refs on the previous ones taken successfully so far
-                    V.mapM_ (RC.removeReference . blobRefCount) (V.take i refs)
-                    throwIO (ErrBlobRefInvalid i)
-               ) refs
-
-    removeReferences =
-      V.mapM_ (RC.removeReference . blobRefCount) refs
 
 {-------------------------------------------------------------------------------
   Cursors

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -40,7 +40,7 @@ import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word (Word32)
-import           Database.LSMTree.Internal.BlobRef (BlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (WeakBlobRef (..))
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.IndexCompact (IndexCompact,
                      PageSpan (..))
@@ -222,7 +222,7 @@ data ByteCountDiscrepancy = ByteCountDiscrepancy {
     -> V.Vector IndexCompact
     -> V.Vector (Handle h)
     -> V.Vector SerialisedKey
-    -> IO (V.Vector (Maybe (Entry SerialisedValue (BlobRef IO (Handle h)))))
+    -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO (Handle h)))))
   #-}
 -- | Batched lookups in I\/O.
 --
@@ -240,7 +240,7 @@ lookupsIO ::
   -> V.Vector IndexCompact -- ^ The indexes inside @rs@
   -> V.Vector (Handle h) -- ^ The file handles to the key\/value files inside @rs@
   -> V.Vector SerialisedKey
-  -> m (V.Vector (Maybe (Entry SerialisedValue (BlobRef m (Handle h)))))
+  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h)))))
 lookupsIO !hbio !mgr !resolveV !rs !blooms !indexes !kopsFiles !ks = assert precondition $ withArena mgr $ \arena -> do
     (rkixs, ioops) <- Class.stToIO $ prepLookups arena blooms indexes kopsFiles ks
     ioress <- submitIO hbio ioops
@@ -261,7 +261,7 @@ lookupsIO !hbio !mgr !resolveV !rs !blooms !indexes !kopsFiles !ks = assert prec
     -> VU.Vector (RunIx, KeyIx)
     -> V.Vector (IOOp RealWorld h)
     -> VU.Vector IOResult
-    -> IO (V.Vector (Maybe (Entry SerialisedValue (BlobRef IO (Handle h)))))
+    -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO (Handle h)))))
   #-}
 -- | Intra-page lookups.
 --
@@ -276,7 +276,7 @@ intraPageLookups ::
   -> VU.Vector (RunIx, KeyIx)
   -> V.Vector (IOOp (PrimState m) h)
   -> VU.Vector IOResult
-  -> m (V.Vector (Maybe (Entry SerialisedValue (BlobRef m (Handle h)))))
+  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h)))))
 intraPageLookups !resolveV !rs !ks !rkixs !ioops !ioress = do
     res <- VM.replicate (V.length ks) Nothing
     loop res 0
@@ -285,7 +285,8 @@ intraPageLookups !resolveV !rs !ks !rkixs !ioops !ioress = do
     !n = V.length ioops
 
     loop ::
-         VM.MVector (PrimState m) (Maybe (Entry SerialisedValue (BlobRef m (Handle h))))
+         VM.MVector (PrimState m)
+                    (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h))))
       -> Int
       -> m ()
     loop !res !ioopix
@@ -304,7 +305,8 @@ intraPageLookups !resolveV !rs !ks !rkixs !ioops !ioress = do
             -- Laziness ensures that we only compute the forcing of the value in
             -- the entry when the result is needed.
             LookupEntry e         -> do
-                let e' = bimap copySerialisedValue (mkBlobRefForRun r) e
+                let e' = bimap copySerialisedValue
+                               (WeakBlobRef . mkBlobRefForRun r) e
                 V.unsafeInsertWithMStrict res (combine resolveV) kix e'
             -- Laziness ensures that we only compute the appending of the prefix
             -- and suffix when the result is needed. We do not use 'force' here,
@@ -315,7 +317,7 @@ intraPageLookups !resolveV !rs !ks !rkixs !ioops !ioress = do
                                   (unBufferOffset (ioopBufferOffset ioop) + 4096)
                                   (fromIntegral m)
                                   buf)
-                    e' = bimap v' (mkBlobRefForRun r) e
+                    e' = bimap v' (WeakBlobRef . mkBlobRefForRun r) e
                 V.unsafeInsertWithMStrict res (combine resolveV) kix e'
           loop res (ioopix + 1)
 

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -46,7 +46,7 @@ import qualified Data.Map.Range as Map.R
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
-import           Database.LSMTree.Internal.BlobRef (BlobRef)
+import           Database.LSMTree.Internal.BlobRef (WeakBlobRef)
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Monoidal as Monoidal
 import qualified Database.LSMTree.Internal.Normal as Normal
@@ -164,7 +164,10 @@ lookups ::
 lookups (WB !m) !ks = V.mapStrict (`Map.lookup` m) ks
 
 -- | TODO: update once blob references are implemented
-lookup :: WriteBuffer -> SerialisedKey -> Maybe (Entry SerialisedValue (BlobRef m h))
+lookup ::
+     WriteBuffer
+  -> SerialisedKey
+  -> Maybe (Entry SerialisedValue (WeakBlobRef m h))
 lookup (WB !m) !k = case Map.lookup k m of
     Nothing -> Nothing
     Just x  -> Just $! errOnBlob x
@@ -174,11 +177,11 @@ lookup (WB !m) !k = case Map.lookup k m of
 lookups' ::
      WriteBuffer
   -> V.Vector SerialisedKey
-  -> V.Vector (Maybe (Entry SerialisedValue (BlobRef m h)))
+  -> V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m h)))
 lookups' wb !ks = V.mapStrict (lookup wb) ks
 
 -- | TODO: remove once blob references are implemented
-errOnBlob :: Entry SerialisedValue SerialisedBlob -> Entry SerialisedValue (BlobRef m h)
+errOnBlob :: Entry SerialisedValue SerialisedBlob -> Entry SerialisedValue (WeakBlobRef m h)
 errOnBlob (Insert v)           = Insert v
 errOnBlob (InsertWithBlob _ b) = error $ "lookups: blob references not supported: " ++ show b
 errOnBlob (Mupdate v)          = Mupdate v


### PR DESCRIPTION
Introduce an internal `WeakBlobRef` type. This is used as the internal representation for the public API `BlobRef` type.

Otherwise internally, `WeakBlobRef` is the weak version and `BlobRef` is the strong one where you have (or are assumed to have) a reference on the file/run whatever.

And then provide utilities for dereferencing a weak ref to get a strong ref. This means we get all the weak refcount stuff in one place (in the `BlobRef` module) and its use in `Database.LSMTree.Internal` becomes quite straightforward and doesn't need access to internal representations.