### PR TITLE
Allow creating cursor at offset

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -850,7 +850,7 @@ newCursor th = withOpenTable th $ \thEnv -> do
           allocTableContent reg (tableContent thEnv)
         cursorReaders <-
           allocateMaybeTemp reg
-            (Readers.new hfs hbio (Just writeBuffer) (V.toList cursorRuns))
+            (Readers.new hfs hbio Nothing (Just writeBuffer) (V.toList cursorRuns))
             (Readers.close hfs hbio)
         cursorState <- newMVar (CursorOpen CursorEnv {..})
         let !cursor = Cursor {cursorState, cursorTracer}

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -63,7 +63,7 @@ new ::
   -> IO (Maybe (Merge IO (FS.Handle h)))
 new fs hbio mergeCaching alloc mergeLevel mergeMappend targetPaths runs = do
     -- no offset, no write buffer
-    mreaders <- Readers.new fs hbio Nothing Nothing runs
+    mreaders <- Readers.new fs hbio Readers.NoOffsetKey Nothing runs
     for mreaders $ \mergeReaders -> do
       -- calculate upper bounds based on input runs
       let numEntries = coerce (sum @[] @Int) (map Run.runNumEntries runs)

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -62,7 +62,8 @@ new ::
   -> [Run IO (FS.Handle h)]
   -> IO (Maybe (Merge IO (FS.Handle h)))
 new fs hbio mergeCaching alloc mergeLevel mergeMappend targetPaths runs = do
-    mreaders <- Readers.new fs hbio Nothing runs
+    -- no offset, no write buffer
+    mreaders <- Readers.new fs hbio Nothing Nothing runs
     for mreaders $ \mergeReaders -> do
       -- calculate upper bounds based on input runs
       let numEntries = coerce (sum @[] @Int) (map Run.runNumEntries runs)

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -1,5 +1,6 @@
 module Database.LSMTree.Internal.RunReaders (
     Readers (..)
+  , OffsetKey (..)
   , new
   , close
   , peekKey
@@ -24,7 +25,7 @@ import           Data.Traversable (for)
 import           Database.LSMTree.Internal.BlobRef (BlobRef, BlobSpan)
 import           Database.LSMTree.Internal.Entry (Entry (..))
 import           Database.LSMTree.Internal.Run (Run)
-import           Database.LSMTree.Internal.RunReader (RunReader)
+import           Database.LSMTree.Internal.RunReader (OffsetKey (..), RunReader)
 import qualified Database.LSMTree.Internal.RunReader as Reader
 import           Database.LSMTree.Internal.Serialise
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
@@ -102,14 +103,15 @@ data Reader m fhandle =
 
 type KOp m fhandle = (SerialisedKey, Entry SerialisedValue (BlobRef m fhandle))
 
+-- TODO: take a vector of runs instead of a list to avoid conversions
 new :: forall h .
      HasFS IO h
   -> HasBlockIO IO h
-  -> Maybe SerialisedKey  -- ^ offset
+  -> OffsetKey
   -> Maybe WB.WriteBuffer
   -> [Run IO (FS.Handle h)]
   -> IO (Maybe (Readers IO (FS.Handle h)))
-new fs hbio mOffset wbs runs = do
+new fs hbio !offsetKey wbs runs = do
     wBuffer <- maybe (pure Nothing) fromWB wbs
     readers <- zipWithM (fromRun . ReaderNumber) [1..] runs
     let contexts = nonEmpty . catMaybes $ wBuffer : readers
@@ -122,12 +124,17 @@ new fs hbio mOffset wbs runs = do
     fromWB wb = do
         kops <-
           newMutVar $ map (fmap errOnBlob) $ Map.toList $
-            maybe id (\o -> Map.dropWhileAntitone (< o)) mOffset $
-              WB.toMap wb
+            filterWB $ WB.toMap wb
         nextReadCtx fs hbio (ReaderNumber 0) (ReadBuffer kops)
+      where
+        filterWB = case offsetKey of
+            NoOffsetKey -> id
+            OffsetKey k -> Map.dropWhileAntitone (< k)
 
     fromRun :: ReaderNumber -> Run IO (FS.Handle h) -> IO (Maybe (ReadCtx IO (FS.Handle h)))
-    fromRun n run = nextReadCtx fs hbio n . ReadRun =<< Reader.new fs hbio mOffset run
+    fromRun n run = do
+        reader <- Reader.new fs hbio offsetKey run
+        nextReadCtx fs hbio n (ReadRun reader)
 
 -- | TODO: remove once blob references are implemented
 errOnBlob :: Entry SerialisedValue BlobSpan -> Entry SerialisedValue (BlobRef m h)

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -261,12 +261,15 @@ type Cursor = Internal.MonoidalCursor
 --
 -- If possible, it is recommended to use this function instead of 'newCursor'
 -- and 'closeCursor'.
+--
+-- TODO: Also provide `withCursorAtOffset` variant?
 withCursor ::
      IOLike m
   => TableHandle m k v
   -> (Cursor m k v -> m a)
   -> m a
-withCursor = undefined
+withCursor (Internal.MonoidalTable th) action =
+    Internal.withCursor Internal.NoOffsetKey th (action . Internal.MonoidalCursor)
 
 {-# SPECIALISE newCursor :: TableHandle IO k v -> IO (Cursor IO k v) #-}
 -- | Create a new cursor to read from a given table. Future updates to the table
@@ -277,11 +280,14 @@ withCursor = undefined
 --
 -- NOTE: cursors hold open resources (such as open files) and should be closed
 -- using 'close' as soon as they are no longer used.
+--
+-- TODO: Also provide `newCursorAtOffset` variant?
 newCursor ::
      IOLike m
   => TableHandle m k v
   -> m (Cursor m k v)
-newCursor (Internal.MonoidalTable th) = Internal.MonoidalCursor <$> Internal.newCursor th
+newCursor (Internal.MonoidalTable th) =
+    Internal.MonoidalCursor <$> Internal.newCursor Internal.NoOffsetKey th
 
 {-# SPECIALISE closeCursor :: Cursor IO k v -> IO () #-}
 -- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -71,7 +71,9 @@ module Database.LSMTree.Monoidal (
     -- ** Cursor
   , Cursor
   , withCursor
+  , withCursorAtOffset
   , newCursor
+  , newCursorAtOffset
   , closeCursor
   , readCursor
     -- ** Updates
@@ -261,8 +263,6 @@ type Cursor = Internal.MonoidalCursor
 --
 -- If possible, it is recommended to use this function instead of 'newCursor'
 -- and 'closeCursor'.
---
--- TODO: Also provide `withCursorAtOffset` variant?
 withCursor ::
      IOLike m
   => TableHandle m k v
@@ -270,6 +270,24 @@ withCursor ::
   -> m a
 withCursor (Internal.MonoidalTable th) action =
     Internal.withCursor Internal.NoOffsetKey th (action . Internal.MonoidalCursor)
+
+{-# SPECIALISE withCursorAtOffset :: SerialiseKey k => k -> TableHandle IO k v -> (Cursor IO k v -> IO a) -> IO a #-}
+-- | A variant of 'withCursor' that allows initialising the cursor at an offset
+-- within the table such that the first entry the cursor returns will be the
+-- one with the lowest key that is greater than or equal to the given key.
+-- In other words, it uses an inclusive lower bound.
+--
+-- NOTE: The ordering of the serialised keys will be used, which can lead to
+-- unexpected results if the 'SerialiseKey' instance is not order-preserving!
+withCursorAtOffset ::
+     (IOLike m, SerialiseKey k)
+  => k
+  -> TableHandle m k v
+  -> (Cursor m k v -> m a)
+  -> m a
+withCursorAtOffset offset (Internal.MonoidalTable th) action =
+    Internal.withCursor (Internal.OffsetKey (Internal.serialiseKey offset)) th $
+      action . Internal.MonoidalCursor
 
 {-# SPECIALISE newCursor :: TableHandle IO k v -> IO (Cursor IO k v) #-}
 -- | Create a new cursor to read from a given table. Future updates to the table
@@ -280,14 +298,29 @@ withCursor (Internal.MonoidalTable th) action =
 --
 -- NOTE: cursors hold open resources (such as open files) and should be closed
 -- using 'close' as soon as they are no longer used.
---
--- TODO: Also provide `newCursorAtOffset` variant?
 newCursor ::
      IOLike m
   => TableHandle m k v
   -> m (Cursor m k v)
 newCursor (Internal.MonoidalTable th) =
-    Internal.MonoidalCursor <$> Internal.newCursor Internal.NoOffsetKey th
+    Internal.MonoidalCursor <$!> Internal.newCursor Internal.NoOffsetKey th
+
+{-# SPECIALISE newCursorAtOffset :: SerialiseKey k => k -> TableHandle IO k v -> IO (Cursor IO k v) #-}
+-- | A variant of 'newCursor' that allows initialising the cursor at an offset
+-- within the table such that the first entry the cursor returns will be the
+-- one with the lowest key that is greater than or equal to the given key.
+-- In other words, it uses an inclusive lower bound.
+--
+-- NOTE: The ordering of the serialised keys will be used, which can lead to
+-- unexpected results if the 'SerialiseKey' instance is not order-preserving!
+newCursorAtOffset ::
+     (IOLike m, SerialiseKey k)
+  => k
+  -> TableHandle m k v
+  -> m (Cursor m k v)
+newCursorAtOffset offset (Internal.MonoidalTable th) =
+    Internal.MonoidalCursor <$!>
+      Internal.newCursor (Internal.OffsetKey (Internal.serialiseKey offset)) th
 
 {-# SPECIALISE closeCursor :: Cursor IO k v -> IO () #-}
 -- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -330,12 +330,15 @@ type Cursor = Internal.NormalCursor
 --
 -- If possible, it is recommended to use this function instead of 'newCursor'
 -- and 'closeCursor'.
+--
+-- TODO: Also provide `withCursorAtOffset` variant?
 withCursor ::
      IOLike m
   => TableHandle m k v blob
   -> (Cursor m k v blob -> m a)
   -> m a
-withCursor (Internal.NormalTable th) action = Internal.withCursor th (action . Internal.NormalCursor)
+withCursor (Internal.NormalTable th) action =
+    Internal.withCursor Internal.NoOffsetKey th (action . Internal.NormalCursor)
 
 {-# SPECIALISE newCursor :: TableHandle IO k v blob -> IO (Cursor IO k v blob) #-}
 -- | Create a new cursor to read from a given table. Future updates to the table
@@ -346,11 +349,14 @@ withCursor (Internal.NormalTable th) action = Internal.withCursor th (action . I
 --
 -- NOTE: cursors hold open resources (such as open files) and should be closed
 -- using 'close' as soon as they are no longer used.
+--
+-- TODO: Also provide `newCursorAtOffset` variant?
 newCursor ::
      IOLike m
   => TableHandle m k v blob
   -> m (Cursor m k v blob)
-newCursor (Internal.NormalTable th) = Internal.NormalCursor <$!> Internal.newCursor th
+newCursor (Internal.NormalTable th) =
+    Internal.NormalCursor <$!> Internal.newCursor Internal.NoOffsetKey th
 
 {-# SPECIALISE closeCursor :: Cursor IO k v blob -> IO () #-}
 -- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -70,7 +70,9 @@ module Database.LSMTree.Normal (
     -- ** Cursor
   , Cursor
   , withCursor
+  , withCursorAtOffset
   , newCursor
+  , newCursorAtOffset
   , closeCursor
   , readCursor
     -- ** Updates
@@ -330,8 +332,6 @@ type Cursor = Internal.NormalCursor
 --
 -- If possible, it is recommended to use this function instead of 'newCursor'
 -- and 'closeCursor'.
---
--- TODO: Also provide `withCursorAtOffset` variant?
 withCursor ::
      IOLike m
   => TableHandle m k v blob
@@ -339,6 +339,24 @@ withCursor ::
   -> m a
 withCursor (Internal.NormalTable th) action =
     Internal.withCursor Internal.NoOffsetKey th (action . Internal.NormalCursor)
+
+{-# SPECIALISE withCursorAtOffset :: SerialiseKey k => k -> TableHandle IO k v blob -> (Cursor IO k v blob -> IO a) -> IO a #-}
+-- | A variant of 'withCursor' that allows initialising the cursor at an offset
+-- within the table such that the first entry the cursor returns will be the
+-- one with the lowest key that is greater than or equal to the given key.
+-- In other words, it uses an inclusive lower bound.
+--
+-- NOTE: The ordering of the serialised keys will be used, which can lead to
+-- unexpected results if the 'SerialiseKey' instance is not order-preserving!
+withCursorAtOffset ::
+     (IOLike m, SerialiseKey k)
+  => k
+  -> TableHandle m k v blob
+  -> (Cursor m k v blob -> m a)
+  -> m a
+withCursorAtOffset offset (Internal.NormalTable th) action =
+    Internal.withCursor (Internal.OffsetKey (Internal.serialiseKey offset)) th $
+      action . Internal.NormalCursor
 
 {-# SPECIALISE newCursor :: TableHandle IO k v blob -> IO (Cursor IO k v blob) #-}
 -- | Create a new cursor to read from a given table. Future updates to the table
@@ -349,14 +367,29 @@ withCursor (Internal.NormalTable th) action =
 --
 -- NOTE: cursors hold open resources (such as open files) and should be closed
 -- using 'close' as soon as they are no longer used.
---
--- TODO: Also provide `newCursorAtOffset` variant?
 newCursor ::
      IOLike m
   => TableHandle m k v blob
   -> m (Cursor m k v blob)
 newCursor (Internal.NormalTable th) =
     Internal.NormalCursor <$!> Internal.newCursor Internal.NoOffsetKey th
+
+{-# SPECIALISE newCursorAtOffset :: SerialiseKey k => k -> TableHandle IO k v blob -> IO (Cursor IO k v blob) #-}
+-- | A variant of 'newCursor' that allows initialising the cursor at an offset
+-- within the table such that the first entry the cursor returns will be the
+-- one with the lowest key that is greater than or equal to the given key.
+-- In other words, it uses an inclusive lower bound.
+--
+-- NOTE: The ordering of the serialised keys will be used, which can lead to
+-- unexpected results if the 'SerialiseKey' instance is not order-preserving!
+newCursorAtOffset ::
+     (IOLike m, SerialiseKey k)
+  => k
+  -> TableHandle m k v blob
+  -> m (Cursor m k v blob)
+newCursorAtOffset offset (Internal.NormalTable th) =
+    Internal.NormalCursor <$!>
+      Internal.newCursor (Internal.OffsetKey (Internal.serialiseKey offset)) th
 
 {-# SPECIALISE closeCursor :: Cursor IO k v blob -> IO () #-}
 -- | Close a cursor. 'closeCursor' is idempotent. All operations on a closed

--- a/test/Database/LSMTree/Model/Monoidal.hs
+++ b/test/Database/LSMTree/Model/Monoidal.hs
@@ -216,9 +216,15 @@ data Cursor k v = Cursor
 type role Cursor nominal nominal
 
 newCursor ::
-     Table k v
+     SerialiseKey k
+  => Maybe k
+  -> Table k v
   -> Cursor k v
-newCursor tbl = Cursor (Map.toList $ _values tbl)
+newCursor offset tbl = Cursor (skip $ Map.toList $ _values tbl)
+  where
+    skip = case offset of
+      Nothing -> id
+      Just k  -> dropWhile ((< serialiseKey k) . fst)
 
 readCursor ::
      (SerialiseKey k, SerialiseValue v)

--- a/test/Database/LSMTree/Model/Normal.hs
+++ b/test/Database/LSMTree/Model/Normal.hs
@@ -243,9 +243,15 @@ data Cursor k v blob = Cursor
 type role Cursor nominal nominal nominal
 
 newCursor ::
-     Table k v blob
+     SerialiseKey k
+  => Maybe k
+  -> Table k v blob
   -> Cursor k v blob
-newCursor tbl = Cursor (Map.toList $ _values tbl)
+newCursor offset tbl = Cursor (skip $ Map.toList $ _values tbl)
+  where
+    skip = case offset of
+      Nothing -> id
+      Just k  -> dropWhile ((< serialiseKey k) . fst)
 
 readCursor ::
      (SerialiseKey k, SerialiseValue v)

--- a/test/Database/LSMTree/Model/Normal/Session.hs
+++ b/test/Database/LSMTree/Model/Normal/Session.hs
@@ -520,15 +520,17 @@ data Cursor k v blob = Cursor {
 newCursor ::
      forall k v blob m. (
        MonadState Model m, MonadError Err m
+     , Model.SerialiseKey k
      , C k v blob
      )
-  => TableHandle k v blob
+  => Maybe k
+  -> TableHandle k v blob
   -> m (Cursor k v blob)
-newCursor th = do
+newCursor offset th = do
   table <- snd <$> guardTableHandleIsOpen th
   state $ \Model{..} ->
     let cursor = Cursor { cursorID = nextID }
-        someCursor = toSomeCursor $ Model.newCursor table
+        someCursor = toSomeCursor $ Model.newCursor offset table
         cursors' = Map.insert nextID someCursor cursors
         nextID' = nextID + 1
         model' = Model {

--- a/test/Database/LSMTree/ModelIO/Monoidal.hs
+++ b/test/Database/LSMTree/ModelIO/Monoidal.hs
@@ -239,12 +239,13 @@ data Cursor m k v = Cursor {
     }
 
 newCursor ::
-     IOLike m
-  => TableHandle m k v
+     (IOLike m, SerialiseKey k)
+  => Maybe k
+  -> TableHandle m k v
   -> m (Cursor m k v)
-newCursor TableHandle{..} = atomically $
+newCursor offset TableHandle{..} = atomically $
     withModel "newCursor" "table handle" thSession thRef $ \(tbl) -> do
-      cRef <- newTMVar (Model.newCursor tbl)
+      cRef <- newTMVar (Model.newCursor offset tbl)
       i <- new_handle thSession cRef
       pure Cursor {
           cSession = thSession

--- a/test/Database/LSMTree/ModelIO/Normal.hs
+++ b/test/Database/LSMTree/ModelIO/Normal.hs
@@ -311,12 +311,13 @@ data Cursor m k v blob = Cursor {
     }
 
 newCursor ::
-     IOLike m
-  => TableHandle m k v blob
+     (IOLike m, SerialiseKey k)
+  => Maybe k
+  -> TableHandle m k v blob
   -> m (Cursor m k v blob)
-newCursor TableHandle{..} = atomically $
+newCursor offset TableHandle{..} = atomically $
     withModel "newCursor" "table handle" thSession thRef $ \(_updc, tbl) -> do
-      cRef <- newTMVar (Model.newCursor tbl)
+      cRef <- newTMVar (Model.newCursor offset tbl)
       i <- new_handle thSession cRef
       pure Cursor {
           cSession = thSession

--- a/test/Test/Database/LSMTree/Internal/RunReader.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReader.hs
@@ -192,9 +192,11 @@ readKOps ::
   -> Run IO (FS.Handle h)
   -> IO [SerialisedKOp]
 readKOps fs hbio offset run = do
-    reader <- Reader.new fs hbio offset run
+    reader <- Reader.new fs hbio offsetKey run
     go reader
   where
+    offsetKey = maybe Reader.NoOffsetKey (Reader.OffsetKey . coerce) offset
+
     go reader = do
       Reader.next fs hbio reader >>= \case
         Reader.Empty -> return []

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -344,7 +344,8 @@ runIO act lu = case act of
                          traverse (traverse (WBB.addBlob hfs wbblobs)) .
                          unTypedWriteBuffer)
                         wb
-        mreaders <- Readers.new hfs hbio (coerce offset) wb' runs
+        let offsetKey = maybe Readers.NoOffsetKey (Readers.OffsetKey . coerce) offset
+        mreaders <- Readers.new hfs hbio offsetKey wb' runs
         case mreaders of
           Nothing -> do
             traverse_ Run.removeReference runs

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -344,7 +344,7 @@ runIO act lu = case act of
                          traverse (traverse (WBB.addBlob hfs wbblobs)) .
                          unTypedWriteBuffer)
                         wb
-        mreaders <- Readers.newAtOffsetMaybe hfs hbio (coerce offset) wb' runs
+        mreaders <- Readers.new hfs hbio (coerce offset) wb' runs
         case mreaders of
           Nothing -> do
             traverse_ Run.removeReference runs


### PR DESCRIPTION
# Description

Makes use of #346 to optionally initialise cursors at an offset. This is exposed in the public API and will be the foundation for range lookups.
