### PR TITLE
Add type parameter m to ReadCtx

### DIFF
--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -233,7 +233,7 @@ deriving anyclass instance NoThunks PageNo
 -------------------------------------------------------------------------------}
 
 deriving stock instance Generic (TableContent m h)
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
                         => NoThunks (TableContent m h)
 
 deriving stock instance Generic (LevelsCache m (Handle h))
@@ -241,15 +241,15 @@ deriving anyclass instance (Typeable (PrimState m), Typeable h)
                         => NoThunks (LevelsCache m (Handle h))
 
 deriving stock instance Generic (Level m (Handle h))
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
                         => NoThunks (Level m (Handle h))
 
 deriving stock instance Generic (MergingRun m (Handle h))
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
                         => NoThunks (MergingRun m (Handle h))
 
 deriving stock instance Generic (MergingRunState m (Handle h))
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
                         => NoThunks (MergingRunState m (Handle h))
 
 {-------------------------------------------------------------------------------
@@ -306,9 +306,9 @@ deriving anyclass instance Typeable s
   Merge
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (Merge s (Handle h))
-deriving anyclass instance (Typeable s, Typeable h)
-                        => NoThunks (Merge s (Handle h))
+deriving stock instance Generic (Merge m (Handle h))
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
+                        => NoThunks (Merge m (Handle h))
 
 deriving stock instance Generic Merge.Level
 deriving anyclass instance NoThunks Merge.Level
@@ -317,9 +317,9 @@ deriving anyclass instance NoThunks Merge.Level
   Readers
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (Readers s (Handle h))
-deriving anyclass instance (Typeable s, Typeable h)
-                        => NoThunks (Readers s (Handle h))
+deriving stock instance Generic (Readers m (Handle h))
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
+                        => NoThunks (Readers m (Handle h))
 
 deriving stock instance Generic (Reader m (Handle h))
 instance (Typeable m, Typeable (PrimState m), Typeable h)
@@ -332,8 +332,9 @@ instance (Typeable m, Typeable (PrimState m), Typeable h)
 deriving stock instance Generic ReaderNumber
 deriving anyclass instance NoThunks ReaderNumber
 
-deriving stock instance Generic (ReadCtx (Handle h))
-deriving anyclass instance Typeable h => NoThunks (ReadCtx (Handle h))
+deriving stock instance Generic (ReadCtx m (Handle h))
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
+                        => NoThunks (ReadCtx m (Handle h))
 
 {-------------------------------------------------------------------------------
   Reader

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -804,7 +804,7 @@ data CursorEnv m h = CursorEnv {
     -- However, the reference counts to the runs only get removed when calling
     -- 'closeCursor', as there might still be 'BlobRef's that need the
     -- corresponding run to stay alive.
-  , cursorReaders    :: !(Maybe (Readers.Readers (PrimState m) (Handle h)))
+  , cursorReaders    :: !(Maybe (Readers.Readers m (Handle h)))
     -- | The runs held open by the cursor. We must remove a reference when the
     -- cursor gets closed.
   , cursorRuns       :: !(V.Vector (Run m (Handle h)))
@@ -936,7 +936,7 @@ readCursorEntries ::
   -> HasBlockIO m h
   -> (SerialisedValue -> SerialisedValue -> SerialisedValue)
   -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m (Handle h)) -> res)
-  -> Readers.Readers RealWorld (Handle h)
+  -> Readers.Readers IO (Handle h)
   -> Int
   -> m (V.Vector res, Readers.HasMore)
 readCursorEntries hfs hbio resolve fromEntry readers n =

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -163,7 +163,7 @@ data MergingRun m h =
 
 data MergingRunState m h =
     CompletedMerge !(Run m h)
-  | OngoingMerge !(V.Vector (Run m h)) !(Merge (PrimState m) h)
+  | OngoingMerge !(V.Vector (Run m h)) !(Merge m h)
 
 {-# SPECIALISE forRunM_ :: Levels IO h -> (Run IO h -> IO ()) -> IO () #-}
 forRunM_ :: PrimMonad m => Levels m h -> (Run m h -> m ()) -> m ()

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -38,7 +38,6 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans ()
 
-import           Control.Monad.Primitive (RealWorld)
 import           Test.QuickCheck.StateModel
 import           Test.QuickCheck.StateModel.Lockstep
 import qualified Test.QuickCheck.StateModel.Lockstep.Defaults as Lockstep
@@ -281,7 +280,7 @@ data RealState =
       !(Maybe ReadersCtx)
 
 -- | Readers, together with the runs being read, so they can be cleaned up at the end
-type ReadersCtx = ([Run.Run IO Handle], Readers RealWorld Handle)
+type ReadersCtx = ([Run.Run IO Handle], Readers IO Handle)
 
 closeReadersCtx :: FS.HasFS IO MockFS.HandleMock -> FS.HasBlockIO IO MockFS.HandleMock -> ReadersCtx -> IO ()
 closeReadersCtx hfs hbio (runs, readers) = do
@@ -337,7 +336,7 @@ runIO act lu = case act of
       return (hasMore, (key, fullEntry, hasMore))
 
     expectReaders ::
-         (FS.HasFS IO MockFS.HandleMock -> FS.HasBlockIO IO MockFS.HandleMock -> Readers RealWorld Handle -> IO (HasMore, a))
+         (FS.HasFS IO MockFS.HandleMock -> FS.HasBlockIO IO MockFS.HandleMock -> Readers IO Handle -> IO (HasMore, a))
       -> RealMonad (Either () a)
     expectReaders f =
         ReaderT $ \(hfs, hbio) -> do


### PR DESCRIPTION
# Description

Just a small refactoring. `ReadCtx` previously hard-coded IO despite being used in other parametrised records.

