### PR TITLE
Add description to chunk module

### DIFF
--- a/src/Database/LSMTree/Internal/Chunk.hs
+++ b/src/Database/LSMTree/Internal/Chunk.hs
@@ -1,5 +1,6 @@
 {- HLINT ignore "Avoid restricted alias" -}
 
+-- | Chunks of bytes, typically output during incremental index serialisation.
 module Database.LSMTree.Internal.Chunk
 (
     -- * Chunks


### PR DESCRIPTION
The module `Database.LSMTree.Internal.Chunk` lacked a description. This pull request adds one.
