### PR TITLE
Fix a bug where `RWVar` was not actually biased towards writers

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -756,7 +756,7 @@ updates resolve es th = do
     withOpenTable th $ \thEnv -> do
       let hfs = tableHasFS thEnv
       modifyWithTempRegistry_
-        (atomically $ RW.unsafeAcquireWriteAccess (tableContent thEnv))
+        (RW.unsafeAcquireWriteAccess (tableContent thEnv))
         (atomically . RW.unsafeReleaseWriteAccess (tableContent thEnv)) $ \reg -> do
           updatesWithInterleavedFlushes
             (TraceMerge `contramap` tableTracer th)
@@ -1142,7 +1142,7 @@ snapshot resolve snap label th = do
       -- before taking the snapshot.
       let hfs = tableHasFS thEnv
       content <- modifyWithTempRegistry
-                    (atomically $ RW.unsafeAcquireWriteAccess (tableContent thEnv))
+                    (RW.unsafeAcquireWriteAccess (tableContent thEnv))
                     (atomically . RW.unsafeReleaseWriteAccess (tableContent thEnv))
                     $ \reg content -> do
         r <- flushWriteBuffer


### PR DESCRIPTION
Resolves #388 

A `retry` in the wrong place was causing writers to wait for all readers to finish, even as new readers were added. The `RWVar` should now be more properly biased towards writers, though there is a new TODO in the code that describes how a `RWVar` could be made to be even more biased.

