### PR TITLE
Refactor: move readCursorEntries to top level function

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -41,6 +41,7 @@ module Database.LSMTree.Internal (
   , withCursor
   , newCursor
   , closeCursor
+  , readCursor
     -- * Snapshots
   , SnapshotLabel
   , snapshot
@@ -66,6 +67,7 @@ import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Char8 as BSC
 import           Data.Char (isNumber)
 import           Data.Foldable
+import           Data.Functor ((<&>))
 import           Data.Functor.Compose (Compose (..))
 import           Data.Kind
 import           Data.Map.Strict (Map)
@@ -77,10 +79,11 @@ import qualified Data.Set as Set
 import           Data.Typeable
 import qualified Data.Vector as V
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.BlobRef (WeakBlobRef)
+import           Database.LSMTree.Internal.BlobRef (WeakBlobRef (..))
 import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.Config
-import           Database.LSMTree.Internal.Entry (Entry, combineMaybe)
+import           Database.LSMTree.Internal.Entry (Entry)
+import qualified Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.Lookup (ByteCountDiscrepancy,
                      ResolveSerialisedValue, lookupsIO)
 import           Database.LSMTree.Internal.MergeSchedule
@@ -91,6 +94,7 @@ import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
 import           Database.LSMTree.Internal.RunNumber
+import qualified Database.LSMTree.Internal.RunReader as Reader
 import qualified Database.LSMTree.Internal.RunReaders as Readers
 import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..),
                      SerialisedKey, SerialisedValue)
@@ -665,9 +669,10 @@ lookups resolve ks th fromEntry = do
             (cachedIndexes cache)
             (cachedKOpsFiles cache)
             ks
-        pure $! V.zipWithStrict
-                  (\k1 e2 -> fromEntry $ combineMaybe resolve (WB.lookup wb k1) e2)
-                  ks ioRes
+        pure $!
+          V.zipWithStrict
+            (\k1 e2 -> fromEntry $ Entry.combineMaybe resolve (WB.lookup wb k1) e2)
+            ks ioRes
 
 {-# SPECIALISE updates :: ResolveSerialisedValue -> V.Vector (SerialisedKey, Entry SerialisedValue SerialisedBlob) -> TableHandle IO h -> IO () #-}
 -- | See 'Database.LSMTree.Normal.updates'.
@@ -743,6 +748,8 @@ retrieveBlobs sesh wrefs =
   Cursors
 -------------------------------------------------------------------------------}
 
+-- TODO: Move to a separate Cursors module
+
 -- | A read-only view into the table state at the time of cursor creation.
 --
 -- For more information, see 'Database.LSMTree.Normal.Cursor'.
@@ -780,7 +787,8 @@ data CursorEnv m h = CursorEnv {
 
     -- | Session-unique identifier for this cursor.
   , cursorId         :: !Word64
-    -- | Readers are immediately discarded once they are 'Readers.Drained'.
+    -- | Readers are immediately discarded once they are 'Readers.Drained',
+    -- so if there is a 'Just', we can assume that it has further entries.
     -- However, the reference counts to the runs only get removed when calling
     -- 'closeCursor', as there might still be 'BlobRef's that need the
     -- corresponding run to stay alive.
@@ -869,6 +877,115 @@ closeCursor Cursor {..} = do
         V.forM_ cursorRuns $ freeTemp reg . Run.removeReference
         return CursorClosed
 
+{-# SPECIALISE readCursor :: ResolveSerialisedValue -> Int -> Cursor IO h -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef IO (Handle h)) -> res) -> IO (V.Vector res) #-}
+-- | See 'Database.LSMTree.Normal.readCursor'.
+readCursor ::
+     forall m h res. m ~ IO -- TODO: replace by @io-classes@ constraints for IO simulation.
+  => ResolveSerialisedValue
+  -> Int  -- ^ Number of entries to read
+  -> Cursor m h
+  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m (Handle h)) -> res)
+     -- ^ How to map to a query result, different for normal/monoidal
+  -> m (V.Vector res)
+readCursor resolve n Cursor {..} fromEntry = do
+    modifyMVar cursorState $ \case
+      CursorClosed -> throwIO ErrCursorClosed
+      state@(CursorOpen cursorEnv) -> do
+        case cursorReaders cursorEnv of
+          Nothing ->
+            -- a drained cursor will just return an empty vector
+            return (state, V.empty)
+          Just readers -> do
+            let hfs = sessionHasFS (cursorSessionEnv cursorEnv)
+            let hbio = sessionHasBlockIO (cursorSessionEnv cursorEnv)
+            (vec, hasMore) <- readEntries hfs hbio readers
+            -- if we drained the readers, remove them from the state
+            let !state' = case hasMore of
+                  Readers.HasMore -> state
+                  Readers.Drained -> CursorOpen (cursorEnv {cursorReaders = Nothing})
+            return (state', vec)
+  where
+    -- General notes on the code below:
+    -- * it is quite similar to the one in Internal.Merge, but different enough
+    --   that it's probably easier to keep them separate
+    -- * any function that doesn't take a 'hasMore' argument assumes that the
+    --   readers have not been drained yet, so we must check before calling them
+    -- * there is probably opportunity for optimisations
+    readEntries hfs hbio readers =
+        flip (V.unfoldrNM' n) Readers.HasMore $ \case
+          Readers.Drained -> return (Nothing, Readers.Drained)
+          Readers.HasMore -> readEntry <&> \case
+            Just (res, hasMore) -> (Just res, hasMore)
+            Nothing             -> (Nothing, Readers.Drained)
+      where
+        -- Produces a result unless the readers have been drained.
+        readEntry :: IO (Maybe (res, Readers.HasMore))
+        readEntry = do
+            (key, readerEntry, hasMore) <- Readers.pop hfs hbio readers
+            let !entry = Reader.toFullEntry readerEntry
+            case hasMore of
+              Readers.Drained -> do
+                handleResolved key entry Readers.Drained
+              Readers.HasMore -> do
+                case entry of
+                  Entry.Mupdate v ->
+                    handleMupdate key v
+                  _ -> do
+                    -- Anything but Mupdate supersedes all previous entries of
+                    -- the same key, so we can simply drop them and are done.
+                    hasMore' <- dropRemaining key
+                    handleResolved key entry hasMore'
+
+        dropRemaining :: SerialisedKey -> IO Readers.HasMore
+        dropRemaining key = do
+            (_, hasMore) <- Readers.dropWhileKey hfs hbio readers key
+            return hasMore
+
+        -- Resolve a 'Mupsert' value with the other entries of the same key.
+        handleMupdate :: SerialisedKey -> SerialisedValue -> IO (Maybe (res, Readers.HasMore))
+        handleMupdate key v = do
+            nextKey <- Readers.peekKey readers
+            if nextKey /= key
+              then
+                -- No more entries for same key, done.
+                handleResolved key (Entry.Mupdate v) Readers.HasMore
+              else do
+                (_, nextEntry, hasMore) <- Readers.pop hfs hbio readers
+                let resolved = Entry.combine resolve (Entry.Mupdate v)
+                                 (Reader.toFullEntry nextEntry)
+                case hasMore of
+                  Readers.HasMore -> case resolved of
+                    Entry.Mupdate v' ->
+                      -- Still a mupsert, keep resolving!
+                      handleMupdate key v'
+                    _ -> do
+                      -- Done with this key, remaining entries are obsolete.
+                      hasMore' <- dropRemaining key
+                      handleResolved key resolved hasMore'
+                  Readers.Drained -> do
+                    handleResolved key resolved Readers.Drained
+
+        -- Once we have a resolved entry, we still have to make sure it's not
+        -- a 'Delete', since we only want to write values to the result vector.
+        handleResolved :: SerialisedKey -> Entry SerialisedValue (BlobRef.BlobRef IO (Handle h)) -> Readers.HasMore -> IO (Maybe (res, Readers.HasMore))
+        handleResolved key entry hasMore =
+            case toResult key entry of
+              Just !res ->
+                -- Found one resolved value, done.
+                return (Just (res, hasMore))
+              Nothing ->
+                -- Resolved value was a Delete, which we don't want to include.
+                -- So look for another one (unless there are no more entries!).
+                case hasMore of
+                  Readers.HasMore -> readEntry
+                  Readers.Drained -> return Nothing
+
+        toResult :: SerialisedKey -> Entry SerialisedValue (BlobRef.BlobRef IO (Handle h)) -> Maybe res
+        toResult key = \case
+            Entry.Insert v -> Just $ fromEntry key v Nothing
+            Entry.InsertWithBlob v b -> Just $ fromEntry key v (Just (WeakBlobRef b))
+            Entry.Mupdate v -> Just $ fromEntry key v Nothing
+            Entry.Delete -> Nothing
 
 {-------------------------------------------------------------------------------
   Snapshots

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -376,7 +376,17 @@ readCursor ::
   => Int
   -> Cursor m k v blob
   -> m (V.Vector (QueryResult k v (BlobRef m blob)))
-readCursor = undefined
+readCursor n (Internal.NormalCursor c) =
+    Internal.readCursor const n c $ \k v mblob ->
+      toNormalQueryResult
+        (Internal.deserialiseKey k)
+        (Internal.deserialiseValue v)
+        (BlobRef <$> mblob)
+
+toNormalQueryResult :: k -> v -> Maybe b -> QueryResult k v b
+toNormalQueryResult k v = \case
+    Nothing    -> FoundInQuery k v
+    Just blob  -> FoundInQueryWithBlob k v blob
 
 {-------------------------------------------------------------------------------
   Table updates

--- a/test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Database/LSMTree/Class/Monoidal.hs
@@ -9,11 +9,12 @@ module Database.LSMTree.Class.Monoidal (
   , withTableOpen
   , withTableDuplicate
   , withTableMerge
+  , withCursor
   ) where
 
 import           Control.Monad.Class.MonadThrow (MonadThrow (..))
 import           Data.Kind (Constraint, Type)
-import           Data.Typeable (Typeable)
+import           Data.Typeable (Proxy (Proxy), Typeable)
 import qualified Data.Vector as V
 import           Database.LSMTree.Class.Normal (IsSession (..),
                      SessionArgs (..), withSession)
@@ -181,6 +182,13 @@ withTableMerge ::
   -> (h m k v -> m a)
   -> m a
 withTableMerge table1 table2 = bracket (merge table1 table2) close
+
+withCursor ::
+     forall h m k v a. (IOLike m, IsTableHandle h)
+  => h m k v
+  -> (Cursor h m k v -> m a)
+  -> m a
+withCursor hdl = bracket (newCursor hdl) (closeCursor (Proxy @h))
 
 {-------------------------------------------------------------------------------
   Model instance

--- a/test/Database/LSMTree/Class/Normal.hs
+++ b/test/Database/LSMTree/Class/Normal.hs
@@ -8,12 +8,13 @@ module Database.LSMTree.Class.Normal (
   , withTableNew
   , withTableOpen
   , withTableDuplicate
+  , withCursor
   ) where
 
 import           Control.Monad.Class.MonadThrow (MonadThrow (..))
 import           Control.Tracer (nullTracer)
 import           Data.Kind (Constraint, Type)
-import           Data.Typeable (Typeable)
+import           Data.Typeable (Proxy (Proxy), Typeable)
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (IOLike, Labellable (..), Range (..),
                      SerialiseKey, SerialiseValue, SnapshotName)
@@ -172,6 +173,13 @@ withTableDuplicate ::
   -> (h m k v blob -> m a)
   -> m a
 withTableDuplicate table = bracket (duplicate table) close
+
+withCursor ::
+     forall h m k v blob a. (IOLike m, IsTableHandle h)
+  => h m k v blob
+  -> (Cursor h m k v blob -> m a)
+  -> m a
+withCursor hdl = bracket (newCursor hdl) (closeCursor (Proxy @h))
 
 {-------------------------------------------------------------------------------
   Model instance

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -193,6 +193,7 @@ propLockstepIO_RealImpl_RealFS = testProperty "propLockstepIO_RealImpl_RealFS" $
       where
         handler' :: LSMTreeError -> Maybe Model.Err
         handler' ErrTableClosed = Just Model.ErrTableHandleClosed
+        handler' ErrCursorClosed = Just Model.ErrCursorClosed
         handler' (ErrSnapshotNotExists _snap) = Just Model.ErrSnapshotDoesNotExist
         handler' (ErrSnapshotExists _snap) = Just Model.ErrSnapshotExists
         handler' (ErrSnapshotWrongType _snap) = Just Model.ErrSnapshotWrongType
@@ -244,7 +245,7 @@ instance Arbitrary R.TableConfig where
       , R.confBloomFilterAlloc  = R.AllocFixed 10
       , R.confFencePointerIndex = R.CompactIndex
       , R.confDiskCachePolicy   = R.DiskCacheNone
-      , R.confMergeSchedule       = R.OneShot
+      , R.confMergeSchedule     = R.OneShot
       }
 
 {-------------------------------------------------------------------------------
@@ -1033,8 +1034,7 @@ arbitraryActionWithVars _ findVars _st = QC.frequency $ concat [
       -> [(Int, Gen (Any (LockstepAction (ModelState h))))]
     withVars' genVar = [
           (2, fmap Some $ CloseCursor <$> (fromRight <$> genVar))
-          -- TODO: enable generators as we implement the actions for the /real/ lsm-tree
-        -- , (10, fmap Some $ ReadCursor <$> (QC.getNonNegative <$> QC.arbitrary) <*> (fromRight <$> genVar))
+        , (10, fmap Some $ ReadCursor <$> (QC.getNonNegative <$> QC.arbitrary) <*> (fromRight <$> genVar))
         ]
 
     withVars'' ::


### PR DESCRIPTION
It was getting rather large to be living in a where clause.