### PR TITLE
Have `LevelsCache`s take references on runs.

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -636,7 +636,7 @@ new sesh conf = do
                WBB.removeReference
         let tableWriteBuffer = WB.empty
             tableLevels = V.empty
-        tableCache <- mkLevelsCache tableLevels
+        tableCache <- mkLevelsCache reg tableLevels
         let tc = TableContent {
                 tableWriteBuffer
               , tableWriteBufferBlobs
@@ -1303,7 +1303,7 @@ open sesh label override snap = do
                (WBB.new hfs blobpath)
                WBB.removeReference
         tableLevels <- openLevels reg hfs hbio (confDiskCachePolicy conf') runPaths
-        tableCache <- mkLevelsCache tableLevels
+        tableCache <- mkLevelsCache reg tableLevels
         newWith reg sesh seshEnv conf' am $! TableContent {
             tableWriteBuffer = WB.empty
           , tableWriteBufferBlobs


### PR DESCRIPTION
Note: this PR is a copy of #425, which was merged prematurely

With the imminent implementation of scheduled merges, we have to take special measures against runs being closed under our feet during operations like `lookups`. `lookups` use a `LevelsCache` for quick access to the runs in a table, and it is currently an invariant that the set of runs in this `LevelsCache` is the same as the set of runs that is stored in the `Levels` structure of a table.  With scheduled merges, if an ongoing merge completes, then the completion process will release a number of references to the merge's input runs, so that unused runs are closed in a timely manner. However, if this happens concurrently with a `lookups` operation, then runs could be closed while `lookups` is still using them, leading to exceptions.

The currently proposed solution is to have the `LevelsCache` take explicit references for the runs contained in the cache, so that runs don't disappear until the `LevelsCache` itself is invalidated. This does mean that the `LevelsCache` can keep runs open for longer than necessary, i.e., even after the `Levels` structure has already forgotten about these runs. This problem is not yet solved in this commit, and will require some thinking and experimentation. For this, a TODO is added to the code.
