### PR TITLE
Enable returning BlobRefs in the API, enable tests, and minor fixes

### DIFF
--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -237,6 +237,9 @@ listSnapshots (Internal.Session' sesh) = Internal.listSnapshots sesh
 -- reference originated from is not updated or closed, the blob reference will
 -- be valid.
 --
+-- Exception: currently the 'snapshot' operation /also/ invalidates 'BlobRef's,
+-- but it should not do. See <https://github.com/IntersectMBO/lsm-tree/issues/392>
+--
 -- TODO: get rid of the @m@ parameter?
 type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -863,13 +863,14 @@ newCursor !offsetKey th = withOpenTable th $ \thEnv -> do
     -- 'sessionOpenTables'.
     withOpenSession cursorSession $ \_ -> do
       withTempRegistry $ \reg -> do
-        (writeBuffer, writeBufferBlobs, cursorRuns) <-
+        (wb, wbblobs, cursorRuns) <-
           allocTableContent reg (tableContent thEnv)
         cursorReaders <-
           allocateMaybeTemp reg
-            (Readers.new hfs hbio offsetKey (Just writeBuffer) cursorRuns)
+            (Readers.new hfs hbio
+               offsetKey (Just (wb, wbblobs)) cursorRuns)
             (Readers.close hfs hbio)
-        let cursorWBB = writeBufferBlobs
+        let cursorWBB = wbblobs
         cursorState <- newMVar (CursorOpen CursorEnv {..})
         let !cursor = Cursor {cursorState, cursorTracer}
         -- Track cursor, but careful: If now an exception is raised, all

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -36,7 +36,6 @@ module Database.LSMTree.Internal.WriteBuffer (
     null,
     lookups,
     lookup,
-    lookups',
     rangeLookups,
 ) where
 
@@ -152,14 +151,6 @@ lookup ::
 lookup (WB !m) !k = case Map.lookup k m of
     Nothing -> Nothing
     Just x  -> Just $! errOnBlob x
-
--- | TODO: remove 'lookups' or 'lookups'', depending on which one we end up
--- using, once blob references are implemented
-lookups' ::
-     WriteBuffer
-  -> V.Vector SerialisedKey
-  -> V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m h)))
-lookups' wb !ks = V.mapStrict (lookup wb) ks
 
 -- | TODO: remove once blob references are implemented
 errOnBlob :: Entry SerialisedValue BlobSpan -> Entry SerialisedValue (WeakBlobRef m h)

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -44,7 +44,7 @@ import qualified Data.Map.Range as Map.R
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
-import           Database.LSMTree.Internal.BlobRef (BlobSpan, WeakBlobRef)
+import           Database.LSMTree.Internal.BlobRef (BlobSpan)
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Monoidal as Monoidal
 import qualified Database.LSMTree.Internal.Normal as Normal
@@ -147,17 +147,8 @@ lookups (WB !m) !ks = V.mapStrict (`Map.lookup` m) ks
 lookup ::
      WriteBuffer
   -> SerialisedKey
-  -> Maybe (Entry SerialisedValue (WeakBlobRef m h))
-lookup (WB !m) !k = case Map.lookup k m of
-    Nothing -> Nothing
-    Just x  -> Just $! errOnBlob x
-
--- | TODO: remove once blob references are implemented
-errOnBlob :: Entry SerialisedValue BlobSpan -> Entry SerialisedValue (WeakBlobRef m h)
-errOnBlob (Insert v)           = Insert v
-errOnBlob (InsertWithBlob _ b) = error $ "lookups: blob references not supported: " ++ show b
-errOnBlob (Mupdate v)          = Mupdate v
-errOnBlob Delete               = Delete
+  -> Maybe (Entry SerialisedValue BlobSpan)
+lookup (WB !m) !k = Map.lookup k m
 
 {-------------------------------------------------------------------------------
   RangeQueries

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -170,7 +170,7 @@ addBlob fs WriteBufferBlobs {blobFileName, blobFileState} blob = do
         -- we can also be asked to retrieve blobs at any time.
         blobFileHandle <- FS.hOpen fs blobFileName (FS.ReadWriteMode FS.MustBeNew)
         blobFilePointer <- newFilePointer
-        P.writeMutVar blobFileState OpenBlobFile {
+        P.writeMutVar blobFileState $! OpenBlobFile {
           blobFileHandle,
           blobFilePointer
         }

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -479,6 +479,9 @@ deletes = updates . fmap (,Delete)
 -- lookup can include a 'BlobRef', which can be used to retrieve the actual
 -- 'Blob'.
 --
+-- Note that 'BlobRef's can become invalid if the table is modified. See
+-- 'BlobRef' for the exact rules on blob reference validity.
+--
 -- Blob lookups can be performed concurrently from multiple Haskell threads.
 retrieveBlobs ::
      (IOLike m, SerialiseValue blob)

--- a/test/Database/LSMTree/Class/Normal.hs
+++ b/test/Database/LSMTree/Class/Normal.hs
@@ -245,14 +245,8 @@ instance IsTableHandle R.TableHandle where
     new = R.new
     close = R.close
     lookups = flip R.lookups
-    -- TODO: This is temporary, because it will otherwise make class tests fail.
-    -- Allow updates with blobs once blob retrieval is implemented.
-    updates th upds = flip R.updates th $ flip V.map upds $ \case
-        (k, R.Insert v _) -> (k, R.Insert v Nothing)
-        upd -> upd
-    -- TODO: This is temporary, because it will otherwise make class tests fail.
-    -- Allow inserts with blobs once blob retrieval is implemented.
-    inserts th ins = flip R.inserts th $ flip V.map ins $ \(k, v, _) -> (k, v, Nothing)
+    updates = flip R.updates
+    inserts = flip R.inserts
     deletes = flip R.deletes
 
     rangeLookup = flip R.rangeLookup

--- a/test/Database/LSMTree/Model/Normal/Session.hs
+++ b/test/Database/LSMTree/Model/Normal/Session.hs
@@ -440,8 +440,19 @@ snapshot ::
   -> TableHandle k v blob
   -> m ()
 snapshot name th@TableHandle{..} = do
-    table <- snd <$> guardTableHandleIsOpen th
+    (updc, table) <- guardTableHandleIsOpen th
     snaps <- gets snapshots
+    -- TODO: For the moment we allow snapshot to invalidate blob refs.
+    -- Ideally we should change the implementation to not invalidate on
+    -- snapshot, and then we can remove the artificial invalidation from
+    -- the model (i.e. delete the lines below that increments updc).
+    -- Furthermore, we invalidate them _before_ checking if there is a
+    -- duplicate snapshot. This is a bit barmy, but it matches the
+    -- implementation. The implementation should be fixed.
+    -- TODO: See https://github.com/IntersectMBO/lsm-tree/issues/392
+    modify (\m -> m {
+        tableHandles = Map.insert tableHandleID (updc + 1, toSomeTable table) (tableHandles m)
+      })
     when (Map.member name snaps) $
       throwError ErrSnapshotExists
     modify (\m -> m {

--- a/test/Test/Database/LSMTree/Class/Normal.hs
+++ b/test/Test/Database/LSMTree/Class/Normal.hs
@@ -71,13 +71,12 @@ tests = testGroup "Test.Database.LSMTree.Class.Normal"
       , False
       , False
       , True
-        --TODO: Blobs are now enabled but cursors do not yet support them
-      , True
-      , True
-      , True
-      , True
-      , True
-      , True
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
       , False
       , False
       , False

--- a/test/Test/Database/LSMTree/Class/Normal.hs
+++ b/test/Test/Database/LSMTree/Class/Normal.hs
@@ -59,24 +59,25 @@ tests = testGroup "Test.Database.LSMTree.Class.Normal"
     expectFailures2 = [
         False
       , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
+      , False
       , True
-      , False
-      , False
-      , False
-      , True
-      , False
+        --TODO: Blobs are now enabled but cursors do not yet support them
       , True
       , True
-      , False
-      , False
-      , False
       , True
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
+      , True
+      , True
+      , True
       , False
       , False
       , False

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -341,7 +341,7 @@ runIO act lu = case act of
           (map unTypedWriteBuffer wbs)
       newReaders <- liftIO $ do
         wbblobs <- WBB.new hfs (FS.mkFsPath ["wb.blobs"])
-        wb' <- traverse (fmap WB.fromMap .
+        wb' <- traverse (fmap (flip (,) wbblobs . WB.fromMap) .
                          traverse (traverse (WBB.addBlob hfs wbblobs)) .
                          unTypedWriteBuffer)
                         wb


### PR DESCRIPTION
This should now complete the functionality and testing for the blobs feature.

Previous PRs changed the way blobs were managed in the write buffer. This PR does the final wiring between lookups in the write buffer and returning BlobRefs via the public API.

Then it also enables generating blobs and blobrefs in various tests. In particular this includes the state machine tests. Enabling these uncovered a few mismatches between the model and implementation. See issue #392.

It also covers some of the overlap between cursors and blobs: returning blob references from cursors is now enabled and the tests are passing.

There are sill some TODOs that would be nice to do. In particular the way the write buffer is handled during lookup is rather ugly. The use of the write buffer could be properly integrated into `lookupIO`. And related, there's more allocations than necessary in various conversions in the lookup process, and part of that is to do with blob references.