### PR TITLE
Hotfix: update `quickcheck-lockstep` commit tag

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,4 +28,4 @@ import: cabal.project.blockio-uring
 source-repository-package
   type: git
   location: https://github.com/well-typed/quickcheck-lockstep.git
-  tag: 8a724c0a7b2328a7444490f18dc7e401badcc8b8
+  tag: 1852cf87a76dc48c71aa0d9fda3fdc7c8b965011


### PR DESCRIPTION
The old commit has disappeared due to a rebase in `quickcheck-lockstep`.
