### PR TITLE
Use `cabal-3.12.1.0` in documentation CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ jobs:
 
     env:
       ghc: "9.6.6"
-      cabal: "3.10.2.1"
+      cabal: "3.12.1.0"
       os: ubuntu-latest"
 
     steps:
@@ -63,7 +63,7 @@ jobs:
     - name: Cache cabal store
       uses: actions/cache@v4
       env:
-        cache-name: ${{ runner.os }}-${{ env.ghc }}-documentation-cabal-store
+        cache-name: ${{ runner.os }}-${{ env.ghc }}-20241004-documentation-cabal-store
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         key: ${{ env.cache-name }}-${{ hashFiles('**/plan.json') }}


### PR DESCRIPTION
This should fix our documentation on github pages, which currently has bad hyperlinks.

