### PR TITLE
Add more labels to the quickcheck-lockstep StateMachine tests

### DIFF
--- a/test/Database/LSMTree/Model/Normal.hs
+++ b/test/Database/LSMTree/Model/Normal.hs
@@ -30,6 +30,8 @@ module Database.LSMTree.Model.Normal (
   , snapshot
     -- * Multiple writable table handles
   , duplicate
+    -- * Testing
+  , size
   ) where
 
 import qualified Crypto.Hash.SHA256 as SHA256
@@ -60,6 +62,9 @@ type role Table nominal nominal nominal
 -- | An empty table.
 empty :: Table k v blob
 empty = Table Map.empty
+
+size :: Table k v blob -> Int
+size (Table m) = Map.size m
 
 -- | This instance is for testing and debugging only.
 instance

--- a/test/Database/LSMTree/Model/Normal/Session.hs
+++ b/test/Database/LSMTree/Model/Normal/Session.hs
@@ -24,12 +24,14 @@ module Database.LSMTree.Model.Normal.Session (
     Model (..)
   , initModel
   , UpdateCounter (..)
-    -- ** SomeTable
+    -- ** SomeTable, for testing
   , SomeTable (..)
   , toSomeTable
   , fromSomeTable
+  , withSomeTable
   , TableHandleID
   , tableHandleID
+  , Model.size
     -- ** Constraints
   , C
   , C_
@@ -138,6 +140,13 @@ fromSomeTable ::
   => SomeTable
   -> Maybe (Model.Table k v blob)
 fromSomeTable (SomeTable tbl) = cast tbl
+
+withSomeTable ::
+     (forall k v blob. (Typeable k, Typeable v, Typeable blob)
+                    => Model.Table k v blob -> a)
+  -> SomeTable
+  -> a
+withSomeTable f (SomeTable tbl) = f tbl
 
 newtype SomeCursor = SomeCursor Dynamic
 

--- a/test/Database/LSMTree/Model/Normal/Session.hs
+++ b/test/Database/LSMTree/Model/Normal/Session.hs
@@ -118,7 +118,9 @@ newtype UpdateCounter = UpdateCounter Word64
   deriving stock (Show, Eq, Ord)
   deriving newtype (Num)
 
-newtype SomeTable = SomeTable Dynamic
+data SomeTable where
+     SomeTable :: (Typeable k, Typeable v, Typeable blob)
+               => Model.Table k v blob -> SomeTable
 
 instance Show SomeTable where
   show (SomeTable table) = show table
@@ -127,13 +129,13 @@ toSomeTable ::
      (Typeable k, Typeable v, Typeable blob)
   => Model.Table k v blob
   -> SomeTable
-toSomeTable = SomeTable . toDyn
+toSomeTable = SomeTable
 
 fromSomeTable ::
      (Typeable k, Typeable v, Typeable blob)
   => SomeTable
   -> Maybe (Model.Table k v blob)
-fromSomeTable (SomeTable tbl) = fromDynamic tbl
+fromSomeTable (SomeTable tbl) = cast tbl
 
 newtype SomeCursor = SomeCursor Dynamic
 

--- a/test/Database/LSMTree/Model/Normal/Session.hs
+++ b/test/Database/LSMTree/Model/Normal/Session.hs
@@ -28,6 +28,8 @@ module Database.LSMTree.Model.Normal.Session (
   , SomeTable (..)
   , toSomeTable
   , fromSomeTable
+  , TableHandleID
+  , tableHandleID
     -- ** Constraints
   , C
   , C_


### PR DESCRIPTION
Add labels for:
 * number of tables
 * number of actions per table
 * logical size of tables
 * per-run number of actions (failing and succeeding)
 * label failing actions with the exception
 * label interleaving depth on duplicate tables

Initial results for each in each patch.

It's clear from several of these measures that the generation is suboptimal. One idea to improve it is to make the generation more sophisticated by (usually) only generating actions on live tables (or cursors, or existant snapshots). This is however difficult-to-impossible to do with the current `quickcheck-lockstep` package which does not provide a `lookUp` function to the action generation `arbitraryWithVars`. So there's no way to filter vars by their liveness (from looking at the model). It may make sense to extend `quickcheck-lockstep` to support this.