### PR TITLE
Swapping IO for abstract IO type-classes

### DIFF
--- a/test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Database/LSMTree/Class/Monoidal.hs
@@ -46,19 +46,29 @@ class (IsSession (Session h)) => IsTableHandle h where
         -> m ()
 
     lookups ::
-            (IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v)
+           ( IOLike m
+           , ResolveValue v
+           , SerialiseKey k
+           , SerialiseValue v
+           )
         => h m k v
         -> V.Vector k
         -> m (V.Vector (LookupResult v))
 
     rangeLookup ::
-            (IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v)
+           ( IOLike m
+           , ResolveValue v
+           , SerialiseKey k
+           , SerialiseValue v
+           )
         => h m k v
         -> Range k
         -> m (V.Vector (QueryResult k v))
 
     newCursor ::
-           (IOLike m, SerialiseKey k)
+           ( IOLike m
+           , SerialiseKey k
+           )
         => Maybe k
         -> h m k v
         -> m (Cursor h m k v)
@@ -70,94 +80,110 @@ class (IsSession (Session h)) => IsTableHandle h where
         -> m ()
 
     readCursor ::
-           (IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v)
+           ( IOLike m
+           , ResolveValue v
+           , SerialiseKey k
+           , SerialiseValue v
+           )
         => proxy h
         -> Int
         -> Cursor h m k v
         -> m (V.Vector (QueryResult k v))
 
     updates ::
-        ( IOLike m
-        , SerialiseKey k
-        , SerialiseValue v
-        , ResolveValue v
-        )
+           ( IOLike m
+           , SerialiseKey k
+           , SerialiseValue v
+           , ResolveValue v
+           )
         => h m k v
         -> V.Vector (k, Update v)
         -> m ()
 
     inserts ::
-        ( IOLike m
-        , SerialiseKey k
-        , SerialiseValue v
-        , ResolveValue v
-        )
+           ( IOLike m
+           , SerialiseKey k
+           , SerialiseValue v
+           , ResolveValue v
+           )
         => h m k v
         -> V.Vector (k, v)
         -> m ()
 
     deletes ::
-        ( IOLike m
-        , SerialiseKey k
-        , SerialiseValue v
-        , ResolveValue v
-        )
+           ( IOLike m
+           , SerialiseKey k
+           , SerialiseValue v
+           , ResolveValue v
+           )
         => h m k v
         -> V.Vector k
         -> m ()
 
     mupserts ::
-        ( IOLike m
-        , SerialiseKey k
-        , SerialiseValue v
-        , ResolveValue v
-        )
+           ( IOLike m
+           , SerialiseKey k
+           , SerialiseValue v
+           , ResolveValue v
+           )
         => h m k v
         -> V.Vector (k, v)
         -> m ()
 
     snapshot ::
-        ( IOLike m, SerialiseKey k, SerialiseValue v, ResolveValue v
-        , Labellable (k, v)
-          -- Model-specific constraints
-        , Typeable k, Typeable v
-        )
+           ( IOLike m
+           , Labellable (k, v)
+           , ResolveValue v
+           , SerialiseKey k
+           , SerialiseValue v
+             -- Model-specific constraints
+           , Typeable k, Typeable v
+           )
         => SnapshotName
         -> h m k v
         -> m ()
 
     open ::
-        ( IOLike m, SerialiseKey k, SerialiseValue v
-        , Labellable (k, v)
-          -- Model-specific constraints
-        , Typeable k, Typeable v
-        )
+           ( IOLike m
+           , Labellable (k, v)
+           , SerialiseKey k
+           , SerialiseValue v
+             -- Model-specific constraints
+           , Typeable k, Typeable v
+           )
         => Session h m
         -> SnapshotName
         -> m (h m k v)
 
     duplicate ::
-            IOLike m
+           IOLike m
         => h m k v
         -> m (h m k v)
 
     merge ::
-        (IOLike m, SerialiseValue v, ResolveValue v)
+           ( IOLike m
+           , ResolveValue v
+           , SerialiseValue v
+           )
         => h m k v
         -> h m k v
         -> m (h m k v)
 
-withTableNew ::
-     forall h m k v a. (IOLike m, IsTableHandle h)
+withTableNew :: forall h m k v a.
+     ( IOLike m
+     , IsTableHandle h
+     )
   => Session h m
   -> TableConfig h
   -> (h m k v -> m a)
   -> m a
 withTableNew sesh conf = bracket (new sesh conf) close
 
-withTableOpen ::
-     forall h m k v a. ( IOLike m, IsTableHandle h
-     , SerialiseKey k, SerialiseValue v
+withTableOpen :: forall h m k v a.
+     ( IOLike m
+     , IsTableHandle h
+     , SerialiseKey k
+     , SerialiseValue v
      , Labellable (k, v)
      , Typeable k, Typeable v
      )
@@ -167,16 +193,20 @@ withTableOpen ::
   -> m a
 withTableOpen sesh snap = bracket (open sesh snap) close
 
-withTableDuplicate ::
-     forall h m k v a. (IOLike m, IsTableHandle h)
+withTableDuplicate :: forall h m k v a.
+     ( IOLike m
+     , IsTableHandle h
+     )
   => h m k v
   -> (h m k v -> m a)
   -> m a
 withTableDuplicate table = bracket (duplicate table) close
 
-withTableMerge ::
-     forall h m k v a. (IOLike m, IsTableHandle h
-     , SerialiseValue v, ResolveValue v
+withTableMerge :: forall h m k v a.
+     ( IOLike m
+     , IsTableHandle h
+     , SerialiseValue v
+     , ResolveValue v
      )
   => h m k v
   -> h m k v
@@ -184,8 +214,11 @@ withTableMerge ::
   -> m a
 withTableMerge table1 table2 = bracket (merge table1 table2) close
 
-withCursor ::
-     forall h m k v a. (IOLike m, IsTableHandle h, SerialiseKey k)
+withCursor :: forall h m k v a.
+     ( IOLike m
+     , IsTableHandle h
+     , SerialiseKey k
+     )
   => Maybe k
   -> h m k v
   -> (Cursor h m k v -> m a)

--- a/test/Test/Database/LSMTree/Class/Monoidal.hs
+++ b/test/Test/Database/LSMTree/Class/Monoidal.hs
@@ -130,8 +130,10 @@ data Setup h m = Setup {
   }
 
 -- | create session, table handle, and populate it with some data.
-withTableNew ::
-     forall h m a. (IsTableHandle h, IOLike m)
+withTableNew :: forall h m a.
+     ( IsTableHandle h
+     , IOLike m
+     )
   => Setup h m
   -> [(Key, Update Value)]
   -> (Session h m -> h m Key Value -> m a)
@@ -143,11 +145,17 @@ withTableNew Setup{..} ups action =
           updates table (V.fromList ups)
           action sesh table
 
-readCursorAll ::
-     forall h m k v proxy. ( IsTableHandle h, IOLike m
-     , SerialiseKey k, SerialiseValue v, ResolveValue v
+readCursorAll :: forall h m k v proxy.
+     ( IsTableHandle h
+     , IOLike m
+     , SerialiseKey k
+     , SerialiseValue v
+     , ResolveValue v
      )
-  => proxy h -> Cursor h m k v -> CursorReadSchedule -> m [V.Vector (QueryResult k v)]
+  => proxy h
+  -> Cursor h m k v
+  -> CursorReadSchedule
+  -> m [V.Vector (QueryResult k v)]
 readCursorAll hdl cursor = go . getCursorReadSchedule
   where
     go [] = error "readCursorAll: finite infinite list"

--- a/test/Test/Util/Orphans.hs
+++ b/test/Test/Util/Orphans.hs
@@ -19,7 +19,7 @@ import qualified Control.Concurrent.STM as Real
 import           Control.Monad ((<=<))
 import           Control.Monad.IOSim (IOSim)
 import           Data.Kind (Type)
-import           Database.LSMTree.Common (BlobRef, SerialiseValue)
+import           Database.LSMTree.Common (BlobRef, IOLike, SerialiseValue)
 import           Database.LSMTree.Internal.Serialise (SerialiseKey)
 import           Database.LSMTree.Normal (LookupResult, QueryResult,
                      TableHandle)
@@ -35,9 +35,7 @@ import           Test.Util.TypeFamilyWrappers (WrapBlob (..), WrapBlobRef (..),
   IOSim
 -------------------------------------------------------------------------------}
 
-{- TODO: temporarily disabled until we start on I/O fault testing.
 instance IOLike (IOSim s)
--}
 
 type instance Realized (IOSim s) a = RealizeIOSim s a
 


### PR DESCRIPTION
# Refactor to use `io-classes` type-classes instead of `IO`

A reasonably large-scale refactoring (of API type signatures) which addresses the numerous TODO annotations stating *"replace by* [`io-classes`](https://hackage.haskell.org/package/io-classes) *constraints for IO simulation"* in order to provide a more general, polymorphic API for users of the `lsm-tree` library. The indirect object to be replaced that the TODO annotation references are the `m ~ IO` constraints found on the same line(s) prefixing the TODO annotation, allowing the post-refactoring functions to abstract over `IO` operations rather than exposing an API which is specialized to `IO`. While most TODO annotations were in the `Database.LSMTree.Internal` module, this PR touches many additional modules. This wide footprint of changes is necessary because the `Database.LSMTree.Internal` module imports many other modules from the `lsm-tree` project, hence each of these "dependency modules" required a "IO-abstraction" API update in order to facilitate the "IO-abstraction" of the `Database.LSMTree.Internal` module.

The [`io-classes`](https://hackage.haskell.org/package/io-classes) which are utilized in place of specialized `IO` functions are:
  * [`MonadCatch`](https://hackage.haskell.org/package/io-classes/docs/Control-Monad-Class-MonadThrow.html#t:MonadCatch)
  * [`MonadMask`](https://hackage.haskell.org/package/io-classes/docs/Control-Monad-Class-MonadThrow.html#t:MonadMask)
  * [`MonadMVar`](https://hackage.haskell.org/package/io-classes/docs/Control-Concurrent-Class-MonadMVar.html)
  * [`MonadSTM`](https://hackage.haskell.org/package/io-classes/docs/Control-Concurrent-Class-MonadSTM.html)
  * [`MonadST`](https://hackage.haskell.org/package/io-classes/docs/Control-Monad-Class-MonadST.html)
  * [`MonadThrow`](https://hackage.haskell.org/package/io-classes/docs/Control-Monad-Class-MonadThrow.html#t:MonadThrow)

### Important Note
Wherever the PR updated a module API from exposing a specialized `IO` version of a function to a generalized `io-classes` function, a `SPECIALISE` directive was also added which specializes the polymorphic `m` type parameter to `IO`. The rational here is to have the module's interface file still expose a version of the function which is specialized to `IO` in order to prevent any performance regressions. However, this may be excessive and result in unnecessarily longer compiler times and code sizes.

*I would like some commentary from reviewers more experience balancing* `SPECIALISE` *directive usage as to whether the abundant and boilerplate additions of the*`SPECIALISE` *directives are a wise decision.*