### PR TITLE
Convert reference counted resources to a new Ref API

### DIFF
--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -7,6 +7,7 @@ import           Control.Monad
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Primitive
 import           Control.Monad.ST.Strict (ST, runST)
+import           Control.RefCount (Ref)
 import           Data.Arena (ArenaManager, newArenaManager, withArena)
 import           Data.Bits ((.&.))
 import           Data.BloomFilter (Bloom)
@@ -464,7 +465,7 @@ benchLookupsIO ::
   -> ArenaManager RealWorld
   -> ResolveSerialisedValue
   -> WB.WriteBuffer
-  -> WBB.WriteBufferBlobs IO h
+  -> Ref (WBB.WriteBufferBlobs IO h)
   -> V.Vector (Run IO h)
   -> V.Vector (Bloom SerialisedKey)
   -> V.Vector IndexCompact

--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -161,9 +161,9 @@ benchmarks !caching = withFS $ \hfs hbio -> do
     putStrLn "<finished>"
 
     traceMarkerIO "Computing statistics for generated runs"
-    let numEntries = V.map Run.runNumEntries runs
-        numPages = V.map Run.sizeInPages runs
-        nhashes = V.map Bloom.hashesN blooms
+    let numEntries = V.map Run.size runs
+        numPages   = V.map Run.sizeInPages runs
+        nhashes    = V.map Bloom.hashesN blooms
         bitsPerEntry = V.zipWith
                          (\b (NumEntries n) -> fromIntegral (Bloom.length b) / fromIntegral n :: Double)
                          blooms

--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -7,7 +7,6 @@ import           Control.Monad
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Primitive
 import           Control.Monad.ST.Strict (ST, runST)
-import           Control.RefCount (RefCount (..))
 import           Data.Arena (ArenaManager, newArenaManager, withArena)
 import           Data.Bits ((.&.))
 import           Data.BloomFilter (Bloom)
@@ -371,8 +370,7 @@ lookupsEnv runSizes keyRng0 hfs hbio caching = do
     putStr "DONE"
 
     -- return runs
-    runs <- V.fromList <$>
-              mapM (Run.fromMutable caching (RefCount 1)) rbs
+    runs <- V.fromList <$> mapM (Run.fromMutable caching) rbs
     let blooms = V.map Run.runFilter runs
         indexes = V.map Run.runIndex runs
         handles = V.map Run.runKOpsFile runs

--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -5,6 +5,7 @@ module Bench.Database.LSMTree.Internal.Lookup (benchmarks) where
 import           Control.Exception (assert)
 import           Control.Monad
 import           Control.Monad.ST.Strict (stToIO)
+import           Control.RefCount
 import           Criterion.Main (Benchmark, bench, bgroup, env, envWithCleanup,
                      perRunEnv, perRunEnvWithCleanup, whnf, whnfAppIO)
 import           Data.Arena (ArenaManager, closeArena, newArena,
@@ -130,7 +131,7 @@ benchLookups conf@Config{name} =
                 )
                 (\(_, _, _, arena, wbblobs) -> do
                     closeArena arenaManager arena
-                    WBB.removeReference wbblobs)
+                    releaseRef wbblobs)
                 (\ ~(rkixs, ioops, ioress, _, wbblobs_unused) -> do
                   !_ <- intraPageLookups resolveV WB.empty wbblobs_unused
                                          rs ks rkixs ioops ioress

--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -20,7 +20,7 @@ import           Database.LSMTree.Extras.Random (frequency,
                      sampleUniformWithReplacement, uniformWithoutReplacement)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
-import           Database.LSMTree.Internal.Entry (Entry (..), unNumEntries)
+import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
 import           Database.LSMTree.Internal.Lookup (bloomQueries, indexSearches,
                      intraPageLookups, lookupsIO, prepLookups)
 import           Database.LSMTree.Internal.Page (getNumPages)
@@ -194,7 +194,7 @@ lookupsInBatchesEnv Config {..} = do
         fsps = RunFsPaths (FS.mkFsPath []) (RunNumber 0)
     wbblobs <- WBB.new hasFS (FS.mkFsPath [])
     r <- Run.fromWriteBuffer hasFS hasBlockIO caching (RunAllocFixed 10) fsps wb wbblobs
-    let nentriesReal = unNumEntries $ Run.runNumEntries r
+    let NumEntries nentriesReal = Run.size r
     assert (nentriesReal == nentries) $ pure ()
     let npagesReal = Run.sizeInPages r
     assert (getNumPages npagesReal * 42 <= nentriesReal) $ pure ()

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -515,7 +515,6 @@ benchmark lsm-tree-bench-lookups
     , lsm-tree
     , lsm-tree:blockio-api
     , lsm-tree:bloomfilter
-    , lsm-tree:control
     , lsm-tree:extras
     , primitive
     , random

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -476,6 +476,7 @@ benchmark lsm-tree-micro-bench
     , lsm-tree
     , lsm-tree:blockio-api
     , lsm-tree:bloomfilter
+    , lsm-tree:control
     , lsm-tree:extras
     , QuickCheck
     , random
@@ -515,6 +516,7 @@ benchmark lsm-tree-bench-lookups
     , lsm-tree
     , lsm-tree:blockio-api
     , lsm-tree:bloomfilter
+    , lsm-tree:control
     , lsm-tree:extras
     , primitive
     , random

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -865,6 +865,7 @@ test-suite control-test
     , io-classes
     , io-sim
     , lsm-tree:control
+    , primitive
     , QuickCheck
     , tasty
     , tasty-quickcheck

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -29,12 +29,6 @@ module Control.RefCount (
   -- * Test API
   , readRefCount
   , checkForgottenRefs
-
-    -- * Old API
-  , mkRefCounter1
-  , addReference
-  , removeReference
-  , upgradeWeakReference
   ) where
 
 import           Data.Kind (Type)
@@ -57,23 +51,6 @@ import           System.IO.Unsafe (unsafeDupablePerformIO, unsafePerformIO)
 import           System.Mem (performMajorGC)
 import           System.Mem.Weak hiding (deRefWeak)
 #endif
-
-
--------------------------------------------------------------------------------
--- Old API
---
-
-mkRefCounter1 :: PrimMonad m => m () -> m (RefCounter m)
-mkRefCounter1 = newRefCounter
-
-addReference :: PrimMonad m => RefCounter m -> m ()
-addReference = incrementRefCounter
-
-removeReference :: (PrimMonad m, MonadMask m) => RefCounter m -> m ()
-removeReference = decrementRefCounter
-
-upgradeWeakReference :: PrimMonad m => RefCounter m -> m Bool
-upgradeWeakReference = tryIncrementRefCounter
 
 
 -------------------------------------------------------------------------------

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -27,7 +27,6 @@ module Control.RefCount (
   , tryIncrementRefCounter
 
   -- * Test API
-  , readRefCount
   , checkForgottenRefs
   ) where
 
@@ -139,13 +138,6 @@ tryIncrementRefCounter RefCounter{countVar} = do
           if prevCount' == prevCount
             then return True
             else casLoop prevCount'
-
--- TODO: remove when removeRefenceN is removed
-{-# SPECIALISE readRefCount :: RefCounter IO -> IO Int #-}
--- | Warning: reading the current reference count is inherently racy as there is
--- no way to reliably act on the information. It can be useful for debugging.
-readRefCount :: PrimMonad m => RefCounter m -> m Int
-readRefCount RefCounter{countVar} = readPrimVar countVar
 
 
 -------------------------------------------------------------------------------

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -1,23 +1,84 @@
-{-# LANGUAGE MagicHash #-}
-
-{- HLINT ignore "Evaluate" -}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE MagicHash         #-}
+{-# LANGUAGE PatternSynonyms   #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module Control.RefCount (
-    RefCounter (..)
+    -- * Using references
+    Ref(DeRef)
+  , releaseRef
+  , withRef
+  , dupRef
+  , RefException (..)
+    -- ** Weak references
+  , WeakRef (..)
+  , mkWeakRef
+  , mkWeakRefFromRaw
+  , deRefWeak
+    -- * Implementing objects with finalisers
+  , RefCounted (..)
+  , newRef
+    -- ** Low level reference counts
+  , RefCounter (RefCounter)
+  , newRefCounter
+  , incrementRefCounter
+  , decrementRefCounter
+  , tryIncrementRefCounter
+
+  -- * Test API
+  , readRefCount
+  , checkForgottenRefs
+
+    -- * Old API
   , mkRefCounter1
   , addReference
   , removeReference
   , upgradeWeakReference
-  , readRefCount
   ) where
+
+import           Data.Kind (Type)
+import           Data.Primitive.PrimVar
 
 import           Control.DeepSeq
 import           Control.Exception (assert)
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive
-import           Data.Primitive.PrimVar
-import           GHC.Stack
+
+import           GHC.Stack (CallStack, prettyCallStack)
+
+#ifdef NO_IGNORE_ASSERTS
+import           Control.Concurrent (yield)
+import qualified Control.Exception
+import           Data.IORef
+import           GHC.Stack (HasCallStack, callStack)
+import           System.IO.Unsafe (unsafeDupablePerformIO, unsafePerformIO)
+import           System.Mem (performMajorGC)
+import           System.Mem.Weak hiding (deRefWeak)
+#endif
+
+
+-------------------------------------------------------------------------------
+-- Old API
+--
+
+mkRefCounter1 :: PrimMonad m => m () -> m (RefCounter m)
+mkRefCounter1 = newRefCounter
+
+addReference :: PrimMonad m => RefCounter m -> m ()
+addReference = incrementRefCounter
+
+removeReference :: (PrimMonad m, MonadMask m) => RefCounter m -> m ()
+removeReference = decrementRefCounter
+
+upgradeWeakReference :: PrimMonad m => RefCounter m -> m Bool
+upgradeWeakReference = tryIncrementRefCounter
+
+
+-------------------------------------------------------------------------------
+-- Low level RefCounter API
+--
 
 -- | A reference counter with an optional finaliser action. Once the reference
 -- count reaches @0@, the finaliser will be run.
@@ -34,38 +95,43 @@ instance NFData (RefCounter m) where
   rnf RefCounter{countVar, finaliser} =
       rwhnf countVar `seq` rwhnf finaliser
 
-{-# SPECIALISE mkRefCounter1 :: IO () -> IO (RefCounter IO) #-}
--- | Make a reference counter with initial value @1@. An optional finaliser is
--- run when the reference counter reaches @0@.
-mkRefCounter1 :: PrimMonad m => m () -> m (RefCounter m)
-mkRefCounter1 finaliser = do
+{-# SPECIALISE newRefCounter :: IO () -> IO (RefCounter IO) #-}
+-- | Make a reference counter with initial value @1@.
+--
+-- The given finaliser is run when the reference counter reaches @0@. The
+-- finaliser is run with async exceptions masked.
+--
+newRefCounter :: PrimMonad m => m () -> m (RefCounter m)
+newRefCounter finaliser = do
     countVar <- newPrimVar 1
-    pure $! RefCounter{countVar, finaliser}
+    return $! RefCounter { countVar, finaliser }
 
-{-# SPECIALISE addReference :: HasCallStack => RefCounter IO -> IO () #-}
+{-# SPECIALISE incrementRefCounter :: RefCounter IO -> IO () #-}
 -- | Increase the reference counter by one.
 --
 -- The count must be known (from context) to be non-zero already. Typically
 -- this will be because the caller has a reference already and is handing out
 -- another reference to some other code.
-addReference :: (HasCallStack, PrimMonad m) => RefCounter m -> m ()
-addReference RefCounter{countVar} = do
+incrementRefCounter :: PrimMonad m => RefCounter m -> m ()
+incrementRefCounter RefCounter{countVar} = do
     prevCount <- fetchAddInt countVar 1
-    assertWithCallStack (prevCount > 0) $ pure ()
+    assert (prevCount > 0) $ pure ()
 
-{-# SPECIALISE removeReference :: HasCallStack => RefCounter IO -> IO () #-}
+{-# SPECIALISE decrementRefCounter :: RefCounter IO -> IO () #-}
 -- | Decrease the reference counter by one.
 --
 -- The count must be known (from context) to be non-zero. Typically this will
 -- be because the caller has a reference already (that they took out themselves
 -- or were given).
-removeReference :: (HasCallStack, PrimMonad m, MonadMask m) => RefCounter m -> m ()
-removeReference RefCounter{countVar, finaliser} =
+decrementRefCounter :: (PrimMonad m, MonadMask m) => RefCounter m -> m ()
+decrementRefCounter RefCounter{countVar, finaliser} =
+    --TODO: remove mask and require all uses to run with exceptions mask.
     mask_ $ do
       prevCount <- fetchSubInt countVar 1
-      assertWithCallStack (prevCount > 0) $ pure ()
+      assert (prevCount > 0) $ pure ()
       when (prevCount == 1) finaliser
 
+{-# SPECIALISE tryIncrementRefCounter :: RefCounter IO -> IO Bool #-}
 -- | Try to turn a \"weak\" reference on something into a proper reference.
 -- This is by analogy with @deRefWeak :: Weak v -> IO (Maybe v)@, but for
 -- reference counts.
@@ -78,8 +144,8 @@ removeReference RefCounter{countVar, finaliser} =
 -- The result is @True@ when a strong reference has been obtained and @False@
 -- when upgrading fails.
 --
-upgradeWeakReference :: PrimMonad m => RefCounter m -> m Bool
-upgradeWeakReference RefCounter{countVar} = do
+tryIncrementRefCounter :: PrimMonad m => RefCounter m -> m Bool
+tryIncrementRefCounter RefCounter{countVar} = do
     prevCount <- atomicReadInt countVar
     casLoop prevCount
   where
@@ -104,8 +170,341 @@ upgradeWeakReference RefCounter{countVar} = do
 readRefCount :: PrimMonad m => RefCounter m -> m Int
 readRefCount RefCounter{countVar} = readPrimVar countVar
 
-{-# INLINE assertWithCallStack #-}
--- | Version of 'assert' that does not complain about redundant constraints when
--- compiling with @-O@ or @-fignore-asserts@.
-assertWithCallStack :: HasCallStack => Bool -> a -> a
-assertWithCallStack b = assert (const b callStack)
+
+-------------------------------------------------------------------------------
+-- Ref API
+--
+
+-- | A reference to an object of type @a@. Use references to support prompt
+-- finalisation of object resources.
+--
+-- Rules of use:
+--
+-- * Each 'Ref' must eventually be released /exactly/ once with 'releaseRef'.
+-- * Use 'withRef', or 'DeRef' to (temporarily) obtain the underlying
+--   object.
+-- * After calling 'releaseRef', the operations 'withRef' and pattern 'DeRef'
+--   must /not/ be used.
+-- * After calling 'releaseRef', an object obtained previously from
+--   'DeRef' must /not/ be used. For this reason, it is advisable to use
+--   'withRef' where possible, and be careful with use of 'DeRef'.
+-- * A 'Ref' may be duplicated using 'dupRef' to produce an independent
+--   reference (which must itself be released with 'releaseRef').
+--
+-- All of these operations are thread safe. They are not async-exception safe
+-- however: the operations that allocate or deallocate must be called with
+-- async exceptions masked. This includes 'newRef', 'dupRef' and 'releaseRef'.
+--
+-- Provided that all these rules are followed, this guarantees that the
+-- object's finaliser will be run exactly once, promptly, when the final
+-- reference is released.
+--
+-- In debug mode (when using CPP define @NO_IGNORE_ASSERTS@), adherence to
+-- these rules are checked dynamically. These dynamic checks are however not
+-- thread safe, so it is not guaranteed that all violations are always detected.
+--
+#ifndef NO_IGNORE_ASSERTS
+newtype Ref obj = Ref { refobj :: obj }
+#else
+data    Ref obj = Ref { refobj :: !obj, reftracker :: !RefTracker }
+#endif
+
+instance Show obj => Show (Ref obj) where
+  showsPrec d Ref{refobj} =
+    showParen (d > 10) $
+      showString "Ref " . showsPrec 11 refobj
+
+instance NFData obj => NFData (Ref obj) where
+  rnf Ref{refobj} = rnf refobj
+
+-- | Class of objects which support 'Ref'.
+--
+-- For objects in this class the guarantee is that (when the 'Ref' rules are
+-- followed) the object's finaliser is called exactly once.
+--
+class RefCounted obj where
+  type FinaliserM obj :: Type -> Type
+  getRefCounter       :: obj -> RefCounter (FinaliserM obj)
+
+#ifdef NO_IGNORE_ASSERTS
+#define HAS_CALL_STACK => HasCallStack
+#else
+#define HAS_CALL_STACK
+#endif
+
+-- GHC says specialising is too complicated! But it's ok, each of these can
+-- inline to calling a few other specialised helpers.
+{-# INLINE newRef #-}
+{-# INLINE releaseRef #-}
+{-# INLINE dupRef #-}
+{-# INLINE deRefWeak #-}
+
+-- | Make a new reference.
+--
+-- The given finaliser is run when the last reference is released. The
+-- finaliser is run with async exceptions masked.
+--
+newRef ::
+     (RefCounted obj, FinaliserM obj ~ m, PrimMonad m)
+     HAS_CALL_STACK
+  => m ()
+  -> (RefCounter m -> obj)
+  -> m (Ref obj)
+newRef finaliser mkObject = do
+    rc <- newRefCounter finaliser
+    let !obj = mkObject rc
+    assert (countVar (getRefCounter obj) == countVar rc) $
+      newRefWithTracker obj
+
+-- | Release a reference to an object that will no longer be used (via this
+-- reference).
+--
+releaseRef ::
+     (RefCounted obj, FinaliserM obj ~ m, PrimMonad m, MonadMask m)
+     HAS_CALL_STACK
+  => Ref obj
+  -> m ()
+releaseRef ref@Ref{refobj} = do
+    assertNoDoubleRelease ref
+    decrementRefCounter (getRefCounter refobj)
+    releaseRefTracker ref
+
+{-# COMPLETE DeRef #-}
+#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
+{-# INLINE DeRef #-}
+#endif
+-- | Get the object in a 'Ref'. Be careful with retaining the object for too
+-- long, since the object must not be used after 'releaseRef' is called.
+--
+pattern DeRef :: obj -> Ref obj
+#ifndef NO_IGNORE_ASSERTS
+pattern DeRef obj <- Ref obj
+#else
+pattern DeRef obj <- (deRef -> !obj) -- So we get assertion checking
+
+deRef :: HasCallStack => Ref obj -> obj
+deRef ref@Ref{refobj} =
+          unsafeDupablePerformIO (assertNoUseAfterRelease ref)
+    `seq` refobj
+#endif
+
+{-# INLINE withRef #-}
+-- | Use the object in a 'Ref'. Do not retain the object after the scope of
+-- the body. If you cannot use scoped \"with\" style, use pattern 'DeRef'.
+--
+withRef ::
+     forall m obj a.
+     PrimMonad m
+     HAS_CALL_STACK
+  => Ref obj
+  -> (obj -> m a)
+  -> m a
+withRef ref@Ref{refobj} f = do
+    assertNoUseAfterRelease ref
+    f refobj
+
+-- | Duplicate an existing reference, to produce a new reference.
+--
+dupRef ::
+     (RefCounted obj, FinaliserM obj ~ m, PrimMonad m)
+     HAS_CALL_STACK
+  => Ref obj
+  -> m (Ref obj)
+dupRef ref@Ref{refobj} = do
+    assertNoUseAfterRelease ref
+    incrementRefCounter (getRefCounter refobj)
+    newRefWithTracker refobj
+
+-- | A \"weak\" reference to an object: that is, a reference that does not
+-- guarantee to keep the object alive. If however the object is still alive
+-- (due to other normal references still existing) then it can be converted
+-- back into a normal reference with 'deRefWeak'.
+--
+-- Weak references do not themselves need to be released.
+--
+newtype WeakRef a = WeakRef a
+  deriving stock Show
+
+-- | Given an existing normal reference, create a new weak reference.
+--
+mkWeakRef :: Ref obj -> WeakRef obj
+mkWeakRef Ref {refobj} = WeakRef refobj
+
+-- | Given an existing raw reference, create a new weak reference.
+--
+mkWeakRefFromRaw :: obj -> WeakRef obj
+mkWeakRefFromRaw obj = WeakRef obj
+
+-- | If the object is still alive, obtain a /new/ normal reference. The normal
+-- rules for 'Ref' apply, including the need to eventually call 'releaseRef'.
+--
+deRefWeak ::
+     (RefCounted obj, FinaliserM obj ~ m, PrimMonad m)
+     HAS_CALL_STACK
+  => WeakRef obj
+  -> m (Maybe (Ref obj))
+deRefWeak (WeakRef obj) = do
+    success <- tryIncrementRefCounter (getRefCounter obj)
+    if success then Just <$> newRefWithTracker obj
+               else return Nothing
+
+{-# INLINE newRefWithTracker #-}
+#ifndef NO_IGNORE_ASSERTS
+newRefWithTracker :: PrimMonad m => obj -> m (Ref obj)
+newRefWithTracker obj =
+    return (Ref obj)
+#else
+newRefWithTracker :: (PrimMonad m, HasCallStack) => obj -> m (Ref obj)
+newRefWithTracker obj = do
+    reftracker' <- newRefTracker callStack
+    return (Ref obj reftracker')
+#endif
+
+data RefException =
+       RefUseAfterRelease RefId
+     | RefDoubleRelease RefId
+     | RefNeverReleased RefId CallStack
+       -- ^ With call stack for Ref allocation site
+
+newtype RefId = RefId Int
+  deriving stock (Show, Eq, Ord)
+
+instance Show RefException where
+  --Sigh. QuickCheck still uses 'show' rather than 'displayException.
+  show = displayException
+
+instance Exception RefException where
+  displayException (RefUseAfterRelease refid) = "RefUseAfterRelease " ++ show refid
+  displayException (RefDoubleRelease   refid) = "RefDoubleRelease " ++ show refid
+  displayException (RefNeverReleased refid allocsite) =
+      "RefNeverReleased " ++ show refid
+   ++ "\nAllocation site: " ++ prettyCallStack allocsite
+
+#ifndef NO_IGNORE_ASSERTS
+
+{-# INLINE releaseRefTracker #-}
+releaseRefTracker :: PrimMonad m => Ref a -> m ()
+releaseRefTracker _ = return ()
+
+{-# INLINE assertNoUseAfterRelease #-}
+assertNoUseAfterRelease :: PrimMonad m => Ref a -> m ()
+assertNoUseAfterRelease _ = return ()
+
+{-# INLINE assertNoDoubleRelease #-}
+assertNoDoubleRelease :: PrimMonad m => Ref a -> m ()
+assertNoDoubleRelease _ = return ()
+
+#else
+
+-- | A weak pointer to an outer IORef, containing an inner IORef with a bool
+-- to indicate if the ref has been explicitly released.
+--
+-- The finaliser for the outer weak pointer is given access to the inner IORef
+-- so that it can tell if the reference has become garbage without being
+-- explicitly released.
+--
+-- The outer IORef is also stored directly. This ensures the weak pointer to
+-- the same is not garbage collected until the RefTracker itself (and thus the
+-- parent Ref) is itself garbage collected.
+--
+-- The inner IORef is mutated when explicitly released. The outer IORef is
+-- never modified, but we use an IORef to ensure the weak pointer is reliable.
+--
+data RefTracker = RefTracker !RefId
+                             !(Weak (IORef (IORef Bool)))
+                             !(IORef (IORef Bool))
+
+{-# NOINLINE globalRefIdSupply #-}
+globalRefIdSupply :: PrimVar RealWorld Int
+globalRefIdSupply = unsafePerformIO $ newPrimVar 0
+
+{-# NOINLINE globalForgottenRef #-}
+globalForgottenRef :: IORef (Maybe (RefId, CallStack))
+globalForgottenRef = unsafePerformIO $ newIORef Nothing
+
+newRefTracker :: PrimMonad m => CallStack -> m RefTracker
+newRefTracker callsite = unsafeIOToPrim $ do
+    inner <- newIORef False
+    outer <- newIORef inner
+    refid <- fetchAddInt globalRefIdSupply 1
+    weak  <- mkWeakIORef outer $
+               finaliserRefTracker inner (RefId refid) callsite
+    return (RefTracker (RefId refid) weak outer)
+
+releaseRefTracker :: PrimMonad m => Ref a -> m ()
+releaseRefTracker Ref { reftracker =  RefTracker _refid _weak outer } =
+  unsafeIOToPrim $ do
+    inner <- readIORef outer
+    writeIORef inner True
+
+finaliserRefTracker :: IORef Bool -> RefId -> CallStack -> IO ()
+finaliserRefTracker inner refid callsite = do
+    released <- readIORef inner
+    when (not released) $ do
+      -- Uh oh! Forgot a reference without releasing!
+      -- Add it to a global var which we can poll elsewhere.
+      mref <- readIORef globalForgottenRef
+      case mref of
+        -- Just keep one, but keep the last allocated one.
+        -- The reason for last is that when there are nested structures with
+        -- refs then the last allocated is likely to be the outermost, which
+        -- is the best place to start hunting for ref leaks. Otherwise one can
+        -- go on a wild goose chase tracking down inner refs that were only
+        -- forgotten due to an outer ref being forgotten.
+        Just (refid', _) | refid < refid' -> return ()
+        _ -> writeIORef globalForgottenRef (Just (refid, callsite))
+
+assertNoForgottenRefs :: IO ()
+assertNoForgottenRefs = do
+    mrefs <- readIORef globalForgottenRef
+    case mrefs of
+      Nothing                -> return ()
+      Just (refid, callsite) -> do
+        -- Clear the var so we don't assert again.
+        writeIORef globalForgottenRef Nothing
+        throwIO (RefNeverReleased refid callsite)
+
+assertNoUseAfterRelease :: (PrimMonad m, HasCallStack) => Ref a -> m ()
+assertNoUseAfterRelease Ref { reftracker = RefTracker refid _weak outer } =
+  unsafeIOToPrim $ do
+    released <- readIORef =<< readIORef outer
+    when released $ Control.Exception.throwIO (RefUseAfterRelease refid)
+    assertNoForgottenRefs
+#if !(MIN_VERSION_base(4,20,0))
+  where
+    _unused = callStack
+#endif
+
+assertNoDoubleRelease :: (PrimMonad m, HasCallStack) => Ref a -> m ()
+assertNoDoubleRelease Ref { reftracker = RefTracker refid _weak outer } =
+  unsafeIOToPrim $ do
+    released <- readIORef =<< readIORef outer
+    when released $ Control.Exception.throwIO (RefDoubleRelease refid)
+    assertNoForgottenRefs
+#if !(MIN_VERSION_base(4,20,0))
+  where
+    _unused = callStack
+#endif
+
+#endif
+
+-- | Run a GC to try and see if any refs have been forgotten without being
+-- released. If so, this will throw a synchronous exception.
+--
+-- Note however that this is not the only place where 'RefNeverReleased'
+-- exceptions can be thrown. All Ref operations poll for forgotten refs.
+--
+checkForgottenRefs :: IO ()
+checkForgottenRefs = do
+#ifndef NO_IGNORE_ASSERTS
+    return ()
+#else
+    performMajorGC
+    yield
+    assertNoForgottenRefs
+    -- And for good measure, we'll do it again
+    performMajorGC
+    yield
+    assertNoForgottenRefs
+#endif
+

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -321,12 +321,12 @@ deRefWeak (WeakRef obj) = do
 #ifndef NO_IGNORE_ASSERTS
 newRefWithTracker :: PrimMonad m => obj -> m (Ref obj)
 newRefWithTracker obj =
-    return (Ref obj)
+    return $! Ref obj
 #else
 newRefWithTracker :: (PrimMonad m, HasCallStack) => obj -> m (Ref obj)
 newRefWithTracker obj = do
     reftracker' <- newRefTracker callStack
-    return (Ref obj reftracker')
+    return $! Ref obj reftracker'
 #endif
 
 data RefException =

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -4,13 +4,9 @@
 
 module Control.RefCount (
     RefCounter (..)
-  , RefCount (..)
-  , unsafeMkRefCounterN
-  , mkRefCounterN
   , mkRefCounter1
   , addReference
   , removeReference
-  , removeReferenceN
   , upgradeWeakReference
   , readRefCount
   ) where
@@ -20,11 +16,8 @@ import           Control.Exception (assert)
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive
-import           Data.Maybe
 import           Data.Primitive.PrimVar
-import           Data.Word
 import           GHC.Stack
-import           Text.Printf
 
 -- | A reference counter with an optional finaliser action. Once the reference
 -- count reaches @0@, the finaliser will be run.
@@ -41,33 +34,13 @@ instance NFData (RefCounter m) where
   rnf RefCounter{countVar, finaliser} =
       rwhnf countVar `seq` rwhnf finaliser
 
-newtype RefCount = RefCount Int
-  deriving stock (Eq, Ord, Show)
-
-{-# SPECIALISE unsafeMkRefCounterN :: RefCount -> IO () -> IO (RefCounter IO) #-}
--- | Like 'mkRefCounterN', but throws an error if the initial @n < 1@
-unsafeMkRefCounterN :: PrimMonad m => RefCount -> m () -> m (RefCounter m)
-unsafeMkRefCounterN !n finaliser = mkRefCounterN n finaliser >>= \case
-    Nothing -> error "unsafeMkRefCounterN: n < 1"
-    Just rc -> pure rc
-
-{-# SPECIALISE mkRefCounterN :: RefCount -> IO () -> IO (Maybe (RefCounter IO)) #-}
--- | Make a reference counter with initial value @n@. An optional finaliser is
--- run when the reference counter reaches @0@.
---
--- Returns 'Nothing' if @n < 1@, and 'Just' otherwise.
-mkRefCounterN :: PrimMonad m => RefCount -> m () -> m (Maybe (RefCounter m))
-mkRefCounterN (RefCount !n) finaliser
-  | n < 1 = pure Nothing
-  | otherwise = do
-    countVar <- newPrimVar $! n
-    pure $! Just $! RefCounter{countVar, finaliser}
-
 {-# SPECIALISE mkRefCounter1 :: IO () -> IO (RefCounter IO) #-}
 -- | Make a reference counter with initial value @1@. An optional finaliser is
 -- run when the reference counter reaches @0@.
 mkRefCounter1 :: PrimMonad m => m () -> m (RefCounter m)
-mkRefCounter1 finaliser = fromJust <$> mkRefCounterN (RefCount 1) finaliser
+mkRefCounter1 finaliser = do
+    countVar <- newPrimVar 1
+    pure $! RefCounter{countVar, finaliser}
 
 {-# SPECIALISE addReference :: HasCallStack => RefCounter IO -> IO () #-}
 -- | Increase the reference counter by one.
@@ -92,43 +65,6 @@ removeReference RefCounter{countVar, finaliser} =
       prevCount <- fetchSubInt countVar 1
       assertWithCallStack (prevCount > 0) $ pure ()
       when (prevCount == 1) finaliser
-
--- TODO: remove uses of this API. Eventually all references should be singular,
--- and not use patterns where if A contains B then N references on A becomes N
--- references on B. Instead this should be a single reference from A to B,
--- irrespective of the number of references to A.
-{-# SPECIALISE removeReferenceN :: HasCallStack => RefCounter IO -> Word64 -> IO () #-}
--- | Decrease the reference counter by @n@. @n@ must be a positive number.
---
--- The count must be known (from context) to be non-zero and at least as large
--- as @n@. Typically this will be because the caller has @n@ references already
--- (that they took out themselves or were given).
-removeReferenceN :: (HasCallStack, PrimMonad m, MonadMask m) => RefCounter m -> Word64 -> m ()
-removeReferenceN RefCounter{countVar, finaliser} n = mask_ $ do
-    -- n should be positive
-    assert (n > 0) $ pure ()
-    let !n' = fromIntegralChecked n
-    prevCount <- fetchSubInt countVar n'
-    -- the reference count must not already be 0, because then the finaliser
-    -- will have run already
-    assertWithCallStack (prevCount > 0) $ pure ()
-    -- the reference count can not go below zero
-    assertWithCallStack (prevCount >= n') $ pure ()
-    when (prevCount <= n') finaliser
-
--- TODO: remove when removeReferenceN is removed
-{-# INLINABLE fromIntegralChecked #-}
--- | Like 'fromIntegral', but throws an error when @(x :: a) /= fromIntegral
--- (fromIntegral x :: b)@.
-fromIntegralChecked :: (HasCallStack, Integral a, Integral b, Show a) => a -> b
-fromIntegralChecked x
-  | x'' == x
-  = x'
-  | otherwise
-  = error $ printf "fromIntegralChecked: conversion failed, %s /= %s" (show x) (show x'')
-  where
-    x' = fromIntegral x
-    x'' = fromIntegral x'
 
 -- | Try to turn a \"weak\" reference on something into a proper reference.
 -- This is by analogy with @deRefWeak :: Weak v -> IO (Maybe v)@, but for
@@ -162,11 +98,11 @@ upgradeWeakReference RefCounter{countVar} = do
             else casLoop prevCount'
 
 -- TODO: remove when removeRefenceN is removed
-{-# SPECIALISE readRefCount :: RefCounter IO -> IO RefCount #-}
+{-# SPECIALISE readRefCount :: RefCounter IO -> IO Int #-}
 -- | Warning: reading the current reference count is inherently racy as there is
 -- no way to reliably act on the information. It can be useful for debugging.
-readRefCount :: PrimMonad m => RefCounter m -> m RefCount
-readRefCount RefCounter{countVar} = RefCount <$> readPrimVar countVar
+readRefCount :: PrimMonad m => RefCounter m -> m Int
+readRefCount RefCounter{countVar} = readPrimVar countVar
 
 {-# INLINE assertWithCallStack #-}
 -- | Version of 'assert' that does not complain about redundant constraints when

--- a/src-control/Control/TempRegistry.hs
+++ b/src-control/Control/TempRegistry.hs
@@ -114,7 +114,8 @@ allocateTemp :: (MonadMask m, MonadMVar m) =>
   -> m a
   -> (a -> m ())
   -> m a
-allocateTemp reg acquire free = mustBeRight <$> allocateEitherTemp reg (fmap Right acquire) free
+allocateTemp reg acquire free =
+    mustBeRight <$!> allocateEitherTemp reg (fmap Right acquire) free
   where
     mustBeRight :: Either Void a -> a
     mustBeRight (Left  v) = absurd v
@@ -128,7 +129,8 @@ allocateMaybeTemp ::
   -> m (Maybe a)
   -> (a -> m ())
   -> m (Maybe a)
-allocateMaybeTemp reg acquire free = fromEither <$!> allocateEitherTemp reg (toEither <$> acquire) free
+allocateMaybeTemp reg acquire free =
+    fromEither <$!> allocateEitherTemp reg (toEither <$> acquire) free
   where
     toEither :: Maybe a -> Either () a
     toEither Nothing  = Left ()

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -505,10 +505,10 @@ deriving anyclass instance NoThunks a => NoThunks (RWState a)
 instance Typeable (PrimState m) => NoThunks (RefCounter m) where
   showTypeOf (_ :: Proxy (RefCounter m)) = "RefCounter"
   wNoThunks ctx
-    (RefCounter (a :: PrimVar (PrimState m) Int) (b :: Maybe (m ())))
+    (RefCounter (a :: PrimVar (PrimState m) Int) (b :: m ()))
     = allNoThunks [
           noThunks ctx a
-        , noThunks ctx $ (OnlyCheckWhnfNamed b :: OnlyCheckWhnfNamed "finaliser" (Maybe (m ())))
+        , noThunks ctx $ (OnlyCheckWhnfNamed b :: OnlyCheckWhnfNamed "finaliser" (m ()))
         ]
 
 deriving stock instance Generic RefCount

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -250,7 +250,7 @@ instance NoThunks WriteBuffer where
 -------------------------------------------------------------------------------}
 
 deriving stock instance Generic (WriteBufferBlobs m h)
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
+deriving anyclass instance (Typeable (PrimState m), Typeable m, Typeable h)
                         => NoThunks (WriteBufferBlobs m h)
 
 deriving stock instance Generic (FilePointer m)
@@ -449,7 +449,7 @@ deriving anyclass instance (Typeable h, Typeable (PrimState m))
                         => NoThunks (RawBlobRef m h)
 
 deriving stock instance Generic (WeakBlobRef m h)
-deriving anyclass instance (Typeable h, Typeable (PrimState m))
+deriving anyclass instance (Typeable h, Typeable m, Typeable (PrimState m))
                         => NoThunks (WeakBlobRef m h)
 
 {-------------------------------------------------------------------------------
@@ -510,6 +510,14 @@ instance Typeable (PrimState m) => NoThunks (RefCounter m) where
           noThunks ctx a
         , noThunks ctx $ (OnlyCheckWhnfNamed b :: OnlyCheckWhnfNamed "finaliser" (m ()))
         ]
+
+-- Ref constructor not exported, cannot derive Generic, use DeRef instead.
+instance (NoThunks obj, Typeable obj) => NoThunks (Ref obj) where
+  showTypeOf p@(_ :: Proxy (Ref obj)) = show $ typeRep p
+  wNoThunks ctx (DeRef ref) = noThunks ctx ref
+
+deriving stock instance Generic (WeakRef obj)
+deriving anyclass instance (NoThunks obj, Typeable obj) => NoThunks (WeakRef obj)
 
 {-------------------------------------------------------------------------------
   kmerge

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -499,7 +499,7 @@ deriving stock instance Generic (RWState a)
 deriving anyclass instance NoThunks a => NoThunks (RWState a)
 
 {-------------------------------------------------------------------------------
-  RefCount
+  RefCounter
 -------------------------------------------------------------------------------}
 
 instance Typeable (PrimState m) => NoThunks (RefCounter m) where
@@ -510,9 +510,6 @@ instance Typeable (PrimState m) => NoThunks (RefCounter m) where
           noThunks ctx a
         , noThunks ctx $ (OnlyCheckWhnfNamed b :: OnlyCheckWhnfNamed "finaliser" (m ()))
         ]
-
-deriving stock instance Generic RefCount
-deriving anyclass instance NoThunks RefCount
 
 {-------------------------------------------------------------------------------
   kmerge

--- a/src-extras/Database/LSMTree/Extras/RunData.hs
+++ b/src-extras/Database/LSMTree/Extras/RunData.hs
@@ -22,6 +22,7 @@ module Database.LSMTree.Extras.RunData (
 
 import           Control.Exception (bracket)
 import           Control.Monad
+import           Control.RefCount
 import           Data.Bifoldable (Bifoldable (bifoldMap))
 import           Data.Bifunctor
 import           Data.Map.Strict (Map)
@@ -92,7 +93,7 @@ unsafeFlushAsWriteBuffer fs hbio fsPaths (RunData m) = do
     wb <- WB.fromMap <$> traverse (traverse (WBB.addBlob fs wbblobs)) m
     run <- Run.fromWriteBuffer fs hbio CacheRunData (RunAllocFixed 10)
                                fsPaths wb wbblobs
-    WBB.removeReference wbblobs
+    releaseRef wbblobs
     return run
 
 {-------------------------------------------------------------------------------

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -49,7 +49,6 @@ import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.Concurrent.Class.MonadSTM (MonadSTM, STM)
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive (PrimMonad)
 import           Control.Tracer (Tracer)
 import           Data.Kind (Type)
@@ -73,7 +72,7 @@ import           System.FS.IO (HandleIO)
 
 -- | Utility class for grouping @io-classes@ constraints.
 class ( MonadMVar m, MonadSTM m, MonadThrow (STM m), MonadThrow m, MonadCatch m
-      , MonadMask m, PrimMonad m, MonadFix m , MonadST m
+      , MonadMask m, PrimMonad m, MonadST m
       ) => IOLike m
 
 instance IOLike IO

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -77,7 +77,6 @@ import           Control.DeepSeq
 import           Control.Monad (unless)
 import           Control.Monad.Class.MonadST (MonadST (..))
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive
 import           Control.TempRegistry
 import           Control.Tracer
@@ -759,7 +758,7 @@ lookups resolve ks t = do
   -> IO (V.Vector res) #-}
 -- | See 'Database.LSMTree.Normal.rangeLookup'.
 rangeLookup ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> Range SerialisedKey
   -> Table m h
@@ -800,7 +799,7 @@ rangeLookup resolve range t fromEntry = do
 --
 -- Does not enforce that mupsert and blobs should not occur in the same table.
 updates ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> V.Vector (SerialisedKey, Entry SerialisedValue SerialisedBlob)
   -> Table m h
@@ -908,7 +907,7 @@ data CursorEnv m h = CursorEnv {
   -> IO a #-}
 -- | See 'Database.LSMTree.Normal.withCursor'.
 withCursor ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => OffsetKey
   -> Table m h
   -> (Cursor m h -> m a)
@@ -921,7 +920,7 @@ withCursor offsetKey t = bracket (newCursor offsetKey t) closeCursor
   -> IO (Cursor IO h) #-}
 -- | See 'Database.LSMTree.Normal.newCursor'.
 newCursor ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => OffsetKey
   -> Table m h
   -> m (Cursor m h)
@@ -1005,7 +1004,7 @@ closeCursor Cursor {..} = do
 -- | See 'Database.LSMTree.Normal.readCursor'.
 readCursor ::
      forall m h res.
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> Int  -- ^ Maximum number of entries to read
   -> Cursor m h
@@ -1032,7 +1031,7 @@ readCursor resolve n cursor fromEntry =
 -- calls with the same predicate @p@ will return an empty vector.
 readCursorWhile ::
      forall m h res.
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> (SerialisedKey -> Bool)  -- ^ Only read as long as this predicate holds
   -> Int  -- ^ Maximum number of entries to read
@@ -1070,7 +1069,7 @@ readCursorWhile resolve keyIsWanted n Cursor {..} fromEntry = do
   -> IO () #-}
 -- |  See 'Database.LSMTree.Normal.createSnapshot''.
 createSnapshot ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> SnapshotName
   -> SnapshotLabel
@@ -1143,7 +1142,7 @@ createSnapshot resolve snap label tableType t = do
   -> IO (Table IO h) #-}
 -- |  See 'Database.LSMTree.Normal.openSnapshot'.
 openSnapshot ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => Session m h
   -> SnapshotLabel -- ^ Expected label
   -> SnapshotTableType -- ^ Expected table type
@@ -1207,7 +1206,7 @@ openSnapshot sesh label tableType override snap resolve = do
   -> IO () #-}
 -- |  See 'Database.LSMTree.Common.deleteSnapshot'.
 deleteSnapshot ::
-     (MonadFix m, MonadMask m, MonadSTM m)
+     (MonadMask m, MonadSTM m)
   => Session m h
   -> SnapshotName
   -> m ()
@@ -1225,7 +1224,7 @@ deleteSnapshot sesh snap = do
 {-# SPECIALISE listSnapshots :: Session IO h -> IO [SnapshotName] #-}
 -- |  See 'Database.LSMTree.Common.listSnapshots'.
 listSnapshots ::
-     (MonadFix m, MonadMask m, MonadSTM m)
+     (MonadMask m, MonadSTM m)
   => Session m h
   -> m [SnapshotName]
 listSnapshots sesh = do
@@ -1254,7 +1253,7 @@ listSnapshots sesh = do
 {-# SPECIALISE duplicate :: Table IO h -> IO (Table IO h) #-}
 -- | See 'Database.LSMTree.Normal.duplicate'.
 duplicate ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => Table m h
   -> m (Table m h)
 duplicate t@Table{..} = do

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -908,7 +908,7 @@ data CursorEnv m h = CursorEnv {
 
     -- | The write buffer blobs, which like the runs, we have to keep open
     -- untile the cursor is closed.
-  , cursorWBB        :: Ref (WBB.WriteBufferBlobs m h)
+  , cursorWBB        :: !(Ref (WBB.WriteBufferBlobs m h))
   }
 
 {-# SPECIALISE withCursor ::
@@ -969,8 +969,8 @@ newCursor !offsetKey t = withOpenTable t $ \thEnv -> do
     -- references to each run, so it is safe.
     dupTableContent reg contentVar = do
         RW.withReadAccess contentVar $ \content -> do
-          let wb      = tableWriteBuffer content
-              wbblobs = tableWriteBufferBlobs content
+          let !wb      = tableWriteBuffer content
+              !wbblobs = tableWriteBufferBlobs content
           wbblobs' <- allocateTemp reg (dupRef wbblobs) releaseRef
           let runs = cachedRuns (tableCache content)
           runs' <- V.forM runs $ \r ->

--- a/src/Database/LSMTree/Internal/BlobFile.hs
+++ b/src/Database/LSMTree/Internal/BlobFile.hs
@@ -67,7 +67,7 @@ openBlobFile fs path mode = do
     let finaliser = do
           FS.hClose fs blobFileHandle
           FS.removeFile fs (FS.handlePath blobFileHandle)
-    blobFileRefCounter <- RC.mkRefCounter1 (Just finaliser)
+    blobFileRefCounter <- RC.mkRefCounter1 finaliser
     return BlobFile {
       blobFileHandle,
       blobFileRefCounter

--- a/src/Database/LSMTree/Internal/BlobFile.hs
+++ b/src/Database/LSMTree/Internal/BlobFile.hs
@@ -1,17 +1,17 @@
+{-# LANGUAGE TypeFamilies #-}
 module Database.LSMTree.Internal.BlobFile (
     BlobFile (..)
   , BlobSpan (..)
-  , removeReference
   , openBlobFile
   , readBlob
+  , readBlobRaw
   , writeBlob
   ) where
 
 import           Control.DeepSeq (NFData (..))
-import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
+import           Control.Monad.Class.MonadThrow (MonadThrow)
 import           Control.Monad.Primitive (PrimMonad)
-import           Control.RefCount (RefCounter)
-import qualified Control.RefCount as RC
+import           Control.RefCount
 import qualified Data.Primitive.ByteArray as P
 import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word32, Word64)
@@ -32,6 +32,10 @@ data BlobFile m h = BlobFile {
      }
   deriving stock (Show)
 
+instance RefCounted (BlobFile m h) where
+    type FinaliserM (BlobFile m h) = m
+    getRefCounter = blobFileRefCounter
+
 instance NFData h => NFData (BlobFile m h) where
   rnf (BlobFile a b) = rnf a `seq` rnf b
 
@@ -45,42 +49,43 @@ data BlobSpan = BlobSpan {
 instance NFData BlobSpan where
   rnf (BlobSpan a b) = rnf a `seq` rnf b
 
-{-# INLINE removeReference #-}
-removeReference ::
-     (MonadMask m, PrimMonad m)
-  => BlobFile m h
-  -> m ()
-removeReference BlobFile{blobFileRefCounter} =
-    RC.removeReference blobFileRefCounter
-
 -- | Open the given file to make a 'BlobFile'. The finaliser will close and
 -- delete the file.
-{-# SPECIALISE openBlobFile :: HasFS IO h -> FS.FsPath -> FS.OpenMode -> IO (BlobFile IO h) #-}
+{-# SPECIALISE openBlobFile :: HasFS IO h -> FS.FsPath -> FS.OpenMode -> IO (Ref (BlobFile IO h)) #-}
 openBlobFile ::
      PrimMonad m
   => HasFS m h
   -> FS.FsPath
   -> FS.OpenMode
-  -> m (BlobFile m h)
+  -> m (Ref (BlobFile m h))
 openBlobFile fs path mode = do
     blobFileHandle <- FS.hOpen fs path mode
     let finaliser = do
           FS.hClose fs blobFileHandle
           FS.removeFile fs (FS.handlePath blobFileHandle)
-    blobFileRefCounter <- RC.mkRefCounter1 finaliser
-    return BlobFile {
-      blobFileHandle,
-      blobFileRefCounter
-    }
+    newRef finaliser $ \blobFileRefCounter ->
+      BlobFile {
+        blobFileHandle,
+        blobFileRefCounter
+      }
 
-{-# SPECIALISE readBlob :: HasFS IO h -> BlobFile IO h -> BlobSpan -> IO SerialisedBlob #-}
+{-# INLINE readBlob #-}
 readBlob ::
+     (MonadThrow m, PrimMonad m)
+  => HasFS m h
+  -> Ref (BlobFile m h)
+  -> BlobSpan
+  -> m SerialisedBlob
+readBlob fs (DeRef blobfile) blobspan = readBlobRaw fs blobfile blobspan
+
+{-# SPECIALISE readBlobRaw :: HasFS IO h -> BlobFile IO h -> BlobSpan -> IO SerialisedBlob #-}
+readBlobRaw ::
      (MonadThrow m, PrimMonad m)
   => HasFS m h
   -> BlobFile m h
   -> BlobSpan
   -> m SerialisedBlob
-readBlob fs BlobFile {blobFileHandle}
+readBlobRaw fs BlobFile {blobFileHandle}
             BlobSpan {blobSpanOffset, blobSpanSize} = do
     let off = FS.AbsOffset blobSpanOffset
         len :: Int
@@ -92,15 +97,15 @@ readBlob fs BlobFile {blobFileHandle}
     let !rb = RB.fromByteArray 0 len ba
     return (SerialisedBlob rb)
 
-{-# SPECIALISE writeBlob :: HasFS IO h -> BlobFile IO h -> SerialisedBlob -> Word64 -> IO () #-}
+{-# SPECIALISE writeBlob :: HasFS IO h -> Ref (BlobFile IO h) -> SerialisedBlob -> Word64 -> IO () #-}
 writeBlob ::
      (MonadThrow m, PrimMonad m)
   => HasFS m h
-  -> BlobFile m h
+  -> Ref (BlobFile m h)
   -> SerialisedBlob
   -> Word64
   -> m ()
-writeBlob fs BlobFile {blobFileHandle}
+writeBlob fs (DeRef BlobFile {blobFileHandle})
           (SerialisedBlob' (VP.Vector boff blen ba)) off = do
     mba <- P.unsafeThawByteArray ba
     _   <- FS.hPutBufExactlyAt

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -8,6 +8,8 @@ module Database.LSMTree.Internal.BlobRef (
   , RawBlobRef (..)
   , WeakBlobRef (..)
   , WeakBlobRefInvalid (..)
+  , mkRawBlobRef
+  , mkWeakBlobRef
   , rawToWeakBlobRef
   , readRawBlobRef
   , readWeakBlobRef
@@ -85,6 +87,20 @@ rawToWeakBlobRef RawBlobRef {rawBlobRefFile, rawBlobRefSpan} =
     WeakBlobRef {
       weakBlobRefFile = rawBlobRefFile,
       weakBlobRefSpan = rawBlobRefSpan
+    }
+
+mkRawBlobRef :: BlobFile m h -> BlobSpan -> RawBlobRef m h
+mkRawBlobRef blobfile blobspan =
+    RawBlobRef {
+      rawBlobRefFile = blobfile,
+      rawBlobRefSpan = blobspan
+    }
+
+mkWeakBlobRef :: BlobFile m h -> BlobSpan -> WeakBlobRef m h
+mkWeakBlobRef blobfile blobspan =
+    WeakBlobRef {
+      weakBlobRefFile = blobfile,
+      weakBlobRefSpan = blobspan
     }
 
 -- | The 'WeakBlobRef' now points to a blob that is no longer available.

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -39,10 +39,10 @@ import           System.FS.BlockIO.API (HasBlockIO)
 
 -- | A raw blob reference is a reference to a blob within a blob file.
 --
--- The \"raw\" means that it does no reference counting, so does not maintain
--- ownership of the 'BlobFile'. Thus these are only safe to use in the context
--- of code that already (directly or indirectly) owns the blob file that the
--- blob ref uses (such as within run merging).
+-- The \"raw\" means that it does not maintain ownership of the 'BlobFile' to
+-- keep it open. Thus these are only safe to use in the context of code that
+-- already (directly or indirectly) owns the blob file that the blob ref uses
+-- (such as within run merging).
 --
 -- Thus these cannot be handed out via the API. Use 'WeakBlobRef' for that.
 --
@@ -56,9 +56,9 @@ data RawBlobRef m h = RawBlobRef {
 -- can return in the public API and can outlive their parent table.
 --
 -- They are weak references in that they do not keep the file open using a
--- reference count. So when we want to use our weak reference we have to
--- dereference them to obtain a normal strong reference while we do the I\/O
--- to read the blob. This ensures the file is not closed under our feet.
+-- reference. So when we want to use our weak reference we have to dereference
+-- them to obtain a normal strong reference while we do the I\/O to read the
+-- blob. This ensures the file is not closed under our feet.
 --
 -- See 'Database.LSMTree.Common.BlobRef' for more info.
 --

--- a/src/Database/LSMTree/Internal/Cursor.hs
+++ b/src/Database/LSMTree/Internal/Cursor.hs
@@ -7,7 +7,6 @@ module Database.LSMTree.Internal.Cursor (
 import           Control.Concurrent.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadST (MonadST (..))
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Fix (MonadFix)
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.BlobRef (RawBlobRef,
                      WeakBlobRef (..))
@@ -36,7 +35,7 @@ import qualified Database.LSMTree.Internal.Vector as V
 --   readers have not been drained yet, so we must check before calling them
 -- * there is probably opportunity for optimisations
 readEntriesWhile :: forall h m res.
-     (MonadFix m, MonadMask m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> (SerialisedKey -> Bool)
   -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m h) -> res)

--- a/src/Database/LSMTree/Internal/Entry.hs
+++ b/src/Database/LSMTree/Internal/Entry.hs
@@ -73,6 +73,12 @@ newtype NumEntries = NumEntries Int
   deriving stock (Eq, Ord, Show)
   deriving newtype NFData
 
+instance Semigroup NumEntries where
+  NumEntries a <> NumEntries b = NumEntries (a + b)
+
+instance Monoid NumEntries where
+  mempty = NumEntries 0
+
 unNumEntries :: NumEntries -> Int
 unNumEntries (NumEntries x) = x
 

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -160,7 +160,7 @@ data ByteCountDiscrepancy = ByteCountDiscrepancy {
     -> ResolveSerialisedValue
     -> WB.WriteBuffer
     -> Ref (WBB.WriteBufferBlobs IO h)
-    -> V.Vector (Run IO h)
+    -> V.Vector (Ref (Run IO h))
     -> V.Vector (Bloom SerialisedKey)
     -> V.Vector IndexCompact
     -> V.Vector (Handle h)
@@ -180,7 +180,7 @@ lookupsIO ::
   -> ResolveSerialisedValue
   -> WB.WriteBuffer
   -> Ref (WBB.WriteBufferBlobs m h)
-  -> V.Vector (Run m h) -- ^ Runs @rs@
+  -> V.Vector (Ref (Run m h)) -- ^ Runs @rs@
   -> V.Vector (Bloom SerialisedKey) -- ^ The bloom filters inside @rs@
   -> V.Vector IndexCompact -- ^ The indexes inside @rs@
   -> V.Vector (Handle h) -- ^ The file handles to the key\/value files inside @rs@
@@ -205,7 +205,7 @@ lookupsIO !hbio !mgr !resolveV !wb !wbblobs !rs !blooms !indexes !kopsFiles !ks 
        ResolveSerialisedValue
     -> WB.WriteBuffer
     -> Ref (WBB.WriteBufferBlobs IO h)
-    -> V.Vector (Run IO h)
+    -> V.Vector (Ref (Run IO h))
     -> V.Vector SerialisedKey
     -> VP.Vector RunIxKeyIx
     -> V.Vector (IOOp RealWorld h)
@@ -224,7 +224,7 @@ intraPageLookups ::
   => ResolveSerialisedValue
   -> WB.WriteBuffer
   -> Ref (WBB.WriteBufferBlobs m h)
-  -> V.Vector (Run m h)
+  -> V.Vector (Ref (Run m h))
   -> V.Vector SerialisedKey
   -> VP.Vector RunIxKeyIx
   -> V.Vector (IOOp (PrimState m) h)

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -37,6 +37,7 @@ import           Control.Monad.Class.MonadST as Class
 import           Control.Monad.Class.MonadThrow (MonadThrow (..))
 import           Control.Monad.Primitive
 import           Control.Monad.ST.Strict
+import           Control.RefCount
 
 import           Database.LSMTree.Internal.BlobRef (WeakBlobRef (..))
 import           Database.LSMTree.Internal.Entry
@@ -158,7 +159,7 @@ data ByteCountDiscrepancy = ByteCountDiscrepancy {
     -> ArenaManager RealWorld
     -> ResolveSerialisedValue
     -> WB.WriteBuffer
-    -> WBB.WriteBufferBlobs IO h
+    -> Ref (WBB.WriteBufferBlobs IO h)
     -> V.Vector (Run IO h)
     -> V.Vector (Bloom SerialisedKey)
     -> V.Vector IndexCompact
@@ -178,7 +179,7 @@ lookupsIO ::
   -> ArenaManager (PrimState m)
   -> ResolveSerialisedValue
   -> WB.WriteBuffer
-  -> WBB.WriteBufferBlobs m h
+  -> Ref (WBB.WriteBufferBlobs m h)
   -> V.Vector (Run m h) -- ^ Runs @rs@
   -> V.Vector (Bloom SerialisedKey) -- ^ The bloom filters inside @rs@
   -> V.Vector IndexCompact -- ^ The indexes inside @rs@
@@ -203,7 +204,7 @@ lookupsIO !hbio !mgr !resolveV !wb !wbblobs !rs !blooms !indexes !kopsFiles !ks 
 {-# SPECIALIZE intraPageLookups ::
        ResolveSerialisedValue
     -> WB.WriteBuffer
-    -> WBB.WriteBufferBlobs IO h
+    -> Ref (WBB.WriteBufferBlobs IO h)
     -> V.Vector (Run IO h)
     -> V.Vector SerialisedKey
     -> VP.Vector RunIxKeyIx
@@ -222,7 +223,7 @@ intraPageLookups ::
      forall m h. (PrimMonad m, MonadThrow m)
   => ResolveSerialisedValue
   -> WB.WriteBuffer
-  -> WBB.WriteBufferBlobs m h
+  -> Ref (WBB.WriteBufferBlobs m h)
   -> V.Vector (Run m h)
   -> V.Vector SerialisedKey
   -> VP.Vector RunIxKeyIx

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -19,8 +19,7 @@ import           Control.Exception (assert)
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
-import           Control.Monad.Class.MonadThrow (MonadCatch, MonadMask,
-                     MonadThrow (..))
+import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
 import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive (PrimState)
 import           Data.Coerce (coerce)
@@ -91,7 +90,7 @@ type Mappend = SerialisedValue -> SerialisedValue -> SerialisedValue
 -- | Returns 'Nothing' if no input 'Run' contains any entries.
 -- The list of runs should be sorted from new to old.
 new ::
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => HasFS m h
   -> HasBlockIO m h
   -> RunDataCaching
@@ -121,7 +120,7 @@ new fs hbio mergeCaching alloc mergeLevel mergeMappend targetPaths runs = do
 -- created for the new run so far and avoids leaking file handles.
 --
 -- Once it has been called, do not use the 'Merge' any more!
-abort :: (MonadSTM m, MonadST m) => Merge m h -> m ()
+abort :: (MonadMask m, MonadSTM m, MonadST m) => Merge m h -> m ()
 abort Merge {..} = do
     readMutVar mergeState >>= \case
       Merging -> do
@@ -233,7 +232,7 @@ stepsInvariant requestedSteps = \case
 -- Returns an error if the merge was already completed or closed.
 steps ::
      forall m h.
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => Merge m h
   -> Int  -- ^ How many input entries to consume (at least)
   -> m (Int, StepResult)

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -142,8 +142,6 @@ abort Merge {..} = do
 --
 -- All resources held by the merge are released, so do not use the it any more!
 --
--- The resulting run has a reference count of 1.
---
 -- This function will /not/ do any merging work if there is any remaining. That
 -- is, if not enough 'steps' were performed to exhaust the input 'Readers', this
 -- function will throw an error.
@@ -153,7 +151,8 @@ abort Merge {..} = do
 --
 -- Note: this function creates new 'Run' resources, so it is recommended to run
 -- this function with async exceptions masked. Otherwise, these resources can
--- leak.
+-- leak. And it must eventually be released with 'releaseRef'.
+--
 complete ::
      (MonadSTM m, MonadST m, MonadMask m)
   => Merge m h

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -20,7 +20,6 @@ import           Control.Monad (when)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
-import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive (PrimState)
 import           Data.Coerce (coerce)
 import           Data.Primitive.MutVar
@@ -156,7 +155,7 @@ abort Merge {..} = do
 -- this function with async exceptions masked. Otherwise, these resources can
 -- leak.
 complete ::
-     (MonadFix m, MonadSTM m, MonadST m, MonadMask m)
+     (MonadSTM m, MonadST m, MonadMask m)
   => Merge m h
   -> m (Run m h)
 complete Merge{..} = do
@@ -178,7 +177,7 @@ complete Merge{..} = do
 --
 -- Note: run with async exceptions masked. See 'complete'.
 stepsToCompletion ::
-      (MonadMask m, MonadFix m, MonadSTM m, MonadST m)
+      (MonadMask m, MonadSTM m, MonadST m)
    => Merge m h
    -> Int
    -> m (Run m h)
@@ -197,7 +196,7 @@ stepsToCompletion m stepBatchSize = go
 --
 -- Note: run with async exceptions masked. See 'complete'.
 stepsToCompletionCounted ::
-     (MonadMask m, MonadFix m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => Merge m h
   -> Int
   -> m (Int, Run m h)

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -104,7 +104,7 @@ new fs hbio mergeCaching alloc mergeLevel mergeMappend targetPaths runs = do
     mreaders <- Readers.new Readers.NoOffsetKey Nothing runs
     for mreaders $ \mergeReaders -> do
       -- calculate upper bounds based on input runs
-      let numEntries = coerce (sum @V.Vector @Int) (fmap Run.runNumEntries runs)
+      let numEntries = coerce (sum @V.Vector @Int) (fmap Run.size runs)
       mergeBuilder <- Builder.new fs hbio targetPaths numEntries alloc
       mergeState <- newMutVar $! Merging
       return Merge {

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -23,7 +23,6 @@ import           Control.Monad.Class.MonadThrow (MonadCatch, MonadMask,
                      MonadThrow (..))
 import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive (PrimState)
-import           Control.RefCount (RefCount (..))
 import           Data.Coerce (coerce)
 import           Data.Primitive.MutVar
 import           Data.Traversable (for)
@@ -166,7 +165,7 @@ complete Merge{..} = do
       Merging -> error "complete: Merge is not done"
       MergingDone -> do
         -- the readers are already drained, therefore closed
-        r <- Run.fromMutable mergeCaching (RefCount 1) mergeBuilder
+        r <- Run.fromMutable mergeCaching mergeBuilder
         writeMutVar mergeState $! Completed
         pure r
       Completed -> error "complete: Merge is already completed"

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -21,7 +21,6 @@ import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
 import           Control.Monad.Primitive (PrimState)
-import           Data.Coerce (coerce)
 import           Data.Primitive.MutVar
 import           Data.Traversable (for)
 import qualified Data.Vector as V
@@ -104,7 +103,7 @@ new fs hbio mergeCaching alloc mergeLevel mergeMappend targetPaths runs = do
     mreaders <- Readers.new Readers.NoOffsetKey Nothing runs
     for mreaders $ \mergeReaders -> do
       -- calculate upper bounds based on input runs
-      let numEntries = coerce (sum @V.Vector @Int) (fmap Run.size runs)
+      let numEntries = V.foldMap' Run.size runs
       mergeBuilder <- Builder.new fs hbio targetPaths numEntries alloc
       mergeState <- newMutVar $! Merging
       return Merge {

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -355,7 +355,7 @@ newMergingRun mergePolicy mergeNumRuns mergeNumEntries knownCompleted state = do
       CompletedMerge{} -> pure ()
     mergeKnownCompleted <- newMutVar knownCompleted
     mergeState <- newMVar $! state
-    mergeRefCounter <- RC.mkRefCounter1 (Just (finalise mergeState))
+    mergeRefCounter <- RC.mkRefCounter1 (finalise mergeState)
     pure $! MergingRun {
         mergePolicy
       , mergeNumRuns

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -854,7 +854,7 @@ addRunToLevels tr conf@TableConfig{..} resolve hfs hbio root uc r0 reg levels = 
         traceWith tr $ AtLevel ln $
           TraceNewMerge (V.map Run.size rs) (runNumber runPaths) caching alloc mergePolicy mergelast
         let numInputRuns = NumRuns $ V.length rs
-        let numInputEntries = NumEntries $ V.sum (V.map (unNumEntries . Run.size) rs)
+        let numInputEntries = V.foldMap' Run.size rs
         case confMergeSchedule of
           OneShot -> do
             r <- allocateTemp reg

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -49,7 +49,6 @@ import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadCatch (bracketOnError),
                      MonadMask, MonadThrow (..))
-import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive
 import qualified Control.RefCount as RC
 import           Control.TempRegistry
@@ -519,7 +518,7 @@ iforLevelM_ lvls k = V.iforM_ lvls $ \i lvl -> k (LevelNo (i + 1)) lvl
 -- whole run should then end up in a fresh write buffer.
 updatesWithInterleavedFlushes ::
      forall m h.
-     (MonadFix m, MonadMask m, MonadMVar m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadMVar m, MonadSTM m, MonadST m)
   => Tracer m (AtLevel MergeTrace)
   -> TableConfig
   -> ResolveSerialisedValue
@@ -615,7 +614,7 @@ addWriteBufferEntries hfs f wbblobs maxn =
 -- The returned table content contains an updated set of levels, where the write
 -- buffer is inserted into level 1.
 flushWriteBuffer ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => Tracer m (AtLevel MergeTrace)
   -> TableConfig
   -> ResolveSerialisedValue
@@ -754,7 +753,7 @@ _levelsInvariant conf levels =
 -- for documentation about the merge algorithm.
 addRunToLevels ::
      forall m h.
-     (MonadFix m, MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
   => Tracer m (AtLevel MergeTrace)
   -> TableConfig
   -> ResolveSerialisedValue
@@ -921,7 +920,7 @@ levelIsFull sr rs = V.length rs + 1 >= (sizeRatioInt sr)
 
 {-# SPECIALISE mergeRuns :: ResolveSerialisedValue -> HasFS IO h -> HasBlockIO IO h -> RunDataCaching -> RunBloomFilterAlloc -> RunFsPaths -> Merge.Level -> V.Vector (Run IO h) -> IO (Run IO h) #-}
 mergeRuns ::
-     (MonadMask m, MonadFix m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> HasFS m h
   -> HasBlockIO m h
@@ -1045,7 +1044,7 @@ newtype Credit = Credit Int
 -- | Supply the given amount of credits to each merge in the levels structure.
 -- This /may/ cause some merges to progress.
 supplyCredits ::
-     (MonadSTM m, MonadST m, MonadMVar m, MonadMask m, MonadFix m)
+     (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
   => TableConfig
   -> Credit
   -> Levels m h
@@ -1094,7 +1093,7 @@ scaleCreditsForMerge (Merging MergingRun {..}) (Credit c) =
 -- | Supply the given amount of credits to a merging run. This /may/ cause an
 -- ongoing merge to progress.
 supplyMergeCredits ::
-     forall m h. (MonadSTM m, MonadST m, MonadMVar m, MonadMask m, MonadFix m)
+     forall m h. (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
   => ScaledCredits
   -> CreditThreshold
   -> IncomingRun m h
@@ -1274,7 +1273,7 @@ stepMerge mergeVar (TotalStepsVar totalStepsVar) (Credit c) =
   -> IO () #-}
 -- | Convert an 'OngoingMerge' to a 'CompletedMerge'.
 completeMerge ::
-     (MonadSTM m, MonadST m, MonadMVar m, MonadMask m, MonadFix m)
+     (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
   => StrictMVar m (MergingRunState m h)
   -> MutVar (PrimState m) MergeKnownCompleted
   -> m ()
@@ -1292,7 +1291,7 @@ completeMerge mergeVar mergeKnownCompletedVar = do
 
 {-# SPECIALISE expectCompletedMerge :: TempRegistry IO -> IncomingRun IO h -> IO (Run IO h) #-}
 expectCompletedMerge ::
-     (MonadMVar m, MonadSTM m, MonadST m, MonadMask m, MonadFix m)
+     (MonadMVar m, MonadSTM m, MonadST m, MonadMask m)
   => TempRegistry m -> IncomingRun m h -> m (Run m h)
 expectCompletedMerge _ (Single r) = pure r
 expectCompletedMerge reg (Merging (mr@MergingRun {..})) = do

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -1223,7 +1223,7 @@ takeAllUnspentCredits (UnspentCreditsVar !unspentCreditsVar) = do
 
 {-# SPECIALISE stepMerge :: StrictMVar IO (MergingRunState IO h) -> TotalStepsVar RealWorld -> Credit -> IO Bool #-}
 stepMerge ::
-     (MonadMVar m, MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMVar m, MonadMask m, MonadSTM m, MonadST m)
   => StrictMVar m (MergingRunState m h)
   -> TotalStepsVar (PrimState m)
   -> Credit

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -145,7 +145,7 @@ duplicateTableContent reg (TableContent wb wbb levels cache) = do
     wbb'    <- allocateTemp reg (dupRef wbb) releaseRef
     levels' <- duplicateLevels reg levels
     cache'  <- duplicateLevelsCache reg cache
-    return $ TableContent wb wbb' levels' cache'
+    return $! TableContent wb wbb' levels' cache'
 
 {-# SPECIALISE releaseTableContent :: TempRegistry IO -> TableContent IO h -> IO () #-}
 releaseTableContent ::
@@ -441,7 +441,7 @@ duplicateLevels reg levels =
       incomingRun'  <- duplicateIncomingRun reg incomingRun
       residentRuns' <- V.forM residentRuns $ \r ->
                          allocateTemp reg (dupRef r) releaseRef
-      return Level {
+      return $! Level {
         incomingRun  = incomingRun',
         residentRuns = residentRuns'
       }
@@ -787,7 +787,7 @@ addRunToLevels tr conf@TableConfig{..} resolve hfs hbio root uc r0 reg levels = 
         -- Make a new level
         let policyForLevel = mergePolicyForLevel confMergePolicy ln V.empty
         ir <- newMerge policyForLevel Merge.LastLevel ln rs
-        return $ V.singleton $ Level ir V.empty
+        return $! V.singleton $ Level ir V.empty
     go !ln rs' (V.uncons -> Just (Level ir rs, ls)) = do
         r <- expectCompletedMergeTraced ln ir
         case mergePolicyForLevel confMergePolicy ln ls of

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -169,8 +169,8 @@ releaseTableContent reg (TableContent _wb wbb levels cache) = do
 -- handles. This allows for quick access in the lookup code. Recomputing this
 -- cache should be relatively rare.
 --
--- Caches take reference counts for its runs on construction, and they release
--- references when the cache is invalidated. This is done so that incremental
+-- Caches keep references to its runs on construction, and they release each
+-- reference when the cache is invalidated. This is done so that incremental
 -- merges can remove references for their input runs when a merge completes,
 -- without closing runs that might be in use for other operations such as
 -- lookups. This does mean that a cache can keep runs open for longer than

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -194,7 +194,7 @@ fromMutable runRunDataCaching refCount builder = do
     runKOpsFile <- FS.hOpen runHasFS (runKOpsPath runRunFsPaths) FS.ReadMode
     runBlobFile <- openBlobFile runHasFS (runBlobPath runRunFsPaths) FS.ReadMode
     setRunDataCaching runHasBlockIO runKOpsFile runRunDataCaching
-    rec runRefCounter <- RC.unsafeMkRefCounterN refCount (Just $ close r)
+    rec runRefCounter <- RC.unsafeMkRefCounterN refCount (close r)
         let !r = Run { .. }
     pure r
 
@@ -283,7 +283,7 @@ openFromDisk fs hbio runRunDataCaching runRunFsPaths = do
     runKOpsFile <- FS.hOpen fs (runKOpsPath runRunFsPaths) FS.ReadMode
     runBlobFile <- openBlobFile fs (runBlobPath runRunFsPaths) FS.ReadMode
     setRunDataCaching hbio runKOpsFile runRunDataCaching
-    rec runRefCounter <- RC.unsafeMkRefCounterN (RefCount 1) (Just $ close r)
+    rec runRefCounter <- RC.unsafeMkRefCounterN (RefCount 1) (close r)
         let !r = Run
               { runHasFS = fs
               , runHasBlockIO = hbio

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -208,7 +208,8 @@ fromMutable runRunDataCaching builder = do
   -> Ref (WriteBufferBlobs IO h)
   -> IO (Ref (Run IO h)) #-}
 -- | Write a write buffer to disk, including the blobs it contains.
--- The resulting run has a reference count of 1.
+--
+-- This creates a new 'Run' which must eventually be released with 'releaseRef'.
 --
 -- TODO: As a possible optimisation, blobs could be written to a blob file
 -- immediately when they are added to the write buffer, avoiding the need to do
@@ -250,7 +251,8 @@ data FileFormatError = FileFormatError FS.FsPath String
   -> IO (Ref (Run IO h)) #-}
 -- | Load a previously written run from disk, checking each file's checksum
 -- against the checksum file.
--- The resulting 'Run' has a reference count of 1.
+--
+-- This creates a new 'Run' which must eventually be released with 'releaseRef'.
 --
 -- Exceptions will be raised when any of the file's contents don't match their
 -- checksum ('ChecksumError') or can't be parsed ('FileFormatError').

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -29,7 +29,6 @@ import           Control.Monad (when)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive
 import           Control.RefCount (RefCounter)
 import qualified Control.RefCount as RC
@@ -184,7 +183,7 @@ setRunDataCaching hbio runKOpsFile NoCacheRunData = do
   -> RunBuilder IO h
   -> IO (Run IO h) #-}
 fromMutable ::
-     (MonadFix m, MonadST m, MonadSTM m, MonadMask m)
+     (MonadST m, MonadSTM m, MonadMask m)
   => RunDataCaching
   -> RunBuilder m h
   -> m (Run m h)
@@ -214,7 +213,7 @@ fromMutable runRunDataCaching builder = do
 -- immediately when they are added to the write buffer, avoiding the need to do
 -- it here.
 fromWriteBuffer ::
-     (MonadFix m, MonadST m, MonadSTM m, MonadMask m)
+     (MonadST m, MonadSTM m, MonadMask m)
   => HasFS m h
   -> HasBlockIO m h
   -> RunDataCaching
@@ -256,7 +255,7 @@ data FileFormatError = FileFormatError FS.FsPath String
 -- checksum ('ChecksumError') or can't be parsed ('FileFormatError').
 openFromDisk ::
      forall m h.
-     (MonadFix m, MonadSTM m, MonadMask m, PrimMonad m)
+     (MonadSTM m, MonadMask m, PrimMonad m)
   => HasFS m h
   -> HasBlockIO m h
   -> RunDataCaching

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -217,7 +217,7 @@ fromMutable runRunDataCaching builder = do
   -> RunBloomFilterAlloc
   -> RunFsPaths
   -> WriteBuffer
-  -> WriteBufferBlobs IO h
+  -> Ref (WriteBufferBlobs IO h)
   -> IO (Run IO h) #-}
 -- | Write a write buffer to disk, including the blobs it contains.
 -- The resulting run has a reference count of 1.
@@ -233,7 +233,7 @@ fromWriteBuffer ::
   -> RunBloomFilterAlloc
   -> RunFsPaths
   -> WriteBuffer
-  -> WriteBufferBlobs m h
+  -> Ref (WriteBufferBlobs m h)
   -> m (Run m h)
 fromWriteBuffer fs hbio caching alloc fsPaths buffer blobs = do
     builder <- Builder.new fs hbio fsPaths (WB.numEntries buffer) alloc

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -73,7 +73,6 @@ data RunBuilder m h = RunBuilder {
   -> RunBloomFilterAlloc
   -> IO (RunBuilder IO h) #-}
 -- | Create an 'RunBuilder' to start building a run.
--- The result will have an initial reference count of 1.
 --
 -- NOTE: 'new' assumes that 'runDir' that the run is created in exists.
 new ::

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -80,20 +80,21 @@ data OffsetKey = NoOffsetKey | OffsetKey !SerialisedKey
 
 {-# SPECIALISE new ::
      OffsetKey
-  -> Run.Run IO h
+  -> Ref (Run.Run IO h)
   -> IO (RunReader IO h) #-}
 new :: forall m h.
      (MonadMask m, MonadSTM m, PrimMonad m)
   => OffsetKey
-  -> Run.Run m h
+  -> Ref (Run.Run m h)
   -> m  (RunReader m h)
-new !offsetKey readerRun@(Run.Run {
-                 runBlobFile,
-                 runRunDataCaching = readerRunDataCaching,
-                 runHasFS          = readerHasFS,
-                 runHasBlockIO     = readerHasBlockIO,
-                 runIndex          = index
-               }) = do
+new !offsetKey
+    readerRun@(DeRef Run.Run {
+      runBlobFile,
+      runRunDataCaching = readerRunDataCaching,
+      runHasFS          = readerHasFS,
+      runHasBlockIO     = readerHasBlockIO,
+      runIndex          = index
+    }) = do
     (readerKOpsHandle :: FS.Handle h) <-
       FS.hOpen readerHasFS (runKOpsPath (Run.runFsPaths readerRun)) FS.ReadMode >>= \h -> do
         fileSize <- FS.hGetSize readerHasFS h

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -95,7 +95,7 @@ new !offsetKey readerRun@(Run.Run {
                  runIndex          = index
                }) = do
     (readerKOpsHandle :: FS.Handle h) <-
-      FS.hOpen readerHasFS (runKOpsPath (Run.runRunFsPaths readerRun)) FS.ReadMode >>= \h -> do
+      FS.hOpen readerHasFS (runKOpsPath (Run.runFsPaths readerRun)) FS.ReadMode >>= \h -> do
         fileSize <- FS.hGetSize readerHasFS h
         let fileSizeInPages = fileSize `div` toEnum pageSize
         let indexedPages = getNumPages $ Run.sizeInPages readerRun

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -17,8 +17,9 @@ import           Control.Monad (guard, when)
 import           Control.Monad.Class.MonadST (MonadST (..))
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadCatch (..),
-                     MonadThrow (..))
+                     MonadMask (..), MonadThrow (..))
 import           Control.Monad.Primitive (PrimMonad (..))
+import           Control.RefCount
 import           Data.Bifunctor (first)
 import           Data.Maybe (isNothing)
 import           Data.Primitive.ByteArray (newPinnedByteArray,
@@ -29,7 +30,8 @@ import           Data.Primitive.PrimVar
 import           Data.Word (Word16, Word32)
 import           Database.LSMTree.Internal.BitMath (ceilDivPageSize,
                      mulPageSize, roundUpToPageSize)
-import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..))
+import           Database.LSMTree.Internal.BlobFile as BlobFile
+import           Database.LSMTree.Internal.BlobRef as BlobRef
 import qualified Database.LSMTree.Internal.Entry as E
 import qualified Database.LSMTree.Internal.Index as Index (search)
 import           Database.LSMTree.Internal.Page (PageNo (..), PageSpan (..),
@@ -67,8 +69,9 @@ data RunReader m h = RunReader {
       -- a counter ourselves. Also, the run's handle is supposed to be opened
       -- with @O_DIRECT@, which is counterproductive here.
     , readerKOpsHandle     :: !(FS.Handle h)
-      -- | The run this reader is reading from.
-    , readerRun            :: !(Run.Run m h)
+      -- | The blob file from the run this reader is reading from.
+    , readerBlobFile       :: !(BlobFile m h)
+    , readerRunDataCaching :: !Run.RunDataCaching
     , readerHasFS          :: !(HasFS m h)
     , readerHasBlockIO     :: !(HasBlockIO m h)
     }
@@ -80,11 +83,17 @@ data OffsetKey = NoOffsetKey | OffsetKey !SerialisedKey
   -> Run.Run IO h
   -> IO (RunReader IO h) #-}
 new :: forall m h.
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, PrimMonad m)
   => OffsetKey
   -> Run.Run m h
   -> m  (RunReader m h)
-new !offsetKey readerRun = do
+new !offsetKey readerRun@(Run.Run {
+                 runBlobFile,
+                 runRunDataCaching = readerRunDataCaching,
+                 runHasFS          = readerHasFS,
+                 runHasBlockIO     = readerHasBlockIO,
+                 runIndex          = index
+               }) = do
     (readerKOpsHandle :: FS.Handle h) <-
       FS.hOpen readerHasFS (runKOpsPath (Run.runRunFsPaths readerRun)) FS.ReadMode >>= \h -> do
         fileSize <- FS.hGetSize readerHasFS h
@@ -96,6 +105,10 @@ new !offsetKey readerRun = do
 
     (page, entryNo) <- seekFirstEntry readerKOpsHandle
 
+    --TODO: instead use: readerBlobFile <- dupRef runBlobFile
+    let readerBlobFile = runBlobFile
+    addReference (blobFileRefCounter readerBlobFile)
+
     readerCurrentEntryNo <- newPrimVar entryNo
     readerCurrentPage <- newMutVar page
     let reader = RunReader {..}
@@ -104,11 +117,6 @@ new !offsetKey readerRun = do
       close reader
     return reader
   where
-    -- Inherit the FS & BlockIO internals of the Run
-    readerHasFS = Run.runHasFS readerRun
-    readerHasBlockIO = Run.runHasBlockIO readerRun
-    index = Run.runIndex readerRun
-
     seekFirstEntry readerKOpsHandle =
         case offsetKey of
           NoOffsetKey -> do
@@ -149,14 +157,15 @@ new !offsetKey readerRun = do
 -- was done (i.e. returned 'Empty'). This avoids leaking file handles.
 -- Once it has been called, do not use the reader any more!
 close ::
-     (MonadSTM m)
+     (MonadSTM m, MonadMask m, PrimMonad m)
   => RunReader m h
   -> m ()
 close RunReader{..} = do
-    when (Run.runRunDataCaching readerRun == Run.NoCacheRunData) $
+    when (readerRunDataCaching == Run.NoCacheRunData) $
       -- drop the file from the OS page cache
       FS.hDropCacheAll readerHasBlockIO readerKOpsHandle
     FS.hClose readerHasFS readerKOpsHandle
+    BlobFile.removeReference readerBlobFile
 
 -- | The 'SerialisedKey' and 'SerialisedValue' point into the in-memory disk
 -- page. Keeping them alive will also prevent garbage collection of the 4k byte
@@ -218,7 +227,7 @@ appendOverflow len overflowPages (SerialisedValue prefix) =
 -- | Stop using the 'RunReader' after getting 'Empty', because the 'Reader' is
 -- automatically closed!
 next :: forall m h.
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => RunReader m h
   -> m (Result m h)
 next reader@RunReader {..} = do
@@ -246,14 +255,14 @@ next reader@RunReader {..} = do
                 go 0 p  -- try again on the new page
           IndexEntry key entry -> do
             modifyPrimVar readerCurrentEntryNo (+1)
-            let entry' = fmap (Run.mkRawBlobRef readerRun) entry
+            let entry' = fmap (BlobRef.mkRawBlobRef readerBlobFile) entry
             let rawEntry = Entry entry'
             return (ReadEntry key rawEntry)
           IndexEntryOverflow key entry lenSuffix -> do
             -- TODO: we know that we need the next page, could already load?
             modifyPrimVar readerCurrentEntryNo (+1)
             let entry' :: E.Entry SerialisedValue (RawBlobRef m h)
-                entry' = fmap (Run.mkRawBlobRef readerRun) entry
+                entry' = fmap (BlobRef.mkRawBlobRef readerBlobFile) entry
             overflowPages <- readOverflowPages readerHasFS readerKOpsHandle lenSuffix
             let rawEntry = mkEntryOverflow entry' page lenSuffix overflowPages
             return (ReadEntry key rawEntry)

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -164,6 +164,10 @@ close RunReader{..} = do
       FS.hDropCacheAll readerHasBlockIO readerKOpsHandle
     FS.hClose readerHasFS readerKOpsHandle
     releaseRef readerBlobFile
+    --TODO: arguably we should have distinct finish and close and require that
+    -- readers are _always_ closed, even after they have been drained.
+    -- This would allow BlobRefs to remain valid until the reader is closed.
+    -- Currently they are invalidated as soon as the cursor is drained.
 
 -- | The 'SerialisedKey' and 'SerialisedValue' point into the in-memory disk
 -- page. Keeping them alive will also prevent garbage collection of the 4k byte

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -51,8 +51,15 @@ import           System.FS.BlockIO.API (HasBlockIO)
 -- | Allows reading the k\/ops of a run incrementally, using its own read-only
 -- file handle and in-memory cache of the current disk page.
 --
--- Creating a 'RunReader' does not increase the run's reference count, so make
--- sure the run remains open while using the reader.
+-- Creating a 'RunReader' does not retain a reference to the 'Run', but does
+-- retain an independent reference on the run's blob file. It is not necessary
+-- to separately retain the 'Run' for correct use of the 'RunReader'. There is
+-- one important caveat however: the 'RunReader' maintains the validity of
+-- 'BlobRef's only up until the point where the reader is drained (or
+-- explicitly closed). In particular this means 'BlobRefs' can be invalidated
+-- as soon as the 'next' returns 'Empty'. If this is not sufficient then it is
+-- necessary to separately retain a reference to the 'Run' or its 'BlobFile' to
+-- preserve the validity of 'BlobRefs'.
 --
 -- New pages are loaded when trying to read their first entry.
 --

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -16,7 +16,7 @@ module Database.LSMTree.Internal.RunReaders (
 import           Control.Monad (zipWithM)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
-import           Control.Monad.Class.MonadThrow (MonadCatch)
+import           Control.Monad.Class.MonadThrow (MonadMask)
 import           Control.Monad.Primitive
 import           Data.Function (on)
 import           Data.Functor ((<&>))
@@ -113,7 +113,7 @@ type KOp m h = (SerialisedKey, Entry SerialisedValue (RawBlobRef m h))
   -> V.Vector (Run IO h)
   -> IO (Maybe (Readers IO h)) #-}
 new :: forall m h.
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadST m, MonadSTM m)
   => OffsetKey
   -> Maybe (WB.WriteBuffer, WB.WriteBufferBlobs m h)
   -> V.Vector (Run m h)
@@ -150,7 +150,7 @@ new !offsetKey wbs runs = do
   -> IO () #-}
 -- | Only call when aborting before all readers have been drained.
 close ::
-     (MonadSTM m, PrimMonad m)
+     (MonadMask m, MonadSTM m, PrimMonad m)
   => Readers m h
   -> m ()
 close Readers {..} = do
@@ -186,7 +186,7 @@ data HasMore = HasMore | Drained
     Readers IO h
   -> IO (SerialisedKey, Reader.Entry IO h, HasMore) #-}
 pop ::
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => Readers m h
   -> m (SerialisedKey, Reader.Entry m h, HasMore)
 pop r@Readers {..} = do
@@ -199,7 +199,7 @@ pop r@Readers {..} = do
   -> SerialisedKey
   -> IO (Int, HasMore) #-}
 dropWhileKey ::
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => Readers m h
   -> SerialisedKey
   -> m (Int, HasMore)  -- ^ How many were dropped?
@@ -233,7 +233,7 @@ dropWhileKey Readers {..} key = do
   -> Reader IO h
   -> IO HasMore #-}
 dropOne ::
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => Readers m h
   -> ReaderNumber
   -> Reader m h
@@ -254,7 +254,7 @@ dropOne Readers {..} number reader = do
   -> Reader IO h
   -> IO (Maybe (ReadCtx IO h)) #-}
 nextReadCtx ::
-     (MonadCatch m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadSTM m, MonadST m)
   => ReaderNumber
   -> Reader m h
   -> m (Maybe (ReadCtx m h))

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -18,6 +18,7 @@ import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadMask)
 import           Control.Monad.Primitive
+import           Control.RefCount
 import           Data.Function (on)
 import           Data.Functor ((<&>))
 import           Data.List.NonEmpty (nonEmpty)
@@ -109,13 +110,13 @@ type KOp m h = (SerialisedKey, Entry SerialisedValue (RawBlobRef m h))
 
 {-# SPECIALISE new ::
      OffsetKey
-  -> Maybe (WB.WriteBuffer, WB.WriteBufferBlobs IO h)
+  -> Maybe (WB.WriteBuffer, Ref (WB.WriteBufferBlobs IO h))
   -> V.Vector (Run IO h)
   -> IO (Maybe (Readers IO h)) #-}
 new :: forall m h.
      (MonadMask m, MonadST m, MonadSTM m)
   => OffsetKey
-  -> Maybe (WB.WriteBuffer, WB.WriteBufferBlobs m h)
+  -> Maybe (WB.WriteBuffer, Ref (WB.WriteBufferBlobs m h))
   -> V.Vector (Run m h)
   -> m (Maybe (Readers m h))
 new !offsetKey wbs runs = do
@@ -128,7 +129,7 @@ new !offsetKey wbs runs = do
       return Readers {..}
   where
     fromWB :: WB.WriteBuffer
-           -> WB.WriteBufferBlobs m h
+           -> Ref (WB.WriteBufferBlobs m h)
            -> m (Maybe (ReadCtx m h))
     fromWB wb wbblobs = do
         --TODO: this BlobSpan to BlobRef conversion involves quite a lot of allocation

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -47,8 +47,18 @@ import qualified System.FS.API as FS
 -- Construct with 'new', then keep calling 'pop'.
 -- If aborting early, remember to call 'close'!
 --
--- Creating a 'RunReaders' does not increase the runs' reference count, so make
--- sure they remain open while using the 'RunReaders'.
+-- Creating a 'Readers' does not retain a reference to the input 'Run's or the
+-- 'WriteBufferBlobs', but does retain an independent reference on their blob
+-- files. It is not necessary to separately retain the 'Run's or the
+-- 'WriteBufferBlobs' for correct use of the 'Readers'. There is one important
+-- caveat however: to preserve the validity of 'BlobRef's then it is necessary
+-- to separately retain a reference to the 'Run' or its 'BlobFile' to preserve
+-- the validity of 'BlobRefs'.
+--
+-- TODO: do this more nicely by changing 'Reader' to preserve the 'BlobFile'
+-- ref until it is explicitly closed, and also retain the 'BlobFile' from the
+-- WBB and release all of these 'BlobFiles' once the 'Readers' is itself closed.
+--
 data Readers m h = Readers {
       readersHeap :: !(Heap.MutableHeap (PrimState m) (ReadCtx m h))
       -- | Since there is always one reader outside of the heap, we need to

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -111,13 +111,13 @@ type KOp m h = (SerialisedKey, Entry SerialisedValue (RawBlobRef m h))
 {-# SPECIALISE new ::
      OffsetKey
   -> Maybe (WB.WriteBuffer, Ref (WB.WriteBufferBlobs IO h))
-  -> V.Vector (Run IO h)
+  -> V.Vector (Ref (Run IO h))
   -> IO (Maybe (Readers IO h)) #-}
 new :: forall m h.
      (MonadMask m, MonadST m, MonadSTM m)
   => OffsetKey
   -> Maybe (WB.WriteBuffer, Ref (WB.WriteBufferBlobs m h))
-  -> V.Vector (Run m h)
+  -> V.Vector (Ref (Run m h))
   -> m (Maybe (Readers m h))
 new !offsetKey wbs runs = do
     wBuffer <- maybe (pure Nothing) (uncurry fromWB) wbs
@@ -141,7 +141,7 @@ new !offsetKey wbs runs = do
             NoOffsetKey -> id
             OffsetKey k -> Map.dropWhileAntitone (< k)
 
-    fromRun :: ReaderNumber -> Run m h -> m (Maybe (ReadCtx m h))
+    fromRun :: ReaderNumber -> Ref (Run m h) -> m (Maybe (ReadCtx m h))
     fromRun n run = do
         reader <- Reader.new offsetKey run
         nextReadCtx n (ReadRun reader)

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -26,7 +26,6 @@ import           Control.Concurrent.Class.MonadSTM (MonadSTM)
 import           Control.Monad (void)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
-import           Control.Monad.Fix (MonadFix)
 import           Control.Monad.Primitive (PrimMonad)
 import           Control.TempRegistry
 import           Data.Foldable (sequenceA_)
@@ -225,7 +224,7 @@ snapshotRuns reg (NamedSnapshotDir targetDir) levels = for levels $ \run -> do
 -- (hard linked) files that represents a run is opened and verified, returning
 -- 'Run's as a result.
 openRuns ::
-     (MonadFix m, MonadMask m, MonadSTM m, MonadST m, MonadMVar m)
+     (MonadMask m, MonadSTM m, MonadST m, MonadMVar m)
   => TempRegistry m
   -> HasFS m h
   -> HasBlockIO m h
@@ -269,7 +268,7 @@ openRuns
   -> IO (Levels IO h)
   #-}
 fromSnapLevels ::
-     forall m h. (MonadFix m, MonadMask m, MonadMVar m, MonadSTM m, MonadST m)
+     forall m h. (MonadMask m, MonadMVar m, MonadSTM m, MonadST m)
   => TempRegistry m
   -> HasFS m h
   -> HasBlockIO m h

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -27,6 +27,7 @@ import           Control.Monad (void)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
 import           Control.Monad.Primitive (PrimMonad)
+import           Control.RefCount
 import           Control.TempRegistry
 import           Data.Foldable (sequenceA_)
 import           Data.Primitive (readMutVar)
@@ -132,32 +133,32 @@ newtype SpentCredits = SpentCredits { getSpentCredits :: Int }
   Conversion to levels snapshot format
 -------------------------------------------------------------------------------}
 
-{-# SPECIALISE toSnapLevels :: Levels IO h -> IO (SnapLevels (Run IO h)) #-}
+{-# SPECIALISE toSnapLevels :: Levels IO h -> IO (SnapLevels (Ref (Run IO h))) #-}
 toSnapLevels ::
      (PrimMonad m, MonadMVar m)
   => Levels m h
-  -> m (SnapLevels (Run m h))
+  -> m (SnapLevels (Ref (Run m h)))
 toSnapLevels levels = SnapLevels <$> V.mapM toSnapLevel levels
 
-{-# SPECIALISE toSnapLevel :: Level IO h -> IO (SnapLevel (Run IO h)) #-}
+{-# SPECIALISE toSnapLevel :: Level IO h -> IO (SnapLevel (Ref (Run IO h))) #-}
 toSnapLevel ::
      (PrimMonad m, MonadMVar m)
   => Level m h
-  -> m (SnapLevel (Run m h))
+  -> m (SnapLevel (Ref (Run m h)))
 toSnapLevel Level{..} = do
     sir <- toSnapIncomingRun incomingRun
     pure (SnapLevel sir residentRuns)
 
-{-# SPECIALISE toSnapIncomingRun :: IncomingRun IO h -> IO (SnapIncomingRun (Run IO h)) #-}
+{-# SPECIALISE toSnapIncomingRun :: IncomingRun IO h -> IO (SnapIncomingRun (Ref (Run IO h))) #-}
 toSnapIncomingRun ::
      (PrimMonad m, MonadMVar m)
   => IncomingRun m h
-  -> m (SnapIncomingRun (Run m h))
+  -> m (SnapIncomingRun (Ref (Run m h)))
 toSnapIncomingRun (Single r) = pure (SnapSingleRun r)
 -- We need to know how many credits were yet unspent so we can restore merge
 -- work on snapshot load. No need to snapshot the contents of totalStepsVar
 -- here, since we still start counting from 0 again when loading the snapshot.
-toSnapIncomingRun (Merging MergingRun {..}) = do
+toSnapIncomingRun (Merging (DeRef MergingRun {..})) = do
     unspentCredits <- readPrimVar (getUnspentCreditsVar mergeUnspentCredits)
     mergeCompletedCache <- readMutVar mergeKnownCompleted
     smrs <- withMVar mergeState $ \mrs -> toSnapMergingRunState mrs
@@ -172,11 +173,11 @@ toSnapIncomingRun (Merging MergingRun {..}) = do
 
 {-# SPECIALISE toSnapMergingRunState ::
      MergingRunState IO h
-  -> IO (SnapMergingRunState (Run IO h)) #-}
+  -> IO (SnapMergingRunState (Ref (Run IO h))) #-}
 toSnapMergingRunState ::
      PrimMonad m
   => MergingRunState m h
-  -> m (SnapMergingRunState (Run m h))
+  -> m (SnapMergingRunState (Ref (Run m h)))
 toSnapMergingRunState (CompletedMerge r) = pure (SnapCompletedMerge r)
 -- We need to know how many credits were spent already so we can restore merge
 -- work on snapshot load.
@@ -191,7 +192,7 @@ toSnapMergingRunState (OngoingMerge rs (SpentCreditsVar spentCreditsVar) m) = do
 {-# SPECIALISE snapshotRuns ::
      TempRegistry IO
   -> NamedSnapshotDir
-  -> SnapLevels (Run IO h)
+  -> SnapLevels (Ref (Run IO h))
   -> IO (SnapLevels RunNumber) #-}
 -- | @'snapshotRuns' _ targetDir levels@ creates hard links for all run files
 -- associated with the runs in @levels@, and puts the new directory entries in
@@ -200,13 +201,15 @@ snapshotRuns ::
      (MonadMask m, MonadMVar m)
   => TempRegistry m
   -> NamedSnapshotDir
-  -> SnapLevels (Run m h)
+  -> SnapLevels (Ref (Run m h))
   -> m (SnapLevels RunNumber)
-snapshotRuns reg (NamedSnapshotDir targetDir) levels = for levels $ \run -> do
-    let sourcePaths = Run.runFsPaths run
-    let targetPaths = sourcePaths { runDir = targetDir }
-    hardLinkRunFiles reg (Run.runHasFS run) (Run.runHasBlockIO run) sourcePaths targetPaths
-    pure (runNumber targetPaths)
+snapshotRuns reg (NamedSnapshotDir targetDir) levels =
+    for levels $ \run@(DeRef Run.Run { Run.runHasFS = hfs,
+                                       Run.runHasBlockIO = hbio }) -> do
+      let sourcePaths = Run.runFsPaths run
+      let targetPaths = sourcePaths { runDir = targetDir }
+      hardLinkRunFiles reg hfs hbio sourcePaths targetPaths
+      pure (runNumber targetPaths)
 
 {-# SPECIALISE openRuns ::
      TempRegistry IO
@@ -217,7 +220,7 @@ snapshotRuns reg (NamedSnapshotDir targetDir) levels = for levels $ \run -> do
   -> NamedSnapshotDir
   -> ActiveDir
   -> SnapLevels RunNumber
-  -> IO (SnapLevels (Run IO h)) #-}
+  -> IO (SnapLevels (Ref (Run IO h))) #-}
 -- | @'openRuns' _ _ _ _ uniqCounter sourceDir targetDir levels@ takes all run
 -- files that are referenced by @levels@, and hard links them from @sourceDir@
 -- into @targetDir@ with new, unique names (using @uniqCounter@). Each set of
@@ -233,7 +236,7 @@ openRuns ::
   -> NamedSnapshotDir
   -> ActiveDir
   -> SnapLevels RunNumber
-  -> m (SnapLevels (Run m h))
+  -> m (SnapLevels (Ref (Run m h)))
 openRuns
   reg hfs hbio TableConfig{..} uc
   (NamedSnapshotDir sourceDir) (ActiveDir targetDir) (SnapLevels levels) = do
@@ -249,7 +252,7 @@ openRuns
 
           allocateTemp reg
             (Run.openFromDisk hfs hbio caching targetPaths)
-            Run.removeReference
+            releaseRef
     pure (SnapLevels levels')
 
 {-------------------------------------------------------------------------------
@@ -264,7 +267,7 @@ openRuns
   -> UniqCounter IO
   -> ResolveSerialisedValue
   -> ActiveDir
-  -> SnapLevels (Run IO h)
+  -> SnapLevels (Ref (Run IO h))
   -> IO (Levels IO h)
   #-}
 fromSnapLevels ::
@@ -276,14 +279,14 @@ fromSnapLevels ::
   -> UniqCounter m
   -> ResolveSerialisedValue
   -> ActiveDir
-  -> SnapLevels (Run m h)
+  -> SnapLevels (Ref (Run m h))
   -> m (Levels m h)
 fromSnapLevels reg hfs hbio conf@TableConfig{..} uc resolve dir (SnapLevels levels) =
     V.iforM levels $ \i -> fromSnapLevel (LevelNo (i+1))
   where
     mkPath = RunFsPaths (getActiveDir dir)
 
-    fromSnapLevel :: LevelNo -> SnapLevel (Run m h) -> m (Level m h)
+    fromSnapLevel :: LevelNo -> SnapLevel (Ref (Run m h)) -> m (Level m h)
     fromSnapLevel ln SnapLevel{..} = do
         (unspentCreditsMay, spentCreditsMay, incomingRun) <- fromSnapIncomingRun snapIncoming
         -- When a snapshot is created, merge progress is lost, so we have to
@@ -309,7 +312,9 @@ fromSnapLevels reg hfs hbio conf@TableConfig{..} uc resolve dir (SnapLevels leve
         caching = diskCachePolicyForLevel confDiskCachePolicy ln
         alloc = bloomFilterAllocForLevel conf ln
 
-        fromSnapIncomingRun :: SnapIncomingRun (Run m h) -> m (Maybe UnspentCredits, Maybe SpentCredits, IncomingRun m h)
+        fromSnapIncomingRun ::
+             SnapIncomingRun (Ref (Run m h))
+          -> m (Maybe UnspentCredits, Maybe SpentCredits, IncomingRun m h)
         fromSnapIncomingRun (SnapMergingRun mpfl nr ne unspentCredits knownCompleted smrs) = do
             (spentCreditsMay, mrs) <- fromSnapMergingRunState smrs
             (Just unspentCredits, spentCreditsMay,) . Merging <$>
@@ -317,7 +322,9 @@ fromSnapLevels reg hfs hbio conf@TableConfig{..} uc resolve dir (SnapLevels leve
         fromSnapIncomingRun (SnapSingleRun run) =
             pure (Nothing, Nothing, Single run)
 
-        fromSnapMergingRunState :: SnapMergingRunState (Run m h) -> m (Maybe SpentCredits, MergingRunState m h)
+        fromSnapMergingRunState ::
+             SnapMergingRunState (Ref (Run m h))
+          -> m (Maybe SpentCredits, MergingRunState m h)
         fromSnapMergingRunState (SnapCompletedMerge run) =
             pure (Nothing, CompletedMerge run)
         fromSnapMergingRunState (SnapOngoingMerge runs spentCredits mergeLast) = do

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -203,7 +203,7 @@ snapshotRuns ::
   -> SnapLevels (Run m h)
   -> m (SnapLevels RunNumber)
 snapshotRuns reg (NamedSnapshotDir targetDir) levels = for levels $ \run -> do
-    let sourcePaths = Run.runRunFsPaths run
+    let sourcePaths = Run.runFsPaths run
     let targetPaths = sourcePaths { runDir = targetDir }
     hardLinkRunFiles reg (Run.runHasFS run) (Run.runHasBlockIO run) sourcePaths targetPaths
     pure (runNumber targetPaths)

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeFamilies #-}
+
 {-# OPTIONS_GHC -Wno-partial-fields #-}
 {- HLINT ignore "Use record patterns" -}
 
@@ -9,10 +11,9 @@
 --
 -- A single write buffer blob file can be shared between multiple tables. As a
 -- consequence, the lifetime of the 'WriteBufferBlobs' must be managed using
--- 'new','addReference' and 'removeReference'. A fresh 'WriteBufferBlobs' has a
--- reference count of 1, and so must be matched by 'removeReference'. When a
--- table is duplicated, the new table needs its own reference, so use
--- 'addReference' upon duplication.
+-- 'new', and with the 'Ref' API: 'releaseRef' and 'dupRef'. When a table is
+-- duplicated, the new table needs its own reference, so use 'dupRef' upon
+-- duplication.
 --
 -- Blobs are copied from the write buffer blob file when the write buffer is
 -- flushed to make a run. This is needed since the blob file is shared and so
@@ -24,8 +25,6 @@
 module Database.LSMTree.Internal.WriteBufferBlobs (
     WriteBufferBlobs (..),
     new,
-    addReference,
-    removeReference,
     addBlob,
     mkRawBlobRef,
     mkWeakBlobRef,
@@ -36,8 +35,7 @@ module Database.LSMTree.Internal.WriteBufferBlobs (
 import           Control.DeepSeq (NFData (..))
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive (PrimMonad, PrimState)
-import           Control.RefCount hiding (addReference, removeReference)
-import qualified Control.RefCount as RC
+import           Control.RefCount
 import           Data.Primitive.PrimVar as P
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.BlobFile
@@ -114,40 +112,34 @@ data WriteBufferBlobs m h =
 instance NFData h => NFData (WriteBufferBlobs m h) where
   rnf (WriteBufferBlobs a b c) = rnf a `seq` rnf b `seq` rnf c
 
-{-# SPECIALISE new :: HasFS IO h -> FS.FsPath -> IO (WriteBufferBlobs IO h) #-}
+instance RefCounted (WriteBufferBlobs m h) where
+  type FinaliserM (WriteBufferBlobs m h) = m
+  getRefCounter = writeBufRefCounter
+
+{-# SPECIALISE new :: HasFS IO h -> FS.FsPath -> IO (Ref (WriteBufferBlobs IO h)) #-}
 new :: (PrimMonad m, MonadMask m)
     => HasFS m h
     -> FS.FsPath
-    -> m (WriteBufferBlobs m h)
+    -> m (Ref (WriteBufferBlobs m h))
 new fs blobFileName = do
     -- Must use read/write mode because we write blobs when adding, but
     -- we can also be asked to retrieve blobs at any time.
     blobFile <- openBlobFile fs blobFileName (FS.ReadWriteMode FS.MustBeNew)
     blobFilePointer <- newFilePointer
-    writeBufRefCounter <- newRefCounter (releaseRef blobFile)
-    return WriteBufferBlobs {
-      blobFile,
-      blobFilePointer,
-      writeBufRefCounter
-    }
+    newRef (releaseRef blobFile) $ \writeBufRefCounter ->
+      WriteBufferBlobs {
+        blobFile,
+        blobFilePointer,
+        writeBufRefCounter
+      }
 
-{-# SPECIALISE addReference :: WriteBufferBlobs IO h -> IO () #-}
-addReference :: PrimMonad m => WriteBufferBlobs m h -> m ()
-addReference WriteBufferBlobs {writeBufRefCounter} =
-    RC.addReference writeBufRefCounter
-
-{-# SPECIALISE removeReference :: WriteBufferBlobs IO h -> IO () #-}
-removeReference :: (PrimMonad m, MonadMask m) => WriteBufferBlobs m h -> m ()
-removeReference WriteBufferBlobs {writeBufRefCounter} =
-    RC.removeReference writeBufRefCounter
-
-{-# SPECIALISE addBlob :: HasFS IO h -> WriteBufferBlobs IO h -> SerialisedBlob -> IO BlobSpan #-}
+{-# SPECIALISE addBlob :: HasFS IO h -> Ref (WriteBufferBlobs IO h) -> SerialisedBlob -> IO BlobSpan #-}
 addBlob :: (PrimMonad m, MonadThrow m)
         => HasFS m h
-        -> WriteBufferBlobs m h
+        -> Ref (WriteBufferBlobs m h)
         -> SerialisedBlob
         -> m BlobSpan
-addBlob fs WriteBufferBlobs {blobFile, blobFilePointer} blob = do
+addBlob fs (DeRef WriteBufferBlobs {blobFile, blobFilePointer}) blob = do
     let blobsize = sizeofBlob blob
     bloboffset <- updateFilePointer blobFilePointer blobsize
     BlobFile.writeBlob fs blobFile blob bloboffset
@@ -158,10 +150,10 @@ addBlob fs WriteBufferBlobs {blobFile, blobFilePointer} blob = do
 
 -- | Helper function to make a 'RawBlobRef' that points into a
 -- 'WriteBufferBlobs'.
-mkRawBlobRef :: WriteBufferBlobs m h
+mkRawBlobRef :: Ref (WriteBufferBlobs m h)
              -> BlobSpan
              -> RawBlobRef m h
-mkRawBlobRef WriteBufferBlobs {blobFile = DeRef blobfile} blobspan =
+mkRawBlobRef (DeRef WriteBufferBlobs {blobFile = DeRef blobfile}) blobspan =
     RawBlobRef {
       rawBlobRefFile = blobfile,
       rawBlobRefSpan = blobspan
@@ -169,10 +161,10 @@ mkRawBlobRef WriteBufferBlobs {blobFile = DeRef blobfile} blobspan =
 
 -- | Helper function to make a 'WeakBlobRef' that points into a
 -- 'WriteBufferBlobs'.
-mkWeakBlobRef :: WriteBufferBlobs m h
+mkWeakBlobRef :: Ref (WriteBufferBlobs m h)
               -> BlobSpan
               -> WeakBlobRef m h
-mkWeakBlobRef WriteBufferBlobs {blobFile} blobspan =
+mkWeakBlobRef (DeRef WriteBufferBlobs {blobFile}) blobspan =
     WeakBlobRef {
       weakBlobRefFile = mkWeakRef blobFile,
       weakBlobRefSpan = blobspan

--- a/test-control/Test/Control/RefCount.hs
+++ b/test-control/Test/Control/RefCount.hs
@@ -3,7 +3,6 @@
 
 module Test.Control.RefCount (tests) where
 
-import           Data.Primitive.PrimVar
 import           Control.Concurrent.Class.MonadMVar
 import           Control.Exception
 import           Control.Monad

--- a/test-control/Test/Control/RefCount.hs
+++ b/test-control/Test/Control/RefCount.hs
@@ -3,6 +3,7 @@
 
 module Test.Control.RefCount (tests) where
 
+import           Data.Primitive.PrimVar
 import           Control.Concurrent.Class.MonadMVar
 import           Control.Exception
 import           Control.Monad
@@ -97,6 +98,13 @@ prop_RefCounter = once $ ioProperty $ do
 #else
     check = \case Left (AssertionFailed _) -> False; Right () -> True
 #endif
+
+-- | Warning: reading the current reference count is inherently racy as there
+-- is no way to reliably act on the information. It is only useful for tests or
+-- debugging.
+--
+readRefCount :: RefCounter IO -> IO Int
+readRefCount (RefCounter countVar _) = readPrimVar countVar
 
 #ifdef NO_IGNORE_ASSERTS
 data TestObject = TestObject !(RefCounter IO)

--- a/test-control/Test/Control/RefCount.hs
+++ b/test-control/Test/Control/RefCount.hs
@@ -1,50 +1,68 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Test.Control.RefCount (tests) where
 
 import           Control.Concurrent.Class.MonadMVar
-import           Control.Exception (AssertionFailed (..), try)
+import           Control.Exception
 import           Control.Monad
 import           Control.RefCount
+import           Data.Primitive.PrimVar
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck
 
+#ifdef NO_IGNORE_ASSERTS
+import           Data.IORef
+#endif
+
 tests :: TestTree
 tests = testGroup "Control.RefCount" [
-      testProperty "prop_refCount" prop_refCount
+      testProperty "prop_RefCounter"          prop_RefCounter
+#ifdef NO_IGNORE_ASSERTS
+      -- All of these tests below are checking that the debug implementation of
+      -- Ref does indeed detect all the violations (double-free, use-after-free,
+      -- never-free). But this obviously depends on the debug implementation
+      -- being in use. Hence only tested when NO_IGNORE_ASSERTS.
+    , testProperty "prop_ref_double_free"     prop_ref_double_free
+    , testProperty "prop_ref_use_after_free"  prop_ref_use_after_free
+    , testProperty "prop_ref_never_released0" prop_ref_never_released0
+    , testProperty "prop_ref_never_released1" prop_ref_never_released1
+    , testProperty "prop_ref_never_released2" prop_ref_never_released2
+#endif
     ]
 
-prop_refCount :: Property
-prop_refCount = once $ ioProperty $ do
+-- | Test for the low level RefCounter API
+prop_RefCounter :: Property
+prop_RefCounter = once $ ioProperty $ do
     obj <- newMVar False
-    ref <- mkRefCounter1 (void $ modifyMVar_ obj (\x -> pure (not x)) )
+    ref <- newRefCounter (void $ modifyMVar_ obj (\x -> pure (not x)) )
 
-    addReference ref
+    incrementRefCounter ref
     n1 <- readRefCount ref -- 2
     b1 <- readMVar obj -- False
 
-    removeReference ref
+    decrementRefCounter ref
     n2 <- readRefCount ref -- 1
     b2 <- readMVar obj -- False
 
-    e2w <- upgradeWeakReference ref -- ok, True
+    e2w <- tryIncrementRefCounter ref -- ok, True
     n2w <- readRefCount ref -- 2
     b2w <- readMVar obj -- False
-    removeReference ref
+    decrementRefCounter ref
 
-    removeReference ref
+    decrementRefCounter ref
     n3 <- readRefCount ref -- 0
     b3 <- readMVar obj -- True, finaliser ran
 
-    e4 <- try (removeReference ref) -- error
+    e4 <- try (decrementRefCounter ref) -- error
     n4 <- readRefCount ref -- -1
     b4 <- readMVar obj -- True, finaliser did not run again
 
-    e5 <- try (addReference ref) -- error
+    e5 <- try (incrementRefCounter ref) -- error
     n5 <- readRefCount ref -- 0
     b5 <- readMVar obj -- True, finaliser did not run again
 
-    e6 <- upgradeWeakReference ref
+    e6 <- tryIncrementRefCounter ref
     n6 <- readRefCount ref -- 0
     b6 <- readMVar obj -- True, finaliser did not run again
 
@@ -79,3 +97,79 @@ prop_refCount = once $ ioProperty $ do
 #else
     check = \case Left (AssertionFailed _) -> False; Right () -> True
 #endif
+
+#ifdef NO_IGNORE_ASSERTS
+data TestObject = TestObject !(RefCounter IO)
+
+instance RefCounted TestObject where
+    type FinaliserM TestObject = IO
+    getRefCounter (TestObject rc) = rc
+
+data TestObject2 = TestObject2 (Ref TestObject)
+
+instance RefCounted TestObject2 where
+    type FinaliserM TestObject2 = IO
+    getRefCounter (TestObject2 (DeRef to1)) = getRefCounter to1
+
+prop_ref_double_free :: Property
+prop_ref_double_free = once $ ioProperty $ do
+    finalised <- newIORef False
+    ref <- newRef (writeIORef finalised True) TestObject
+    releaseRef ref
+    True <- readIORef finalised
+    Left RefDoubleRelease{} <- try $ releaseRef ref
+    checkForgottenRefs
+
+prop_ref_use_after_free :: Property
+prop_ref_use_after_free = once $ ioProperty $ do
+    finalised <- newIORef False
+    ref <- newRef (writeIORef finalised True) TestObject
+    releaseRef ref
+    True <- readIORef finalised
+    Left RefUseAfterRelease{} <- try $ withRef ref return
+    Left RefUseAfterRelease{} <- try $ case ref of DeRef _ -> return ()
+    Left RefUseAfterRelease{} <- try $ dupRef ref
+    checkForgottenRefs
+
+prop_ref_never_released0 :: Property
+prop_ref_never_released0 = once $ ioProperty $ do
+    finalised <- newIORef False
+    ref <- newRef (writeIORef finalised True) TestObject
+    _ <- case ref of DeRef _ -> return ()
+    checkForgottenRefs
+    -- ref is still being used, so check should not fail
+    _ <- case ref of DeRef _ -> return ()
+    releaseRef ref
+
+prop_ref_never_released1 :: Property
+prop_ref_never_released1 =
+    once $ ioProperty $
+    handle expectRefNeverReleased $ do
+      finalised <- newIORef False
+      ref <- newRef (writeIORef finalised True) TestObject
+      _ <- withRef ref return
+      _ <- case ref of DeRef _ -> return ()
+      -- ref is never released, so should fail
+      checkForgottenRefs
+      return (counterexample "no forgotten refs detected" $ property False)
+
+prop_ref_never_released2 :: Property
+prop_ref_never_released2 =
+    once $ ioProperty $
+    handle expectRefNeverReleased $ do
+      finalised <- newIORef False
+      ref  <- newRef (writeIORef finalised True) TestObject
+      ref2 <- dupRef ref
+      releaseRef ref
+      _ <- withRef ref2 return
+      _ <- case ref2 of DeRef _ -> return ()
+      -- ref2 is never released, so should fail
+      checkForgottenRefs
+      return (counterexample "no forgotten refs detected" $ property False)
+
+expectRefNeverReleased :: RefException -> IO Property
+expectRefNeverReleased RefNeverReleased{} = return (property True)
+expectRefNeverReleased e =
+    return (counterexample (displayException e) $ property False)
+#endif
+

--- a/test-control/Test/Control/RefCount.hs
+++ b/test-control/Test/Control/RefCount.hs
@@ -19,7 +19,7 @@ tests = testGroup "Control.RefCount" [
 prop_refCount :: Property
 prop_refCount = once $ ioProperty $ do
     obj <- newMVar False
-    ref <- mkRefCounter1 $ Just (void $ modifyMVar_ obj (\x -> pure (not x)) )
+    ref <- mkRefCounter1 (void $ modifyMVar_ obj (\x -> pure (not x)) )
 
     addReference ref
     n1 <- readRefCount ref -- 2
@@ -85,7 +85,7 @@ prop_refCount = once $ ioProperty $ do
 prop_removeReferenceN :: Positive Int -> NonNegative Int -> Property
 prop_removeReferenceN (Positive n) (NonNegative m) = ioProperty $ do
     obj <- newMVar False
-    ref <- unsafeMkRefCounterN (RefCount n) $ Just (void $ modifyMVar_ obj (\x -> pure (not x)) )
+    ref <- unsafeMkRefCounterN (RefCount n) (void $ modifyMVar_ obj (\x -> pure (not x)) )
 
     e1 <- try @AssertionFailed $ removeReferenceN ref (fromIntegral m)
     n1 <- readRefCount ref -- 0

--- a/test/Database/LSMTree/Class/Normal.hs
+++ b/test/Database/LSMTree/Class/Normal.hs
@@ -16,9 +16,7 @@ module Database.LSMTree.Class.Normal (
   , module Types
   ) where
 
-import           Control.Monad.Class.MonadST (MonadST)
-import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow (..))
-import           Control.Monad.Fix (MonadFix)
+import           Control.Monad.Class.MonadThrow (bracket)
 import           Control.Tracer (nullTracer)
 import           Data.Kind (Constraint, Type)
 import           Data.Typeable (Proxy (Proxy), Typeable)
@@ -271,7 +269,7 @@ withCursor offset hdl = bracket (newCursor offset hdl) (closeCursor (Proxy @h))
 instance IsSession R.Session where
     data SessionArgs R.Session m where
       SessionArgs ::
-           forall m h. (MonadFix m, MonadMask m, MonadST m, Typeable h)
+           forall m h. Typeable h
         => HasFS m h -> HasBlockIO m h -> FsPath
         -> SessionArgs R.Session m
 

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -314,9 +314,9 @@ prop_roundtripFromWriteBufferLookupIO (SmallList dats) =
         resolveV
         wb wbblobs
         runs
-        (V.map Run.runFilter runs)
-        (V.map Run.runIndex runs)
-        (V.map Run.runKOpsFile runs)
+        (V.map (\(DeRef r) -> Run.runFilter   r) runs)
+        (V.map (\(DeRef r) -> Run.runIndex    r) runs)
+        (V.map (\(DeRef r) -> Run.runKOpsFile r) runs)
         keys
     pure $ modelres === realres
   where
@@ -336,7 +336,7 @@ withRuns :: FS.HasFS IO h
          -> [InMemLookupData SerialisedKey SerialisedValue SerialisedBlob]
          -> (   WB.WriteBuffer
              -> Ref (WBB.WriteBufferBlobs IO h)
-             -> V.Vector (Run.Run IO h)
+             -> V.Vector (Ref (Run.Run IO h))
              -> IO a)
          -> IO a
 withRuns hfs _ [] action =
@@ -361,7 +361,7 @@ withRuns hfs hbio (wbdat:rundats) action =
           return (wb, wbblobs, runs))
 
       (\(_wb, wbblobs, runs) -> do
-          V.mapM_ Run.removeReference runs
+          V.mapM_ releaseRef runs
           releaseRef wbblobs)
 
       (\(wb, wbblobs, runs) ->

--- a/test/Test/Database/LSMTree/Internal/Merge.hs
+++ b/test/Test/Database/LSMTree/Internal/Merge.hs
@@ -86,7 +86,7 @@ prop_MergeDistributes fs hbio level stepSize (SmallList rds) =
 
         return $ stats $
               counterexample "numEntries"
-              (Run.runNumEntries lhs === Run.runNumEntries rhs)
+              (Run.size lhs === Run.size rhs)
           .&&. -- we can't just test bloom filter equality, their sizes may differ.
               counterexample "runFilter"
               (Bloom.length (Run.runFilter lhs) >= Bloom.length (Run.runFilter rhs))

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -22,7 +22,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertEqual, testCase, (@=?), (@?))
 import           Test.Tasty.QuickCheck
 
-import           Control.RefCount (RefCount (..), readRefCount)
+import           Control.RefCount (readRefCount)
 import           Control.TempRegistry (withTempRegistry)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..))
 import           Database.LSMTree.Extras.RunData
@@ -193,8 +193,8 @@ prop_WriteAndOpen fs hbio wb =
       hardLinkRunFiles reg fs hbio paths paths'
       loaded <- openFromDisk fs hbio CacheRunData (simplePath 17)
 
-      (RefCount 1 @=?) =<< readRefCount (runRefCounter written)
-      (RefCount 1 @=?) =<< readRefCount (runRefCounter loaded)
+      (1 @=?) =<< readRefCount (runRefCounter written)
+      (1 @=?) =<< readRefCount (runRefCounter loaded)
 
       runNumEntries written @=? runNumEntries loaded
       runFilter written @=? runFilter loaded

--- a/test/Test/Database/LSMTree/Internal/RunReader.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReader.hs
@@ -5,6 +5,7 @@ module Test.Database.LSMTree.Internal.RunReader (
     readKOps,
 ) where
 
+import           Control.RefCount
 import           Data.Coerce (coerce)
 import qualified Data.Map as Map
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..))
@@ -166,7 +167,7 @@ type SerialisedKOp = (SerialisedKey, SerialisedEntry)
 
 readKOps ::
      Maybe (SerialisedKey)  -- ^ offset
-  -> Run IO h
+  -> Ref (Run IO h)
   -> IO [SerialisedKOp]
 readKOps offset run = do
     reader <- Reader.new offsetKey run

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -70,6 +70,7 @@ import           Control.Monad.Class.MonadThrow (Handler (..), MonadCatch (..),
                      MonadThrow (..))
 import           Control.Monad.IOSim
 import           Control.Monad.Reader (ReaderT (..))
+import           Control.RefCount (checkForgottenRefs)
 import           Control.Tracer (Tracer, nullTracer)
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Constraint (Dict (..))
@@ -1775,7 +1776,11 @@ runActionsBracket' ::
   -> Actions (Lockstep state) -> QC.Property
 runActionsBracket' p init cleanup runner tagger actions =
     tagFinalState actions tagger
-  $ Lockstep.Run.runActionsBracket p init cleanup runner actions
+  $ Lockstep.Run.runActionsBracket p init cleanup' runner actions
+  where
+    cleanup' st = do
+      cleanup st
+      checkForgottenRefs
 
 tagFinalState ::
      forall state. StateModel (Lockstep state)


### PR DESCRIPTION
Instead of a referencing counting API, where we must increment and decrement reference counts correctly, we have an API organised around a singular `Ref`. The rules for `Ref` are simple and can be dynamically checked (in test/debug builds): release exactly once, do not use after release. And refs can be duplicated to give new refs (instead of incrementing reference counts). Under the hood it's the same reference counting operations.