### PR TITLE
Make the`Refcounter`'s `finaliser` field  less strict.

### DIFF
--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -57,10 +57,6 @@ mkRefCounterN :: PrimMonad m => RefCount -> Maybe (m ()) -> m (Maybe (RefCounter
 mkRefCounterN (RefCount !n) finaliser
   | n < 1 = pure Nothing
   | otherwise = do
-    -- evaluate the finaliser a little bit before we store it
-    let !() = case finaliser of
-                Nothing       -> ()
-                Just !_action -> ()
     countVar <- newPrimVar $! n
     pure $! Just $! RefCounter{countVar, finaliser}
 

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -446,8 +446,7 @@ instance Typeable (PrimState m) => NoThunks (RefCounter m) where
     (RefCounter (a :: PrimVar (PrimState m) Int) (b :: Maybe (m ())))
     = allNoThunks [
           noThunks ctx a
-          -- it is okay to use @$!@ because @b :: Maybe _@ was already in WHNF
-        , noThunks ctx $! (OnlyCheckWhnfNamed <$> b :: Maybe (OnlyCheckWhnfNamed "finaliser" (m ())))
+        , noThunks ctx $ (OnlyCheckWhnfNamed b :: OnlyCheckWhnfNamed "finaliser" (Maybe (m ())))
         ]
 
 deriving stock instance Generic RefCount


### PR DESCRIPTION
In two places, we use `RecursiveDo` to attach a `RefCounter` with finaliser to a `Run`. Because we evaluate the finaliser as much as possible before storing it in the `RefCounter`, we are getting "cyclic evaluation" errors in some cases where we use recursive `do` (i.e., `fixIO`). To prevent these errors from occurring, we instead do not evaluate the finaliser at all before storing it in a `RefCounter`.
