### PR TITLE
Add `Arbitrary` instantiation for primitive vectors

### DIFF
--- a/src-extras/Database/LSMTree/Extras/Generators.hs
+++ b/src-extras/Database/LSMTree/Extras/Generators.hs
@@ -617,3 +617,11 @@ instance Arbitrary Merge.Level where
   arbitrary = QC.elements [Merge.MidLevel, Merge.LastLevel]
   shrink Merge.LastLevel = [Merge.MidLevel]
   shrink Merge.MidLevel  = []
+
+{-------------------------------------------------------------------------------
+  Vectors
+-------------------------------------------------------------------------------}
+
+instance (VP.Prim a, Arbitrary a) => Arbitrary (VP.Vector a) where
+    arbitrary = VP.fromList <$> arbitrary
+    shrink = QC.shrinkMap VP.fromList VP.toList

--- a/test/Test/Database/LSMTree/Internal/Chunk.hs
+++ b/test/Test/Database/LSMTree/Internal/Chunk.hs
@@ -8,9 +8,10 @@ import           Control.Category ((>>>))
 import           Control.Monad.ST.Strict (runST)
 import qualified Data.List as List (concat, drop, length)
 import           Data.Maybe (catMaybes, fromJust, isJust, isNothing)
-import           Data.Vector.Primitive (Vector, concat, fromList, length,
-                     toList)
+import           Data.Vector.Primitive (Vector, concat, length)
 import           Data.Word (Word8)
+import           Database.LSMTree.Extras.Generators ()
+                     -- for @Arbitrary@ instantiation of @Vector@
 import           Database.LSMTree.Internal.Chunk (Chunk, createBaler, feedBaler,
                      fromChunk, unsafeEndBaler)
 import           Test.QuickCheck (Arbitrary (arbitrary, shrink),
@@ -125,12 +126,6 @@ prop_remnantChunkIsSmall (MinChunkSize minChunkSize)
     = remnantChunkSizeIs (< minChunkSize) minChunkSize
 
 -- * Test case generation and shrinking
-
-instance Arbitrary (Vector Word8) where
-
-    arbitrary = fromList <$> arbitrary
-
-    shrink = shrinkMap fromList toList
 
 {-
     The type of minimum chunk sizes.

--- a/test/Test/Database/LSMTree/Internal/Chunk.hs
+++ b/test/Test/Database/LSMTree/Internal/Chunk.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-orphans #-}
-
 module Test.Database.LSMTree.Internal.Chunk (tests) where
 
 import           Prelude hiding (concat, drop, length)


### PR DESCRIPTION
This makes the type of primitive vectors an instance of `Arbitrary`. The corresponding instance declaration is added to `Database.LSMTree.Extras.Generators`, which previously had only been used for LSM-tree-specific things. If it should be put elsewhere, the reviewer should say so. 🙂
