### PR TITLE
How to run a `DL` expression, and some lockstep improvements

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -371,6 +371,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Monoidal
     Test.Database.LSMTree.Normal.Examples
     Test.Database.LSMTree.Normal.StateMachine
+    Test.Database.LSMTree.Normal.StateMachine.DL
     Test.Database.LSMTree.Normal.StateMachine.Op
     Test.System.Posix.Fcntl.NoCache
     Test.Util.FS

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -375,6 +375,7 @@ test-suite lsm-tree-test
     Test.System.Posix.Fcntl.NoCache
     Test.Util.FS
     Test.Util.Orphans
+    Test.Util.PrettyProxy
     Test.Util.QC
     Test.Util.RawPage
     Test.Util.TypeFamilyWrappers

--- a/test/Database/LSMTree/Model/Normal/Session.hs
+++ b/test/Database/LSMTree/Model/Normal/Session.hs
@@ -24,6 +24,10 @@ module Database.LSMTree.Model.Normal.Session (
     Model (..)
   , initModel
   , UpdateCounter (..)
+    -- ** SomeTable
+  , SomeTable (..)
+  , toSomeTable
+  , fromSomeTable
     -- ** Constraints
   , C
   , C_

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -33,6 +33,7 @@ import qualified Test.Database.LSMTree.Model.Normal
 import qualified Test.Database.LSMTree.Monoidal
 import qualified Test.Database.LSMTree.Normal.Examples
 import qualified Test.Database.LSMTree.Normal.StateMachine
+import qualified Test.Database.LSMTree.Normal.StateMachine.DL
 import qualified Test.System.Posix.Fcntl.NoCache
 import           Test.Tasty
 
@@ -66,8 +67,9 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Model.Normal.tests
     , Test.Database.LSMTree.Model.Monoidal.tests
     , Test.Database.LSMTree.Monoidal.tests
-    , Test.Database.LSMTree.Normal.StateMachine.tests
     , Test.Database.LSMTree.Normal.Examples.tests
+    , Test.Database.LSMTree.Normal.StateMachine.tests
+    , Test.Database.LSMTree.Normal.StateMachine.DL.tests
     , Test.System.Posix.Fcntl.NoCache.tests
     , Test.Data.Arena.tests
     ]

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -55,7 +55,7 @@ import           Control.Monad.Class.MonadThrow (Handler (..), MonadCatch (..),
                      MonadThrow (..))
 import           Control.Monad.IOSim
 import           Control.Monad.Reader (ReaderT (..))
-import           Control.Tracer (nullTracer)
+import           Control.Tracer (Tracer, nullTracer)
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
 import           Data.Constraint (Dict (..))
@@ -119,14 +119,14 @@ tests = testGroup "Normal.StateMachine" [
       testProperty "propLockstep_ModelIOImpl"
         propLockstep_ModelIOImpl
 
-    , testProperty "propLockstep_RealImpl_RealFS_IO"
-        propLockstep_RealImpl_RealFS_IO
+    , testProperty "propLockstep_RealImpl_RealFS_IO" $
+        propLockstep_RealImpl_RealFS_IO nullTracer
 
-    , testProperty "propLockstep_RealImpl_MockFS_IO"
-        propLockstep_RealImpl_MockFS_IO
+    , testProperty "propLockstep_RealImpl_MockFS_IO" $
+        propLockstep_RealImpl_MockFS_IO nullTracer
 
-    , testProperty "propLockstep_RealImpl_MockFS_IOSim"
-        propLockstep_RealImpl_MockFS_IOSim
+    , testProperty "propLockstep_RealImpl_MockFS_IOSim" $
+        propLockstep_RealImpl_MockFS_IOSim nullTracer
     ]
 
 labelledExamples :: IO ()
@@ -205,9 +205,10 @@ instance Arbitrary R.TableConfig where
       }
 
 propLockstep_RealImpl_RealFS_IO ::
-     Actions (Lockstep (ModelState R.TableHandle))
+     Tracer IO R.LSMTreeTrace
+  -> Actions (Lockstep (ModelState R.TableHandle))
   -> QC.Property
-propLockstep_RealImpl_RealFS_IO =
+propLockstep_RealImpl_RealFS_IO tr =
     runActionsBracket'
       (Proxy @(ModelState R.TableHandle))
       acquire
@@ -218,7 +219,7 @@ propLockstep_RealImpl_RealFS_IO =
     acquire :: IO (FilePath, WrapSession R.TableHandle IO)
     acquire = do
         (tmpDir, hasFS, hasBlockIO) <- createSystemTempDirectory "prop_lockstepIO_RealImpl_RealFS"
-        session <- R.openSession nullTracer hasFS hasBlockIO (mkFsPath [])
+        session <- R.openSession tr hasFS hasBlockIO (mkFsPath [])
         pure (tmpDir, WrapSession session)
 
     release :: (FilePath, WrapSession R.TableHandle IO) -> IO ()
@@ -227,25 +228,27 @@ propLockstep_RealImpl_RealFS_IO =
         removeDirectoryRecursive tmpDir
 
 propLockstep_RealImpl_MockFS_IO ::
-     Actions (Lockstep (ModelState R.TableHandle))
+     Tracer IO R.LSMTreeTrace
+  -> Actions (Lockstep (ModelState R.TableHandle))
   -> QC.Property
-propLockstep_RealImpl_MockFS_IO =
+propLockstep_RealImpl_MockFS_IO tr =
     runActionsBracket'
       (Proxy @(ModelState R.TableHandle))
-      acquire_RealImpl_MockFS
+      (acquire_RealImpl_MockFS tr)
       release_RealImpl_MockFS
       (\r (_, session) -> runReaderT r (session, realHandler @IO))
       tagFinalState'
 
 propLockstep_RealImpl_MockFS_IOSim ::
-     Actions (Lockstep (ModelState R.TableHandle))
+     (forall s. Tracer (IOSim s) R.LSMTreeTrace)
+  -> Actions (Lockstep (ModelState R.TableHandle))
   -> QC.Property
-propLockstep_RealImpl_MockFS_IOSim actions =
+propLockstep_RealImpl_MockFS_IOSim tr actions =
     monadicIOSim_ prop
   where
     prop :: forall s. PropertyM (IOSim s) Property
     prop = do
-        (fsVar, session) <- QC.run acquire_RealImpl_MockFS
+        (fsVar, session) <- QC.run (acquire_RealImpl_MockFS tr)
         void $ QD.runPropertyReaderT
                 (QD.runActions @(Lockstep (ModelState R.TableHandle)) actions)
                 (session, realHandler @(IOSim s))
@@ -254,11 +257,12 @@ propLockstep_RealImpl_MockFS_IOSim actions =
 
 acquire_RealImpl_MockFS ::
      R.IOLike m
-  => m (StrictTMVar m MockFS, WrapSession R.TableHandle m)
-acquire_RealImpl_MockFS = do
+  => Tracer m R.LSMTreeTrace
+  -> m (StrictTMVar m MockFS, WrapSession R.TableHandle m)
+acquire_RealImpl_MockFS tr = do
     fsVar <- newTMVarIO MockFS.empty
     (hfs, hbio) <- simHasBlockIO fsVar
-    session <- R.openSession nullTracer hfs hbio (mkFsPath [])
+    session <- R.openSession tr hfs hbio (mkFsPath [])
     pure (fsVar, WrapSession session)
 
 release_RealImpl_MockFS ::

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -324,21 +324,31 @@ createSystemTempDirectory prefix = do
 -- TODO: maybe use reference impl generators here?
 
 newtype Key1   = Key1   { _unKey1 :: QC.Small Word64 }
-  deriving newtype (Show, Eq, Ord, Arbitrary, R.SerialiseKey)
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Arbitrary, R.SerialiseKey)
 newtype Value1 = Value1 { _unValue1 :: QC.Small Word64 }
-  deriving newtype (Show, Eq, Ord, Arbitrary, R.SerialiseValue)
+
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Arbitrary, R.SerialiseValue)
 newtype Blob1  = Blob1  { _unBlob1 :: QC.Small Word64 }
-  deriving newtype (Show, Eq, Ord, Arbitrary, R.SerialiseValue)
+
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Arbitrary, R.SerialiseValue)
 
 instance R.Labellable (Key1, Value1, Blob1) where
   makeSnapshotLabel _ = "Key1 Value1 Blob1"
 
 newtype Key2   = Key2   { _unKey2   :: KeyForIndexCompact }
-  deriving newtype (Show, Eq, Ord, Arbitrary, R.SerialiseKey)
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Arbitrary, R.SerialiseKey)
+
 newtype Value2 = Value2 { _unValue2 :: BS.ByteString }
-  deriving newtype (Show, Eq, Ord, Arbitrary, R.SerialiseValue)
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Arbitrary, R.SerialiseValue)
+
 newtype Blob2  = Blob2  { _unBlob2  :: BS.ByteString }
-  deriving newtype (Show, Eq, Ord, Arbitrary, R.SerialiseValue)
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Arbitrary, R.SerialiseValue)
 
 instance R.Labellable (Key2, Value2, Blob2) where
   makeSnapshotLabel _ = "Key2 Value2 Blob2"

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -46,6 +46,21 @@
 module Test.Database.LSMTree.Normal.StateMachine (
     tests
   , labelledExamples
+    -- * Properties
+  , propLockstep_ModelIOImpl
+  , propLockstep_RealImpl_RealFS_IO
+  , propLockstep_RealImpl_MockFS_IO
+  , propLockstep_RealImpl_MockFS_IOSim
+    -- * Lockstep
+  , ModelState (..)
+  , Key1 (..)
+  , Value1 (..)
+  , Blob1 (..)
+  , Key2 (..)
+  , Value2 (..)
+  , Blob2 (..)
+  , StateModel (..)
+  , Action (..)
   ) where
 
 import           Control.Concurrent.Class.MonadMVar.Strict

--- a/test/Test/Database/LSMTree/Normal/StateMachine/DL.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine/DL.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PolyKinds       #-}
+
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Database.LSMTree.Normal.StateMachine.DL (
+    tests
+  ) where
+
+import           Control.Tracer
+import qualified Data.Map.Strict as Map
+import qualified Data.Vector as V
+import qualified Database.LSMTree.Model.Normal as Model
+import qualified Database.LSMTree.Model.Normal.Session as Model
+import           Database.LSMTree.Normal as R
+import           Prelude
+import           Test.Database.LSMTree.Normal.StateMachine hiding (tests)
+import           Test.Database.LSMTree.Normal.StateMachine.Op
+import           Test.QuickCheck
+import           Test.QuickCheck.DynamicLogic
+import           Test.QuickCheck.StateModel.Lockstep
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+import           Test.Util.PrettyProxy
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Normal.StateMachine.DL" [
+      testProperty "prop_example" prop_example
+    ]
+
+instance DynLogicModel (Lockstep (ModelState R.TableHandle))
+
+-- | An example of how dynamic logic formulas can be run.
+--
+-- 'dl_example' is a manually created formula, but the same method of running a
+-- formula also applies to counterexamples produced by a state machine property
+-- test, such as 'propLockstep_RealImpl_RealFS_IO'. Such counterexamples are
+-- (often almost) valid 'DL' expression. They can be copy-pasted into a Haskell
+-- module with minor tweaks to make the compiler accept the copied code, and
+-- then they can be run as any other 'DL' expression.
+prop_example :: Property
+prop_example =
+    -- Run the example ...
+    forAllDL dl_example $
+    -- ... with the given lockstep property
+    propLockstep_RealImpl_MockFS_IO tr
+  where
+    -- To enable tracing, use something like @show `contramap` stdoutTracer@
+    -- instead
+    tr = nullTracer
+
+-- | Create an initial "large" table, and then proceed with random actions as
+-- usual.
+dl_example :: DL (Lockstep (ModelState R.TableHandle)) ()
+dl_example = do
+    -- Create an initial table and fill it with some inserts
+    var3 <- action $ New (PrettyProxy @((Key1, Value1, Blob1))) (TableConfig {
+          confMergePolicy = MergePolicyLazyLevelling
+        , confSizeRatio = Four
+        , confWriteBufferAlloc = AllocNumEntries (NumEntries 30)
+        , confBloomFilterAlloc = AllocFixed 10
+        , confFencePointerIndex = CompactIndex
+        , confDiskCachePolicy = DiskCacheNone
+        , confMergeSchedule = OneShot })
+    let ins = [ (Key1 y, Value1 y, Nothing)
+              | x <- [1 .. 678]
+              , let y = Small x ]
+    action $ Inserts (V.fromList ins) (unsafeMkGVar var3 (OpFromRight `OpComp` OpId))
+    -- This is a rather ugly assertion, and could be improved using some helper
+    -- function(s). However, it does serve its purpose as checking that the
+    -- insertions we just did were successful.
+    assertModel "table has size 678" $ \s ->
+        let (ModelState s' _) = getModel s in
+        case Map.elems (Model.tableHandles s') of
+          [(_, smTbl)]
+            | Just tbl <- (Model.fromSomeTable @Key1 @Value1 @Blob1 smTbl)
+            -> Map.size (Model.values tbl) == 678
+          _ -> False
+    -- Perform any sequence of actions after
+    anyActions_

--- a/test/Test/Util/PrettyProxy.hs
+++ b/test/Test/Util/PrettyProxy.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE PolyKinds #-}
+
+module Test.Util.PrettyProxy (
+    PrettyProxy (..)
+  ) where
+
+import           Data.Typeable
+
+-- | A version of 'Proxy' that also shows its type parameter.
+data PrettyProxy a = PrettyProxy
+
+-- | Shows the type parameter @a@ as an explicit type application.
+instance Typeable a => Show (PrettyProxy a) where
+  showsPrec d p =
+        showParen (d > app_prec)
+      $ showString "PrettyProxy @("
+      . showString (show (typeRep p))
+      . showString ")"
+    where app_prec = 10


### PR DESCRIPTION
The lockstep improvements are mainly there to make it easier to run counterexamples produced by the state machine tests, which are printed as `DL` expressions.