### PR TITLE
Let RunReaders take a vector of runs

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
@@ -9,6 +9,7 @@ import           Data.Foldable (traverse_)
 import qualified Data.Foldable as Fold
 import qualified Data.List as List
 import           Data.Maybe (fromMaybe)
+import qualified Data.Vector as V
 import           Data.Word (Word64)
 import           Database.LSMTree.Extras.Orphans ()
 import qualified Database.LSMTree.Extras.Random as R
@@ -246,7 +247,7 @@ outputRunPaths = RunFsPaths (FS.mkFsPath []) (RunNumber 0)
 inputRunPaths :: [Run.RunFsPaths]
 inputRunPaths = RunFsPaths (FS.mkFsPath []) . RunNumber <$> [1..]
 
-type InputRuns = [Run IO (FS.Handle FS.HandleIO)]
+type InputRuns = V.Vector (Run IO (FS.Handle FS.HandleIO))
 
 type Mappend = SerialisedValue -> SerialisedValue -> SerialisedValue
 
@@ -352,7 +353,8 @@ randomRuns ::
   -> StdGen
   -> IO InputRuns
 randomRuns hasFS hasBlockIO config@Config {..} =
-      zipWithM (createRun hasFS hasBlockIO mergeMappend) inputRunPaths
+      fmap V.fromList
+    . zipWithM (createRun hasFS hasBlockIO mergeMappend) inputRunPaths
     . zipWith (randomKOps config) nentries
     . List.unfoldr (Just . R.split)
 

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -854,8 +854,7 @@ newCursor !offsetKey th = withOpenTable th $ \thEnv -> do
           allocTableContent reg (tableContent thEnv)
         cursorReaders <-
           allocateMaybeTemp reg
-            (Readers.new hfs hbio
-               offsetKey (Just writeBuffer) (V.toList cursorRuns))
+            (Readers.new hfs hbio offsetKey (Just writeBuffer) cursorRuns)
             (Readers.close hfs hbio)
         cursorState <- newMVar (CursorOpen CursorEnv {..})
         let !cursor = Cursor {cursorState, cursorTracer}

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -28,7 +28,6 @@ import           Control.Monad.Primitive
 import           Control.TempRegistry
 import           Control.Tracer
 import           Data.BloomFilter (Bloom)
-import           Data.Foldable
 import           Data.Primitive.MutVar
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.Assertions (assert)
@@ -613,7 +612,7 @@ mergeRuns ::
   -> V.Vector (Run m (Handle h))
   -> m (Run m (Handle h))
 mergeRuns resolve hfs hbio caching alloc runPaths mergeLevel runs = do
-    Merge.new hfs hbio caching alloc mergeLevel resolve runPaths (toList runs) >>= \case
+    Merge.new hfs hbio caching alloc mergeLevel resolve runPaths runs >>= \case
       Nothing -> error "mergeRuns: no inputs"
       Just merge -> go merge
   where

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -13,6 +13,7 @@ import           Data.Coerce (coerce)
 import           Data.Foldable (toList, traverse_)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
+import qualified Data.Vector as V
 import           Data.Word (Word64)
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..),
@@ -345,7 +346,7 @@ runIO act lu = case act of
                          unTypedWriteBuffer)
                         wb
         let offsetKey = maybe Readers.NoOffsetKey (Readers.OffsetKey . coerce) offset
-        mreaders <- Readers.new hfs hbio offsetKey wb' runs
+        mreaders <- Readers.new hfs hbio offsetKey wb' (V.fromList runs)
         case mreaders of
           Nothing -> do
             traverse_ Run.removeReference runs


### PR DESCRIPTION
# Description

As mentioned in https://github.com/IntersectMBO/lsm-tree/pull/389#discussion_r1761564110, this avoids a few conversions between lists and vectors.

