### PR TITLE
Implement a more proper snapshot format

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -152,6 +152,7 @@ library
     Database.LSMTree.Internal.RunReaders
     Database.LSMTree.Internal.Serialise
     Database.LSMTree.Internal.Serialise.Class
+    Database.LSMTree.Internal.Snapshot
     Database.LSMTree.Internal.UniqCounter
     Database.LSMTree.Internal.Unsliced
     Database.LSMTree.Internal.Vector

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -68,7 +68,6 @@ import           Control.Monad.Primitive
 import           Control.TempRegistry
 import           Control.Tracer
 import           Data.Arena (ArenaManager, newArenaManager)
-import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Char8 as BSC
 import           Data.Char (isNumber)
 import           Data.Foldable
@@ -90,19 +89,19 @@ import qualified Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.Lookup (ByteCountDiscrepancy,
                      ResolveSerialisedValue, lookupsIO)
 import           Database.LSMTree.Internal.MergeSchedule
-import           Database.LSMTree.Internal.Paths (RunFsPaths (..),
-                     SessionRoot (..), SnapshotName)
+import           Database.LSMTree.Internal.Paths (SessionRoot (..),
+                     SnapshotName)
 import qualified Database.LSMTree.Internal.Paths as Paths
 import           Database.LSMTree.Internal.Range (Range (..))
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
-import           Database.LSMTree.Internal.RunNumber
 import qualified Database.LSMTree.Internal.RunReader as Reader
 import           Database.LSMTree.Internal.RunReaders (OffsetKey (..))
 import qualified Database.LSMTree.Internal.RunReaders as Readers
 import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..),
                      SerialisedKey, SerialisedValue)
+import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.UniqCounter
 import qualified Database.LSMTree.Internal.Vector as V
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
@@ -1201,14 +1200,18 @@ snapshot resolve snap label th = do
     traceWith (tableTracer th) $ TraceSnapshot snap
     let conf = tableConfig th
     withOpenTable th $ \thEnv -> do
+      let hfs = tableHasFS thEnv
+      let snapPath = Paths.snapshot (tableSessionRoot thEnv) snap
+      FS.doesFileExist (tableHasFS thEnv) snapPath >>= \b ->
+              when b $ throwIO (ErrSnapshotExists snap)
+
       -- For the temporary implementation it is okay to just flush the buffer
       -- before taking the snapshot.
-      let hfs = tableHasFS thEnv
       content <- modifyWithTempRegistry
                     (RW.unsafeAcquireWriteAccess (tableContent thEnv))
                     (atomically . RW.unsafeReleaseWriteAccess (tableContent thEnv))
                     $ \reg content -> do
-        r <- flushWriteBuffer
+        content' <- flushWriteBuffer
               (TraceMerge `contramap` tableTracer th)
               conf
               resolve
@@ -1218,29 +1221,22 @@ snapshot resolve snap label th = do
               (tableSessionUniqCounter thEnv)
               reg
               content
-        pure (r, r)
+        pure (content', content')
       -- At this point, we've flushed the write buffer but we haven't created the
       -- snapshot file yet. If an asynchronous exception happens beyond this
       -- point, we'll take that loss, as the inner state of the table is still
       -- consistent.
-      runNumbers <- V.forM (tableLevels content) $ \(Level mr rs) -> do
-        (,V.map (runNumber . Run.runRunFsPaths) rs) <$>
-          case mr of
-            SingleRun r -> pure (True, runNumber (Run.runRunFsPaths r))
-            MergingRun var -> do
-              withMVar var $ \case
-                CompletedMerge r -> pure (False, runNumber (Run.runRunFsPaths r))
-                OngoingMerge{}   -> error "snapshot: OngoingMerge not yet supported" -- TODO: implement
-      let snapPath = Paths.snapshot (tableSessionRoot thEnv) snap
-      FS.doesFileExist (tableHasFS thEnv) snapPath >>= \b ->
-              when b $ throwIO (ErrSnapshotExists snap)
+
+      snappedLevels <- snapLevels (tableLevels content)
+      let snapContents = BSC.pack $ show (label, snappedLevels, tableConfig th)
+
       FS.withFile
         (tableHasFS thEnv)
         snapPath
         (FS.WriteMode FS.MustBeNew) $ \h ->
-          void $ FS.hPutAllStrict (tableHasFS thEnv) h
-                      (BSC.pack $ show (label, runNumbers, tableConfig th))
-      pure $! V.sum (V.map (\((_ :: (Bool, RunNumber)), rs) -> 1 + V.length rs) runNumbers)
+          void $ FS.hPutAllStrict (tableHasFS thEnv) h snapContents
+
+      pure $! numSnapRuns snappedLevels
 
 {-# SPECIALISE open ::
      Session IO h
@@ -1270,18 +1266,9 @@ open sesh label override snap = do
                 snapPath
                 FS.ReadMode $ \h ->
                   FS.hGetAll (sessionHasFS seshEnv) h
-        let (label', runNumbers, conf) =
-                -- why we are using read for this?
-                -- apparently this is a temporary solution, to be done properly in WP15
-                read @(SnapshotLabel, V.Vector ((Bool, RunNumber), V.Vector RunNumber), TableConfig) $
-                BSC.unpack $ BSC.toStrict $ bs
-
-        let conf' = applyOverride override conf
+        let (label', snappedLevels, conf) = read $ BSC.unpack $ BSC.toStrict $ bs
         unless (label == label') $ throwIO (ErrSnapshotWrongType snap)
-        let runPaths = V.map (bimap (second $ RunFsPaths (Paths.activeDir $ sessionRoot seshEnv))
-                                    (V.map (RunFsPaths (Paths.activeDir $ sessionRoot seshEnv))))
-                            runNumbers
-
+        let conf' = applyOverride override conf
         am <- newArenaManager
         blobpath <- Paths.tableBlobPath (sessionRoot seshEnv) <$>
                       incrUniqCounter (sessionUniqCounter seshEnv)
@@ -1289,7 +1276,7 @@ open sesh label override snap = do
           <- allocateTemp reg
                (WBB.new hfs blobpath)
                WBB.removeReference
-        tableLevels <- openLevels reg hfs hbio (confDiskCachePolicy conf') runPaths
+        tableLevels <- openLevels reg hfs hbio conf (sessionRoot seshEnv) snappedLevels
         tableCache <- mkLevelsCache reg tableLevels
         newWith reg sesh seshEnv conf' am $! TableContent {
             tableWriteBuffer = WB.empty
@@ -1297,37 +1284,6 @@ open sesh label override snap = do
           , tableLevels
           , tableCache
           }
-
-{-# SPECIALISE openLevels ::
-     TempRegistry IO
-  -> HasFS IO h
-  -> HasBlockIO IO h
-  -> DiskCachePolicy
-  -> V.Vector ((Bool, RunFsPaths), V.Vector RunFsPaths)
-  -> IO (Levels IO h) #-}
--- | Open multiple levels.
-openLevels ::
-     (MonadFix m, MonadMask m, MonadMVar m, MonadSTM m, PrimMonad m)
-  => TempRegistry m
-  -> HasFS m h
-  -> HasBlockIO m h
-  -> DiskCachePolicy
-  -> V.Vector ((Bool, RunFsPaths), V.Vector RunFsPaths)
-  -> m (Levels m h)
-openLevels reg hfs hbio diskCachePolicy levels =
-    flip V.imapMStrict levels $ \i (mrPath, rsPaths) -> do
-      let ln      = LevelNo (i+1) -- level 0 is the write buffer
-          caching = diskCachePolicyForLevel diskCachePolicy ln
-      !r <- allocateTemp reg
-              (Run.openFromDisk hfs hbio caching (snd mrPath))
-              Run.removeReference
-      !rs <- flip V.mapMStrict rsPaths $ \run ->
-        allocateTemp reg
-          (Run.openFromDisk hfs hbio caching run)
-          Run.removeReference
-      var <- newMVar (CompletedMerge r)
-      let !mr = if fst mrPath then SingleRun r else MergingRun var
-      pure $! Level mr rs
 
 {-# SPECIALISE deleteSnapshot ::
      Session IO h

--- a/src/Database/LSMTree/Internal/Config.hs
+++ b/src/Database/LSMTree/Internal/Config.hs
@@ -80,10 +80,6 @@ instance NFData TableConfig where
   rnf (TableConfig a b c d e f g) =
       rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f `seq` rnf g
 
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read TableConfig
-
 -- | A reasonable default 'TableConfig'.
 --
 -- This uses a write buffer with up to 20,000 elements and a generous amount of
@@ -169,10 +165,6 @@ data MergePolicy =
 instance NFData MergePolicy where
   rnf MergePolicyLazyLevelling = ()
 
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read MergePolicy
-
 {-------------------------------------------------------------------------------
   Size ratio
 -------------------------------------------------------------------------------}
@@ -182,10 +174,6 @@ data SizeRatio = Four
 
 instance NFData SizeRatio where
   rnf Four = ()
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read SizeRatio
 
 sizeRatioInt :: SizeRatio -> Int
 sizeRatioInt = \case Four -> 4
@@ -213,14 +201,6 @@ data WriteBufferAlloc =
 
 instance NFData WriteBufferAlloc where
   rnf (AllocNumEntries n) = rnf n
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read WriteBufferAlloc
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read NumEntries
 
 {-------------------------------------------------------------------------------
   Bloom filter allocation
@@ -262,10 +242,6 @@ instance NFData BloomFilterAlloc where
   rnf (AllocFixed n)        = rnf n
   rnf (AllocRequestFPR fpr) = rnf fpr
   rnf (AllocMonkey a b)     = rnf a `seq` rnf b
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read BloomFilterAlloc
 
 defaultBloomFilterAlloc :: BloomFilterAlloc
 defaultBloomFilterAlloc = AllocFixed 10
@@ -333,10 +309,6 @@ data FencePointerIndex =
 instance NFData FencePointerIndex where
   rnf CompactIndex  = ()
   rnf OrdinaryIndex = ()
-
--- | TODO: this should be removed once we have proper snapshotting with proper
--- persistence of the config to disk.
-deriving stock instance Read FencePointerIndex
 
 {-------------------------------------------------------------------------------
   Disk cache policy

--- a/src/Database/LSMTree/Internal/RunNumber.hs
+++ b/src/Database/LSMTree/Internal/RunNumber.hs
@@ -7,7 +7,3 @@ import           Data.Word (Word64)
 
 newtype RunNumber = RunNumber Word64
   deriving newtype (Eq, Ord, Show, NFData)
-
--- read as Word64
--- the Read instance is used in Internal.open ?!?
-deriving newtype instance Read RunNumber

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -69,12 +69,14 @@ data SnapMergingRunState =
   Conversion to snapshot format
 -------------------------------------------------------------------------------}
 
+{-# SPECIALISE snapLevels :: Levels IO h -> IO SnapLevels #-}
 snapLevels ::
      (PrimMonad m, MonadMVar m)
   => Levels m h
   -> m SnapLevels
 snapLevels = V.mapM snapLevel
 
+{-# SPECIALISE snapLevel :: Level IO h -> IO SnapLevel #-}
 snapLevel ::
      (PrimMonad m, MonadMVar m)
   => Level m h
@@ -83,6 +85,7 @@ snapLevel Level{..} = do
     smr <- snapMergingRun incomingRuns
     pure (SnapLevel smr (V.map runNumber residentRuns))
 
+{-# SPECIALISE snapMergingRun :: MergingRun IO h -> IO SnapMergingRun #-}
 snapMergingRun ::
      (PrimMonad m, MonadMVar m)
   => MergingRun m h
@@ -92,6 +95,7 @@ snapMergingRun (MergingRun mrsVar) = do
     pure (SnapMergingRun smrs)
 snapMergingRun (SingleRun r) = pure (SnapSingleRun (runNumber r))
 
+{-# SPECIALISE snapMergingRunState :: MergingRunState IO h -> IO SnapMergingRunState #-}
 snapMergingRunState ::
      PrimMonad m
   => MergingRunState m h
@@ -107,6 +111,15 @@ runNumber r = Paths.runNumber (Run.runRunFsPaths r)
   Opening from snapshot format
 -------------------------------------------------------------------------------}
 
+{-# SPECIALISE openLevels ::
+     TempRegistry IO
+  -> HasFS IO h
+  -> HasBlockIO IO h
+  -> TableConfig
+  -> SessionRoot
+  -> SnapLevels
+  -> IO (Levels IO h)
+  #-}
 openLevels ::
      forall m h. (MonadFix m, MonadMask m, MonadMVar m, MonadSTM m, MonadST m)
   => TempRegistry m
@@ -150,6 +163,7 @@ openLevels reg hfs hbio TableConfig{..} sessionRoot levels =
                 Run.removeReference
         openMergingRunState (SnapOngoingMerge _rns) = do
             error "openLevels: ongoing merge not yet supported"
+
 {-------------------------------------------------------------------------------
   Levels
 -------------------------------------------------------------------------------}

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -1,0 +1,171 @@
+-- TODO: remove once we properly implement snapshots
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Database.LSMTree.Internal.Snapshot (
+    -- * Snapshot format
+    numSnapRuns
+  , SnapLevels
+  , SnapLevel (..)
+  , SnapMergingRun (..)
+  , SnapMergingRunState (..)
+    -- * Creating snapshots
+  , snapLevels
+    -- * Opening snapshots
+  , openLevels
+  ) where
+
+import           Control.Concurrent.Class.MonadMVar.Strict
+import           Control.Concurrent.Class.MonadSTM (MonadSTM)
+import           Control.Monad.Class.MonadST (MonadST)
+import           Control.Monad.Class.MonadThrow (MonadMask)
+import           Control.Monad.Fix (MonadFix)
+import           Control.Monad.Primitive (PrimMonad)
+import           Control.TempRegistry
+import qualified Data.Vector as V
+import           Database.LSMTree.Internal.Config
+import           Database.LSMTree.Internal.Entry
+import qualified Database.LSMTree.Internal.Merge as Merge
+import           Database.LSMTree.Internal.MergeSchedule
+import           Database.LSMTree.Internal.Paths (SessionRoot)
+import qualified Database.LSMTree.Internal.Paths as Paths
+import           Database.LSMTree.Internal.Run (Run)
+import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.RunNumber
+import           System.FS.API (HasFS)
+import           System.FS.BlockIO.API (HasBlockIO)
+
+{-------------------------------------------------------------------------------
+  Levels snapshot format
+-------------------------------------------------------------------------------}
+
+numSnapRuns :: SnapLevels -> Int
+numSnapRuns sl = V.sum $ V.map go1 sl
+  where
+    go1 (SnapLevel sir srr) = go2 sir + V.length srr
+    go2 (SnapMergingRun smrs) = go3 smrs
+    go2 (SnapSingleRun _rn)   = 1
+    go3 (SnapCompletedMerge _rn) = 1
+    go3 (SnapOngoingMerge rns)   = V.length rns
+
+type SnapLevels = V.Vector SnapLevel
+
+data SnapLevel = SnapLevel {
+    snapIncomingRuns :: !SnapMergingRun
+  , snapResidentRuns :: !(V.Vector RunNumber)
+  }
+  deriving stock (Show, Eq, Read)
+
+data SnapMergingRun =
+    SnapMergingRun !SnapMergingRunState
+  | SnapSingleRun !RunNumber
+  deriving stock (Show, Eq, Read)
+
+data SnapMergingRunState =
+    SnapCompletedMerge !RunNumber
+  | SnapOngoingMerge !(V.Vector RunNumber) {- merge -}
+  deriving stock (Show, Eq, Read)
+
+{-------------------------------------------------------------------------------
+  Conversion to snapshot format
+-------------------------------------------------------------------------------}
+
+snapLevels ::
+     (PrimMonad m, MonadMVar m)
+  => Levels m h
+  -> m SnapLevels
+snapLevels = V.mapM snapLevel
+
+snapLevel ::
+     (PrimMonad m, MonadMVar m)
+  => Level m h
+  -> m SnapLevel
+snapLevel Level{..} = do
+    smr <- snapMergingRun incomingRuns
+    pure (SnapLevel smr (V.map runNumber residentRuns))
+
+snapMergingRun ::
+     (PrimMonad m, MonadMVar m)
+  => MergingRun m h
+  -> m SnapMergingRun
+snapMergingRun (MergingRun mrsVar) = do
+    smrs <- withMVar mrsVar $ \mrs -> snapMergingRunState mrs
+    pure (SnapMergingRun smrs)
+snapMergingRun (SingleRun r) = pure (SnapSingleRun (runNumber r))
+
+snapMergingRunState ::
+     PrimMonad m
+  => MergingRunState m h
+  -> m SnapMergingRunState
+snapMergingRunState (CompletedMerge r) = pure (SnapCompletedMerge (runNumber r))
+snapMergingRunState (OngoingMerge rs _m) = do
+    pure (SnapOngoingMerge (V.map runNumber rs))
+
+runNumber :: Run m h -> RunNumber
+runNumber r = Paths.runNumber (Run.runRunFsPaths r)
+
+{-------------------------------------------------------------------------------
+  Opening from snapshot format
+-------------------------------------------------------------------------------}
+
+openLevels ::
+     forall m h. (MonadFix m, MonadMask m, MonadMVar m, MonadSTM m, MonadST m)
+  => TempRegistry m
+  -> HasFS m h
+  -> HasBlockIO m h
+  -> TableConfig
+  -> SessionRoot
+  -> SnapLevels
+  -> m (Levels m h)
+openLevels reg hfs hbio TableConfig{..} sessionRoot levels =
+    V.iforM levels $ \i -> openLevel (LevelNo (i+1))
+  where
+    mkPath = Paths.RunFsPaths (Paths.activeDir sessionRoot)
+
+    openLevel :: LevelNo -> SnapLevel -> m (Level m h)
+    openLevel ln SnapLevel{..} = do
+        incomingRuns <- openMergingRun snapIncomingRuns
+        residentRuns <- V.forM snapResidentRuns $ \rn ->
+          allocateTemp reg
+            (Run.openFromDisk hfs hbio caching (mkPath rn))
+            Run.removeReference
+        pure Level{..}
+      where
+        caching = diskCachePolicyForLevel confDiskCachePolicy ln
+
+        openMergingRun :: SnapMergingRun -> m (MergingRun m h)
+        openMergingRun (SnapMergingRun smrs) = do
+            mrs <- openMergingRunState smrs
+            MergingRun <$> newMVar mrs
+        openMergingRun (SnapSingleRun rn) =
+            SingleRun <$>
+              allocateTemp reg
+                (Run.openFromDisk hfs hbio caching (mkPath rn))
+                Run.removeReference
+
+        openMergingRunState :: SnapMergingRunState -> m (MergingRunState m h)
+        openMergingRunState (SnapCompletedMerge rn) =
+            CompletedMerge <$>
+              allocateTemp reg
+                (Run.openFromDisk hfs hbio caching (mkPath rn))
+                Run.removeReference
+        openMergingRunState (SnapOngoingMerge _rns) = do
+            error "openLevels: ongoing merge not yet supported"
+{-------------------------------------------------------------------------------
+  Levels
+-------------------------------------------------------------------------------}
+
+deriving stock instance Read MergePolicyForLevel
+deriving newtype instance Read RunNumber
+deriving stock instance Read Merge.Level
+
+{-------------------------------------------------------------------------------
+  Config
+-------------------------------------------------------------------------------}
+
+deriving stock instance Read TableConfig
+deriving stock instance Read WriteBufferAlloc
+deriving stock instance Read NumEntries
+deriving stock instance Read SizeRatio
+deriving stock instance Read MergePolicy
+deriving stock instance Read BloomFilterAlloc
+deriving stock instance Read FencePointerIndex


### PR DESCRIPTION
The current snapshot format is only loosely established, so we add a more concrete snapshot format, which is more amenable to refactoring. This snapshot format is still temporary -- we will implement snapshots properly in a later package.

#426 is near to being ready, but it is currently still failing some tests related to snapshots. Establishing a snapshot format makes bug-hunting in the snapshot code easier.