### PR TITLE
store write buffer blobs on disk

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -146,6 +146,7 @@ library
     Database.LSMTree.Internal.Unsliced
     Database.LSMTree.Internal.Vector
     Database.LSMTree.Internal.WriteBuffer
+    Database.LSMTree.Internal.WriteBufferBlobs
     Database.LSMTree.Monoidal
     Database.LSMTree.Normal
 

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -216,7 +216,7 @@ instance NoThunks WriteBuffer where
       -- toMap simply unwraps the WriteBuffer newtype wrapper. The bang pattern
       -- will only evaluate the coercion, because the inner Map is already in
       -- WHNF.
-      y :: Map SerialisedKey (Entry SerialisedValue SerialisedBlob)
+      y :: Map SerialisedKey (Entry SerialisedValue BlobSpan)
       !y = toMap x
 
 {-------------------------------------------------------------------------------

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -57,6 +57,7 @@ import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.UniqCounter
 import           Database.LSMTree.Internal.Unsliced
 import           Database.LSMTree.Internal.WriteBuffer
+import           Database.LSMTree.Internal.WriteBufferBlobs
 import           GHC.Generics
 import           KMerge.Heap
 import           NoThunks.Class
@@ -217,6 +218,22 @@ instance NoThunks WriteBuffer where
       -- WHNF.
       y :: Map SerialisedKey (Entry SerialisedValue SerialisedBlob)
       !y = toMap x
+
+{-------------------------------------------------------------------------------
+  BlobFile
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (WriteBufferBlobs m h)
+deriving anyclass instance (Typeable (PrimState m), Typeable h)
+                        => NoThunks (WriteBufferBlobs m h)
+
+deriving stock instance Generic (BlobFileState m h)
+deriving anyclass instance (Typeable (PrimState m), Typeable h)
+                        => NoThunks (BlobFileState m h)
+
+deriving stock instance Generic (FilePointer m)
+deriving anyclass instance Typeable (PrimState m)
+                        => NoThunks (FilePointer m)
 
 {-------------------------------------------------------------------------------
   IndexCompact

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -607,7 +607,6 @@ newWith ::
   -> m (TableHandle m h)
 newWith sesh seshEnv conf !am !wb !levels = do
     tableId <- incrUniqCounter (sessionUniqCounter seshEnv)
-    n <- incrUniqCounter (sessionUniqCounter seshEnv)
     let tr = TraceTable (uniqueToWord64 tableId) `contramap` sessionTracer sesh
     traceWith tr $ TraceCreateTableHandle conf
     cache <- mkLevelsCache levels
@@ -617,7 +616,6 @@ newWith sesh seshEnv conf !am !wb !levels = do
     -- /updated/ set of tracked tables.
     contentVar <- RW.new $ TableContent
         { tableWriteBuffer = wb
-        , tableWriteBufferRN = uniqueToRunNumber n
         , tableLevels = levels
         , tableCache = cache
         }

--- a/src/Database/LSMTree/Internal/Paths.hs
+++ b/src/Database/LSMTree/Internal/Paths.hs
@@ -5,6 +5,8 @@ module Database.LSMTree.Internal.Paths (
   , runPath
   , snapshotsDir
   , snapshot
+    -- * Table paths
+  , tableBlobPath
     -- * Snapshot name
   , SnapshotName
   , mkSnapshotName
@@ -31,6 +33,7 @@ import           Data.Foldable (toList)
 import qualified Data.Map as Map
 import           Data.Traversable (for)
 import           Database.LSMTree.Internal.RunNumber
+import           Database.LSMTree.Internal.UniqCounter
 import           Prelude hiding (Applicative (..))
 import qualified System.FilePath.Posix
 import qualified System.FilePath.Windows
@@ -96,6 +99,15 @@ mkSnapshotName s
   where
     len = length s
     isValid c = ('a' <= c && c <= 'z') || ('0' <= c && c <= '9' ) || c `elem` "-_"
+
+{-------------------------------------------------------------------------------
+  Table paths
+-------------------------------------------------------------------------------}
+
+-- | The file name for a table's write buffer blob file
+tableBlobPath :: SessionRoot -> Unique -> FsPath
+tableBlobPath session n =
+    activeDir session </> mkFsPath [show (uniqueToWord64 n)] <.> "wbblobs"
 
 {-------------------------------------------------------------------------------
   Run paths

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -23,7 +23,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes)
 import           Data.Primitive.MutVar
 import           Data.Traversable (for)
-import           Database.LSMTree.Internal.BlobRef (BlobRef)
+import           Database.LSMTree.Internal.BlobRef (BlobRef, BlobSpan)
 import           Database.LSMTree.Internal.Entry (Entry (..))
 import           Database.LSMTree.Internal.Run (Run)
 import           Database.LSMTree.Internal.RunReader (RunReader)
@@ -153,7 +153,7 @@ newAtOffsetMaybe fs hbio mOffset wbs runs = do
     fromRun n run = nextReadCtx fs hbio n . ReadRun =<< Reader.new fs hbio mOffset run
 
 -- | TODO: remove once blob references are implemented
-errOnBlob :: Entry SerialisedValue SerialisedBlob -> Entry SerialisedValue (BlobRef m h)
+errOnBlob :: Entry SerialisedValue BlobSpan -> Entry SerialisedValue (BlobRef m h)
 errOnBlob (Insert v)           = Insert v
 errOnBlob (InsertWithBlob _ b) = error $ "RunReaders: blob references not supported: " ++ show b
 errOnBlob (Mupdate v)          = Mupdate v

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -1,0 +1,262 @@
+{-# OPTIONS_GHC -Wno-partial-fields #-}
+
+-- | An on-disk store for blobs for the write buffer.
+--
+-- For table inserts with blobs, the blob get written out immediately to a
+-- file, while the rest of the 'Entry' goes into the 'WriteBuffer'. The
+-- 'WriteBufferBlobs' manages the storage of the blobs.
+--
+-- A single write buffer blob file can be shared between multiple table handles.
+-- As a consequence, the lifetime of the 'WriteBufferBlobs' must be managed
+-- using 'new','addReference' and 'removeReference'. A fresh 'WriteBufferBlobs'
+-- has a reference count of 1, and so must be matched by 'removeReference'.
+-- When a table handle is duplicated, the new handle needs its own reference,
+-- so use 'addReference' upon duplication.
+--
+-- Blobs are copied from the write buffer blob file when the write buffer is
+-- flushed to make a run. This is needed since the blob file is shared and so
+-- not stable by the time one table wants to flush it.
+--
+-- Not all table handles need a blob file so we defer opening the file until it
+-- is needed.
+--
+module Database.LSMTree.Internal.WriteBufferBlobs (
+    WriteBufferBlobs (..),
+    new,
+    addReference,
+    removeReference,
+    addBlob,
+    readBlob,
+    mkBlobRef,
+    -- * For tests
+    BlobFileState (..),
+    FilePointer (..)
+  ) where
+
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Primitive (PrimMonad, PrimState)
+import qualified Control.RefCount as RC
+import           Data.Primitive.ByteArray as P
+import           Data.Primitive.MutVar as P
+import           Data.Primitive.PrimVar as P
+import qualified Data.Vector.Primitive as VP
+import           Data.Word (Word64)
+import           Database.LSMTree.Internal.BlobRef (BlobRef (..), BlobSpan (..))
+import           Database.LSMTree.Internal.RawBytes as RB
+import           Database.LSMTree.Internal.Serialise
+import qualified System.FS.API as FS
+import           System.FS.API (FsPath, HasFS)
+import qualified System.Posix.Types as FS (ByteCount)
+
+-- | A single 'WriteBufferBlobs' may be shared between multiple table handles.
+-- As a consequence of being shared, the management of the shared state has to
+-- be quite careful.
+--
+-- In particular there is the blob file itself. We may have to write to this
+-- blob file from multiple threads on behalf of independent table handles.
+-- The offset at which we write is thus shared mutable state. Our strategy for
+-- the write offset is to explicitly track it (since we need to know the offset
+-- to return correct 'BlobSpan's) and then to not use the file's own file
+-- pointer. We do this by always writing at specific file offsets rather than
+-- writing at the open file's normal file pointer. We use a 'PrimVar' with
+-- atomic operations to manage the file offset.
+--
+-- A consequence of the blob file being shared between the write buffers of
+-- many table handles is that the blobs in the file will not all belong to one
+-- table handle. The write buffer blob file is unsuitable to use as-is as the
+-- blob file for a run when the write buffer is flushed. The run blob file must
+-- be immutable and with a known CRC. Whereas because the write buffer blob
+-- file is shared, it can still be appended to via inserts in one table handle
+-- while another is trying to flush the write buffer. So there is no stable CRC
+-- for the whole file (as required by the snapshot format). Further more we
+-- cannot even incrementally calculate the blob file CRC without additional
+-- expensive serialisation. To solve this we follow the design that the open
+-- file handle for the blob file is only shared between multiple write buffers,
+-- and is /not/ shared with the runs once flushed. This separates the lifetimes
+-- of the files. Correspondingly, the reference counter is only for
+-- tracking the lifetime of the read\/write mode file handle.
+--
+-- One concern with sharing blob files and the open blob file handle between
+-- multiple write buffers is: can we guarantee that the blob file is eventually
+-- closed?
+--
+-- A problematic example would be, starting from a root handle and then
+-- repeatedly: duplicating; inserting (with blobs) into the duplicate; and then
+-- closing it. This would use only a fixed number of table handles at once, but
+-- would keep inserting into the same the write buffer blob file. This could be
+-- done indefinitely.
+--
+-- On the other hand, provided that there's a bound on the number of duplicates
+-- that are created from any point, and each table handle is eventually closed,
+-- then each write buffer blob file will eventually be closed.
+--
+-- The latter seems like the more realistic use case, and so the design here is
+-- probably reasonable.
+--
+-- If not, an entirely different approach would be to manage blobs across all
+-- runs (and the write buffer) differently: avoiding copying when blobs are
+-- merged and using some kind of GC algorithm to recover space for blobs that
+-- are not longer needed. There are LSM algorithms that do this for values
+-- (i.e. copying keys only during merge and referring to values managed in a
+-- separate disk heap), so the same could be applied to blobs.
+--
+data WriteBufferBlobs m h =
+     WriteBufferBlobs {
+       blobFileState      :: !(MutVar (PrimState m) (BlobFileState m h))
+
+       -- | The name is reserved in advance, even if it is not used.
+     , blobFileName       :: !FsPath
+
+       -- | The reference counter for the blob file.
+     , blobFileRefCounter :: {-# UNPACK #-} !(RC.RefCounter m)
+     }
+
+-- | The blob file itself is opened on-demand, to avoid the cost in cases where
+-- blobs are not needed.
+data BlobFileState m h =
+
+     NoBlobFileYet
+   | OpenBlobFile {
+       blobFileHandle  :: {-# UNPACK #-} !(FS.Handle h)
+
+       -- | The manually tracked file pointer.
+     , blobFilePointer :: !(FilePointer m)
+     }
+
+new :: PrimMonad m
+    => HasFS m h
+    -> FS.FsPath
+    -> m (WriteBufferBlobs m h)
+new fs blobFileName = do
+    blobFileState <- P.newMutVar NoBlobFileYet
+    blobFileRefCounter <- RC.mkRefCounter1 (Just (finaliser fs blobFileState))
+    return WriteBufferBlobs {
+      blobFileState,
+      blobFileName,
+      blobFileRefCounter
+    }
+
+finaliser :: PrimMonad m
+          => HasFS m h
+          -> MutVar (PrimState m) (BlobFileState m h)
+          -> m ()
+finaliser fs bf = do
+    bfs <- P.readMutVar bf
+    case bfs of
+      OpenBlobFile {blobFileHandle} -> FS.hClose fs blobFileHandle
+      NoBlobFileYet {}              -> return ()
+
+addReference :: PrimMonad m => WriteBufferBlobs m h -> m ()
+addReference WriteBufferBlobs {blobFileRefCounter} =
+    RC.addReference blobFileRefCounter
+
+removeReference :: (PrimMonad m, MonadMask m) => WriteBufferBlobs m h -> m ()
+removeReference WriteBufferBlobs {blobFileRefCounter} =
+    RC.removeReference blobFileRefCounter
+
+addBlob :: (PrimMonad m, MonadThrow m)
+        => HasFS m h
+        -> WriteBufferBlobs m h
+        -> SerialisedBlob
+        -> m BlobSpan
+addBlob fs WriteBufferBlobs {blobFileName, blobFileState} blob = do
+    bfs <- P.readMutVar blobFileState
+    case bfs of
+      OpenBlobFile {blobFileHandle, blobFilePointer} ->
+        writeBlob blobFileHandle blobFilePointer
+
+      NoBlobFileYet -> do
+        -- Must use read/write mode because we write blobs when adding, but
+        -- we can also be asked to retrieve blobs at any time.
+        blobFileHandle <- FS.hOpen fs blobFileName (FS.ReadWriteMode FS.MustBeNew)
+        blobFilePointer <- newFilePointer
+        P.writeMutVar blobFileState OpenBlobFile {
+          blobFileHandle,
+          blobFilePointer
+        }
+        writeBlob blobFileHandle blobFilePointer
+
+  where
+    writeBlob h hoff = do
+      let blobsize = sizeofBlob blob
+      bloboffset <- updateFilePointer hoff blobsize
+      writeBlobAtOffset fs h blob bloboffset
+      pure BlobSpan {
+        blobSpanOffset = bloboffset,
+        blobSpanSize   = fromIntegral blobsize
+      }
+
+writeBlobAtOffset :: (PrimMonad m, MonadThrow m)
+                  => HasFS m h
+                  -> FS.Handle h
+                  -> SerialisedBlob
+                  -> Word64
+                  -> m ()
+writeBlobAtOffset fs h (SerialisedBlob' (VP.Vector boff blen ba)) off = do
+    mba <- P.unsafeThawByteArray ba
+    _   <- FS.hPutBufExactlyAt
+             fs h mba
+             (FS.BufferOffset boff)
+             (fromIntegral blen :: FS.ByteCount)
+             (FS.AbsOffset off)
+    return ()
+
+readBlob :: (PrimMonad m, MonadThrow m)
+         => HasFS m h
+         -> WriteBufferBlobs m h
+         -> BlobSpan
+         -> m SerialisedBlob
+readBlob fs WriteBufferBlobs {blobFileState} BlobSpan {blobSpanOffset, blobSpanSize} = do
+    bfs <- P.readMutVar blobFileState
+    case bfs of
+      OpenBlobFile {blobFileHandle} -> do
+        let off = FS.AbsOffset blobSpanOffset
+            len :: Int
+            len = fromIntegral blobSpanSize
+        mba <- P.newPinnedByteArray len
+        _ <- FS.hGetBufExactlyAt fs blobFileHandle mba 0
+                                 (fromIntegral len :: FS.ByteCount) off
+        ba <- P.unsafeFreezeByteArray mba
+        let !rb = RB.fromByteArray 0 len ba
+        return (SerialisedBlob rb)
+
+      -- We must not be asking to read blobs if no blobs have been written.
+      -- That would be an internal error.
+      NoBlobFileYet{} ->
+        error "BlobFile.mkBlobRef: no such blob refs, no blob file open"
+
+-- | Helper function to make a 'BlobRef' that points into a 'WriteBufferBlobs'.
+mkBlobRef :: PrimMonad m
+          => WriteBufferBlobs m h
+          -> BlobSpan
+          -> m (BlobRef m (FS.Handle h))
+mkBlobRef WriteBufferBlobs {blobFileState, blobFileRefCounter} blobRefSpan = do
+    bfs <- P.readMutVar blobFileState
+    case bfs of
+      --TODO: for assertion checking we could check the span exists within
+      -- the file.
+      OpenBlobFile {blobFileHandle} ->
+        pure BlobRef {
+          blobRefFile  = blobFileHandle,
+          blobRefCount = blobFileRefCounter,
+          blobRefSpan
+        }
+      -- We must not be handing out references to blobs if no blobs have been
+      -- written. That would be an internal error.
+      NoBlobFileYet{} ->
+        error "BlobFile.mkBlobRef: no such blob refs, no blob file open"
+
+
+-- | A mutable file offset, suitable to share between threads.
+newtype FilePointer m = FilePointer (PrimVar (PrimState m) Int)
+--TODO: this would be better as Word64
+-- otherwise this will not work on 32bit arches
+
+newFilePointer :: PrimMonad m => m (FilePointer m)
+newFilePointer = FilePointer <$> P.newPrimVar 0
+
+-- | Update the file offset by a given amount and return the new offset. This
+-- is safe to use concurrently.
+--
+updateFilePointer :: PrimMonad m => FilePointer m -> Int -> m Word64
+updateFilePointer (FilePointer var) n = fromIntegral <$> P.fetchAddInt var n

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -21,7 +21,6 @@ import           Database.LSMTree.Internal.BlobRef (readBlob)
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Paths as Paths
 import qualified Database.LSMTree.Internal.Run as Run
-import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..))
 import           Database.LSMTree.Internal.RunNumber
 import qualified Database.LSMTree.Internal.RunReader as Reader
 import           Database.LSMTree.Internal.RunReaders
@@ -39,6 +38,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans ()
 
+import           Test.Database.LSMTree.Internal.Run (mkRunFromSerialisedKOps)
 import           Test.QuickCheck.StateModel
 import           Test.QuickCheck.StateModel.Lockstep
 import qualified Test.QuickCheck.StateModel.Lockstep.Defaults as Lockstep
@@ -80,11 +80,13 @@ isEmpty (MockReaders xs) = null xs
 size :: MockReaders -> Int
 size (MockReaders xs) = length xs
 
-newMock :: Maybe SerialisedKey -> [WB.WriteBuffer] -> MockReaders
+newMock :: Maybe SerialisedKey
+        -> [TypedWriteBuffer KeyForIndexCompact SerialisedValue SerialisedBlob]
+        -> MockReaders
 newMock offset =
       MockReaders . Map.assocs . Map.unions
     . zipWith (\i -> Map.mapKeysMonotonic (\k -> (k, RunNumber i))) [0..]
-    . map (skip . WB.toMap)
+    . map (skip . unTypedWriteBuffer)
   where
     skip = maybe id (\k -> Map.dropWhileAntitone (< k)) offset
 
@@ -203,12 +205,12 @@ instance InLockstep ReadersState where
             withoutBlobs ::
                  TypedWriteBuffer KeyForIndexCompact SerialisedValue SerialisedBlob
               -> TypedWriteBuffer KeyForIndexCompact SerialisedValue SerialisedBlob
-            withoutBlobs = TypedWriteBuffer . WB.fromMap
+            withoutBlobs = TypedWriteBuffer
                          . Map.filter (not . hasBlob)
-                         . WB.toMap . unTypedWriteBuffer
+                         . unTypedWriteBuffer
         wb <- fmap withoutBlobs <$> arbitrary
         wbs <- vector =<< chooseInt (1, 10)
-        let keys = map fst $ concatMap (WB.toList . unTypedWriteBuffer) $ toList wb <> wbs
+        let keys = map fst $ concatMap (Map.toList . unTypedWriteBuffer) $ toList wb <> wbs
         offset <-
           if null keys
           then pure Nothing
@@ -250,11 +252,11 @@ instance InLockstep ReadersState where
     -- Directly using strings, since there is only a small number of tags.
     [ [ "NewEntries " <> showPowersOf 10 numEntries
       | New _ wb wbs <- [action]
-      , let numEntries = sum (map (unNumEntries . WB.numEntries . unTypedWriteBuffer) (toList wb <> wbs))
+      , let numEntries = sum (map (Map.size . unTypedWriteBuffer) (toList wb <> wbs))
       ]
     , [ "NewEntriesKeyDuplicates " <> showPowersOf 2 keyCount
       | New _ wb wbs <- [action]
-      , let keyCounts = Map.unionsWith (+) (map (Map.map (const 1) . WB.toMap . unTypedWriteBuffer) (toList wb <> wbs))
+      , let keyCounts = Map.unionsWith (+) (map (Map.map (const 1) . unTypedWriteBuffer) (toList wb <> wbs))
       , keyCount <- Map.elems keyCounts
       , keyCount > 1
       ]
@@ -273,7 +275,7 @@ runMock ::
   -> MockReaders
   -> (ReadersVal a, MockReaders)
 runMock _ = \case
-    New k wb wbs   -> const $ wrap MUnit (Right (), newMock (coerce k) . map unTypedWriteBuffer $ toList wb <> wbs)
+    New k wb wbs   -> const $ wrap MUnit (Right (), newMock (coerce k) (toList wb <> wbs))
     PeekKey        -> \m -> wrap MKey (peekKeyMock m, m)
     Pop n          -> wrap wrapPop . popMock n
     DropWhileKey k -> wrap wrapDrop . dropWhileKeyMock k
@@ -332,15 +334,21 @@ runIO act lu = case act of
       traverse_ (liftIO . closeReadersCtx hfs hbio) mCtx
       runs <-
         zipWithM
-          (\p -> liftIO . Run.fromWriteBuffer hfs hbio Run.CacheRunData (RunAllocFixed 10) p)
+          (\p -> liftIO . mkRunFromSerialisedKOps hfs hbio p)
           (Paths.RunFsPaths (FS.mkFsPath []) . RunNumber <$> [numRuns ..])
           (map unTypedWriteBuffer wbs)
-      newReaders <- liftIO $ Readers.newAtOffsetMaybe hfs hbio (coerce offset) (unTypedWriteBuffer <$> wb) runs >>= \case
-        Nothing -> do
-          traverse_ Run.removeReference runs
-          return Nothing
-        Just readers ->
-          return $ Just (runs, readers)
+      newReaders <- do
+        mreaders <-
+          liftIO $ Readers.newAtOffsetMaybe
+                     hfs hbio (coerce offset)
+                     (WB.fromMap . unTypedWriteBuffer <$> wb)
+                     runs
+        case mreaders of
+          Nothing -> do
+            liftIO $ traverse_ Run.removeReference runs
+            return Nothing
+          Just readers ->
+            return $ Just (runs, readers)
       put (RealState (numRuns + fromIntegral (length wbs)) newReaders)
       return (Right ())
     PeekKey -> expectReaders $ \_ _ r -> do


### PR DESCRIPTION
Change the `WriteBuffer` to store `BlobSpan` rather than `SerialisedBlob`

This requires some preparatory changes and entails a lot of minor changes elsewhere. Instead of storing blobs in memory in the write buffer itself we now have to write blobs to the `WriteBufferBlobs`, which gets us back `BlobSpans` and then those `BlobSpans` go into the `WriteBuffer`.

This PR should be read patch by patch. The final patch is unfortunately rather long, with only one or two interesting bits. Pay attention to the reference counting of the `WriteBufferBlobs`. I'm not sure how well covered that is by tests (though some tests did fail due to files being left open, and those are fixes). In particular duplication isn't covered well yet.