### PR TITLE
WP8 benchmark lookup optimisation

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -505,12 +505,10 @@ benchmark lsm-tree-bench-wp8
   build-depends:
     , async
     , base
-    , binary
     , bytestring
     , clock
     , containers
     , contra-tracer
-    , cryptohash-sha256
     , deepseq
     , fs-api
     , lsm-tree
@@ -519,6 +517,8 @@ benchmark lsm-tree-bench-wp8
     , lsm-tree:mcg
     , optparse-applicative
     , pretty-show
+    , primitive
+    , random
     , vector
 
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -519,6 +519,7 @@ benchmark lsm-tree-bench-wp8
     , pretty-show
     , primitive
     , random
+    , transformers
     , vector
 
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded


### PR DESCRIPTION
Add a --lookup-only mode to the WP8 benchmark.

Optimise the WP8 benchmark by changing the key extension algorithm. The key extension takes an integer and extends it to a 34 byte key, intended to have a good uniform distribution in the key space. The change is that instead of using a crypto hash (SHA256), use a non-crypto PRNG (StdGen). The latter is much cheaper and allocates less.

Also do a few minor micro-optimisations.

Benchmark for 10,000,000 initial keys, and looking up 8,000 batches of 256 keys. Results on my machine, best of two runs each, before and after.

### Before
* Runtime: 27.7s
* IOPs: 74005.0 ops/sec
* Allocated: 13.6 Gb
* Productivity: 98.7%

### After
* Runtime: 25.3s
* IOPs: 80925.3 ops/sec
* Allocated: 2.7 Gb
* Productivity: 99.4%

For 8,000 batches, both before and after `dry-run --check` reports 0 true duplicates. This is reasonable evidence that this has not broken the key generation, despite using a non-crypto key extension method.