### PR TITLE
Refactoring APIs involving HasIO & HasBlockIO

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -180,7 +180,7 @@ lookupsInBatchesEnv ::
         , ArenaManager RealWorld
         , FS.HasFS IO FS.HandleIO
         , FS.HasBlockIO IO FS.HandleIO
-        , V.Vector (Run IO (FS.Handle FS.HandleIO))
+        , V.Vector (Run IO FS.HandleIO)
         , V.Vector SerialisedKey
         )
 lookupsInBatchesEnv Config {..} = do
@@ -212,7 +212,7 @@ lookupsInBatchesCleanup ::
      , ArenaManager RealWorld
      , FS.HasFS IO FS.HandleIO
      , FS.HasBlockIO IO FS.HandleIO
-     , V.Vector (Run IO (FS.Handle FS.HandleIO))
+     , V.Vector (Run IO FS.HandleIO)
      , V.Vector SerialisedKey
      )
   -> IO ()

--- a/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
@@ -228,7 +228,7 @@ merge ::
   -> Config
   -> Run.RunFsPaths
   -> InputRuns
-  -> IO (Run IO (FS.Handle (FS.HandleIO)))
+  -> IO (Run IO FS.HandleIO)
 merge fs hbio Config {..} targetPaths runs = do
     let f = fromMaybe const mergeMappend
     m <- fromMaybe (error "empty inputs, no merge created") <$>
@@ -241,7 +241,7 @@ outputRunPaths = RunFsPaths (FS.mkFsPath []) (RunNumber 0)
 inputRunPaths :: [Run.RunFsPaths]
 inputRunPaths = RunFsPaths (FS.mkFsPath []) . RunNumber <$> [1..]
 
-type InputRuns = V.Vector (Run IO (FS.Handle FS.HandleIO))
+type InputRuns = V.Vector (Run IO FS.HandleIO)
 
 type Mappend = SerialisedValue -> SerialisedValue -> SerialisedValue
 

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -184,9 +184,9 @@ instance NoThunks (Unsliced a) where
   Run
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (Run m (Handle h))
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
-                        => NoThunks (Run m (Handle h))
+deriving stock instance Generic (Run m h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
+                        => NoThunks (Run m h)
 
 deriving stock instance Generic RunDataCaching
 deriving anyclass instance NoThunks RunDataCaching
@@ -259,11 +259,11 @@ deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
                            , NoThunks (StrictMVar m (MergingRunState m h))
                            ) => NoThunks (TableContent m h)
 
-deriving stock instance Generic (LevelsCache m (Handle h))
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
-                        => NoThunks (LevelsCache m (Handle h))
+deriving stock instance Generic (LevelsCache m h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
+                        => NoThunks (LevelsCache m h)
 
-deriving stock instance Generic (Level m  h)
+deriving stock instance Generic (Level m h)
 deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
                            , NoThunks (StrictMVar m (MergingRunState m h))
                            ) => NoThunks (Level m h)
@@ -292,13 +292,13 @@ deriving anyclass instance NoThunks NumEntries
   RunBuilder
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (RunBuilder s (Handle h))
-deriving anyclass instance (Typeable s, Typeable h)
-                        => NoThunks (RunBuilder s (Handle h))
+deriving stock instance Generic (RunBuilder m h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
+                        => NoThunks (RunBuilder m h)
 
-deriving stock instance Generic (ChecksumHandle s (Handle h))
+deriving stock instance Generic (ChecksumHandle s h)
 deriving anyclass instance (Typeable s, Typeable h)
-                        => NoThunks (ChecksumHandle s (Handle h))
+                        => NoThunks (ChecksumHandle s h)
 
 {-------------------------------------------------------------------------------
   RunAcc
@@ -348,14 +348,14 @@ deriving anyclass instance NoThunks Merge.MergeState
   Readers
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (Readers m (Handle h))
+deriving stock instance Generic (Readers m h)
 deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
-                        => NoThunks (Readers m (Handle h))
+                        => NoThunks (Readers m h)
 
-deriving stock instance Generic (Reader m (Handle h))
+deriving stock instance Generic (Reader m h)
 instance (Typeable m, Typeable (PrimState m), Typeable h)
-      => NoThunks (Reader m (Handle h)) where
-  showTypeOf (_ :: Proxy (Reader m (Handle h))) = "Reader"
+      => NoThunks (Reader m h) where
+  showTypeOf (_ :: Proxy (Reader m h)) = "Reader"
   wNoThunks ctx = \case
     ReadRun r      -> noThunks ctx r
     ReadBuffer var -> noThunks ctx (OnlyCheckWhnf var) -- contents intentionally lazy
@@ -363,20 +363,20 @@ instance (Typeable m, Typeable (PrimState m), Typeable h)
 deriving stock instance Generic ReaderNumber
 deriving anyclass instance NoThunks ReaderNumber
 
-deriving stock instance Generic (ReadCtx m (Handle h))
+deriving stock instance Generic (ReadCtx m h)
 deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
-                        => NoThunks (ReadCtx m (Handle h))
+                        => NoThunks (ReadCtx m h)
 
 {-------------------------------------------------------------------------------
   Reader
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (RunReader m (Handle h))
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
-                        => NoThunks (RunReader m (Handle h))
+deriving stock instance Generic (RunReader m h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
+                        => NoThunks (RunReader m h)
 
 deriving stock instance Generic (Reader.Entry m (Handle h))
-deriving anyclass instance (Typeable (PrimState m), Typeable h)
+deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
                         => NoThunks (Reader.Entry m (Handle h))
 
 {-------------------------------------------------------------------------------

--- a/src-extras/Database/LSMTree/Extras/RunData.hs
+++ b/src-extras/Database/LSMTree/Extras/RunData.hs
@@ -53,7 +53,7 @@ withRun ::
   -> HasBlockIO IO h
   -> RunFsPaths
   -> SerialisedRunData
-  -> (Run IO (Handle h) -> IO a)
+  -> (Run IO h -> IO a)
   -> IO a
 withRun hfs hbio path rd = do
     bracket
@@ -67,7 +67,7 @@ withRuns ::
   => HasFS IO h
   -> HasBlockIO IO h
   -> f (RunFsPaths, SerialisedRunData)
-  -> (f (Run IO (Handle h)) -> IO a)
+  -> (f (Run IO h) -> IO a)
   -> IO a
 withRuns hfs hbio xs = do
     bracket
@@ -85,7 +85,7 @@ unsafeFlushAsWriteBuffer ::
   -> HasBlockIO IO h
   -> RunFsPaths
   -> SerialisedRunData
-  -> IO (Run IO (Handle h))
+  -> IO (Run IO h)
 unsafeFlushAsWriteBuffer fs hbio fsPaths (RunData m) = do
     let blobpath = addExtension (runBlobPath fsPaths) ".wb"
     wbblobs <- WBB.new fs blobpath

--- a/src/Database/LSMTree/Internal/CRC32C.hs
+++ b/src/Database/LSMTree/Internal/CRC32C.hs
@@ -3,6 +3,10 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- Needed by GHC <= 9.2 for newtype deriving Prim below
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE UnboxedTuples       #-}
+
 -- | Functionalty related to CRC-32C (Castagnoli) checksums:
 --
 -- * Support for calculating checksums while incrementally writing files.
@@ -65,6 +69,7 @@ import           System.FS.BlockIO.API (ByteCount)
 
 newtype CRC32C = CRC32C Word32
   deriving stock (Eq, Ord, Show)
+  deriving newtype (Prim)
 
 
 initialCRC32C :: CRC32C

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -157,7 +157,7 @@ data ByteCountDiscrepancy = ByteCountDiscrepancy {
     -> ResolveSerialisedValue
     -> WB.WriteBuffer
     -> WBB.WriteBufferBlobs IO h
-    -> V.Vector (Run IO (Handle h))
+    -> V.Vector (Run IO h)
     -> V.Vector (Bloom SerialisedKey)
     -> V.Vector IndexCompact
     -> V.Vector (Handle h)
@@ -177,7 +177,7 @@ lookupsIO ::
   -> ResolveSerialisedValue
   -> WB.WriteBuffer
   -> WBB.WriteBufferBlobs m h
-  -> V.Vector (Run m (Handle h)) -- ^ Runs @rs@
+  -> V.Vector (Run m h) -- ^ Runs @rs@
   -> V.Vector (Bloom SerialisedKey) -- ^ The bloom filters inside @rs@
   -> V.Vector IndexCompact -- ^ The indexes inside @rs@
   -> V.Vector (Handle h) -- ^ The file handles to the key\/value files inside @rs@
@@ -202,7 +202,7 @@ lookupsIO !hbio !mgr !resolveV !wb !wbblobs !rs !blooms !indexes !kopsFiles !ks 
        ResolveSerialisedValue
     -> WB.WriteBuffer
     -> WBB.WriteBufferBlobs IO h
-    -> V.Vector (Run IO (Handle h))
+    -> V.Vector (Run IO h)
     -> V.Vector SerialisedKey
     -> VP.Vector RunIxKeyIx
     -> V.Vector (IOOp RealWorld h)
@@ -221,7 +221,7 @@ intraPageLookups ::
   => ResolveSerialisedValue
   -> WB.WriteBuffer
   -> WBB.WriteBufferBlobs m h
-  -> V.Vector (Run m (Handle h))
+  -> V.Vector (Run m h)
   -> V.Vector SerialisedKey
   -> VP.Vector RunIxKeyIx
   -> V.Vector (IOOp (PrimState m) h)

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -337,7 +337,7 @@ withRuns :: FS.HasFS IO h
          -> [InMemLookupData SerialisedKey SerialisedValue SerialisedBlob]
          -> (   WB.WriteBuffer
              -> WBB.WriteBufferBlobs IO h
-             -> V.Vector (Run.Run IO (Handle h))
+             -> V.Vector (Run.Run IO h)
              -> IO a)
          -> IO a
 withRuns hfs _ [] action =

--- a/test/Test/Database/LSMTree/Internal/Merge.hs
+++ b/test/Test/Database/LSMTree/Internal/Merge.hs
@@ -77,8 +77,8 @@ prop_MergeDistributes fs hbio level stepSize (SmallList rds) =
         rhsKOpsFile <- FS.hGetAll fs (Run.runKOpsFile rhs)
         rhsBlobFile <- FS.hGetAll fs (Run.runBlobFile rhs)
 
-        lhsKOps <- readKOps fs hbio Nothing lhs
-        rhsKOps <- readKOps fs hbio Nothing rhs
+        lhsKOps <- readKOps Nothing lhs
+        rhsKOps <- readKOps Nothing rhs
 
         -- cleanup
         Run.removeReference lhs
@@ -157,9 +157,9 @@ mergeRuns ::
      FS.HasBlockIO IO h ->
      Merge.Level ->
      RunNumber ->
-     V.Vector (Run.Run IO (FS.Handle h)) ->
+     V.Vector (Run.Run IO h) ->
      StepSize ->
-     IO (Int, Run.Run IO (FS.Handle h))
+     IO (Int, Run.Run IO h)
 mergeRuns fs hbio level runNumber runs (Positive stepSize) = do
     Merge.new fs hbio Run.CacheRunData (RunAllocFixed 10) level mappendValues
               (RunFsPaths (FS.mkFsPath []) runNumber) runs >>= \case

--- a/test/Test/Database/LSMTree/Internal/RunBuilder.hs
+++ b/test/Test/Database/LSMTree/Internal/RunBuilder.hs
@@ -11,49 +11,51 @@ import qualified Database.LSMTree.Internal.RunBuilder as RunBuilder
 import           Database.LSMTree.Internal.RunNumber
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS)
+import qualified System.FS.BlockIO.API as FS
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
-import           Test.Util.FS
+import           Test.Util.FS (propNoOpenHandles, withSimHasBlockIO,
+                     withTempIOHasBlockIO)
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.RunBuilder" [
       testGroup "ioHasFS" [
           testProperty "prop_newInExistingDir" $ ioProperty $
-            withTempIOHasFS "prop_newInExistingDir" prop_newInExistingDir
+            withTempIOHasBlockIO "prop_newInExistingDir" prop_newInExistingDir
         , testProperty "prop_newInNonExistingDir" $ ioProperty $
-            withTempIOHasFS "prop_newInNonExistingDir" prop_newInNonExistingDir
+            withTempIOHasBlockIO "prop_newInNonExistingDir" prop_newInNonExistingDir
         , testProperty "prop_newTwice" $ ioProperty $
-            withTempIOHasFS "prop_newTwice" prop_newTwice
+            withTempIOHasBlockIO "prop_newTwice" prop_newTwice
         ]
     , testGroup "simHasFS" [
           testProperty "prop_newInExistingDir" $ ioProperty $
-            withSimHasFS propNoOpenHandles prop_newInExistingDir
+            withSimHasBlockIO propNoOpenHandles prop_newInExistingDir
         , testProperty "prop_newInNonExistingDir" $ ioProperty $
-            withSimHasFS propNoOpenHandles prop_newInNonExistingDir
+            withSimHasBlockIO propNoOpenHandles prop_newInNonExistingDir
         , testProperty "prop_newTwice" $ ioProperty $
-            withSimHasFS propNoOpenHandles prop_newTwice
+            withSimHasBlockIO propNoOpenHandles prop_newTwice
         ]
     ]
 
 -- | 'new' in an existing directory should be succesfull.
-prop_newInExistingDir :: HasFS IO h -> IO Property
-prop_newInExistingDir hfs = do
+prop_newInExistingDir :: HasFS IO h -> FS.HasBlockIO IO h -> IO Property
+prop_newInExistingDir hfs hbio = do
     let runDir = FS.mkFsPath ["a", "b", "c"]
     FS.createDirectoryIfMissing hfs True runDir
     bracket
-      (try (RunBuilder.new hfs (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10)))
-      (traverse_ $ RunBuilder.close hfs) $ pure . \case
+      (try (RunBuilder.new hfs hbio (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10)))
+      (traverse_ RunBuilder.close) $ pure . \case
         Left e@FS.FsError{} ->
           counterexample ("expected a success, but got: " <> show e) $ property False
         Right _ -> property True
 
 -- | 'new' in a non-existing directory should throw an error.
-prop_newInNonExistingDir :: HasFS IO h -> IO Property
-prop_newInNonExistingDir hfs = do
+prop_newInNonExistingDir :: HasFS IO h -> FS.HasBlockIO IO h -> IO Property
+prop_newInNonExistingDir hfs hbio = do
     let runDir = FS.mkFsPath ["a", "b", "c"]
     bracket
-      (try (RunBuilder.new hfs (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10)))
-      (traverse_ $ RunBuilder.close hfs) $ pure . \case
+      (try (RunBuilder.new hfs hbio (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10)))
+      (traverse_ RunBuilder.close) $ pure . \case
         Left FS.FsError{} -> property True
         Right _  ->
           counterexample ("expected an FsError, but got a RunBuilder") $ property False
@@ -62,15 +64,15 @@ prop_newInNonExistingDir hfs = do
 --
 -- TODO: maybe in this case a custom error should be thrown? Does the thrown
 -- 'FsError' cause file resources to leak?
-prop_newTwice :: HasFS IO h -> IO Property
-prop_newTwice hfs = do
+prop_newTwice :: HasFS IO h -> FS.HasBlockIO IO h -> IO Property
+prop_newTwice hfs hbio = do
     let runDir = FS.mkFsPath []
     bracket
-      (RunBuilder.new hfs (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10))
-      (RunBuilder.close hfs) $ \_ ->
+      (RunBuilder.new hfs hbio (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10))
+      RunBuilder.close $ \_ ->
         bracket
-          (try (RunBuilder.new hfs (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10)))
-          (traverse_ $ RunBuilder.close hfs) $ pure . \case
+          (try (RunBuilder.new hfs hbio (RunFsPaths runDir (RunNumber 17)) (NumEntries 0) (RunAllocFixed 10)))
+          (traverse_ RunBuilder.close) $ pure . \case
             Left FS.FsError{} -> property True
             Right _  ->
               counterexample ("expected an FsError, but got a RunBuilder") $ property False


### PR DESCRIPTION
# Description

Refactors the usage of `HasFS` and `HasBlockIO` abstractions, by "internalizing" the values within the data-types which require them. This noticeably cleans up the module API interface, removing the requirement of manually passing `HasFS` and `HasBlockIO` values across multiple abstraction layers of the `LSMTree`. The `HasFS` and `HasBlockIO` are now required from the user *only* when creating a new `RunBuilder, rather than required for most functions exposed by a half dozen module's interfaces.

~~*NB: Still needs to be rebased with `main` which will require another sizable chunk of time.*~~