### PR TITLE
Measure latency for batches of updates and lookups in the WP8 benchmark

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -520,8 +520,19 @@ library mcg
     , base
     , primes
 
+flag measure-batch-latency
+  description:
+    Measure the latency for individual batches of updates and lookups
+
+  default:     False
+  manual:      True
+
+common measure-batch-latency
+  if flag(measure-batch-latency)
+    cpp-options: -DMEASURE_BATCH_LATENCY
+
 benchmark lsm-tree-bench-wp8
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings, wno-x-partial, measure-batch-latency
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench/macro
   main-is:        lsm-tree-bench-wp8.hs


### PR DESCRIPTION
We add a new `measure-batch-latency` flag that, if enabled, produces a file with datapoints about the that can be rendered, for example using `gnuplot`. In sequential mode, the datapoints consist of latency for lookups, and latency for updates separately. In pipelined mode, there are two additional datapoints for the sync latency between threads.

When the flag is disabled, all functions related to latency measurements default to no-ops. These functions are always inlined, and should be optimised away nicely.

