### PR TITLE
Restructure `cabal.project` files.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -26,7 +26,7 @@ jobs:
         cabal: ["3.10.2.1"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         cabal-flags: [""]
-        no-debug: [""]
+        cabal-project-file: ["cabal.project.debug"]
         exclude:
           - ghc: "8.10.7"
             os: macOS-latest
@@ -34,18 +34,21 @@ jobs:
           - ghc: "8.10.7"
             cabal: "3.10.2.1"
             os: macOS-13
+            cabal-project-file: "cabal.project.debug"
           - ghc: "9.6.4"
             cabal: "3.10.2.1"
             os: ubuntu-latest
             cabal-flags: "+serialblockio"
+            cabal-project-file: "cabal.project.debug"
           - ghc: "9.6.4"
             cabal: "3.10.2.1"
             os: ubuntu-latest
-            no-debug: "no-debug"
+            cabal-project-file: "cabal.project.release"
 
     timeout-minutes: 60
 
     steps:
+
     - name: CPU info (macOS)
       if: ${{ startsWith(matrix.os, 'macOS') }}
       run: sysctl -a machdep.cpu
@@ -75,19 +78,13 @@ jobs:
 
     - name: Configure the build
       run: |
-        cabal configure --enable-tests --enable-benchmark --ghc-options="-Werror" --flag="${{ matrix.cabal-flags }}"
-        cat cabal.project.local
-
-    - name: Configure the build (no-debug)
-      if: ${{ matrix.no-debug }}
-      run: |
-        echo "" > cabal.project.debug
-        cat cabal.project.debug
+        cabal configure --project-file="${{ matrix.cabal-project-file }}" --enable-tests --enable-benchmark --ghc-options="-Werror" --flag="${{ matrix.cabal-flags }}"
+        cat "${{ matrix.cabal-project-file }}.local"
 
     - name: Record cabal dependencies
       id: record-deps
       run: |
-        cabal build all --dry-run
+        cabal build all --project-file="${{ matrix.cabal-project-file }}" --dry-run
 
     - name: "Restore cache"
       uses: actions/cache/restore@v4
@@ -104,7 +101,8 @@ jobs:
 
     - name: Install cabal dependencies
       id: build-dependencies
-      run: cabal build --only-dependencies --enable-tests --enable-benchmarks all
+      run: |
+        cabal build --project-file="${{ matrix.cabal-project-file }}" --only-dependencies --enable-tests --enable-benchmarks all
 
     - name: "Save cache"
       uses: actions/cache/save@v4
@@ -118,7 +116,8 @@ jobs:
         key:  ${{ steps.restore-cabal-cache.outputs.cache-primary-key }}
 
     - name: Build
-      run: cabal build all
+      run: |
+        cabal build all --project-file="${{ matrix.cabal-project-file }}"
 
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
     - name: Set test timeout (Unix)
@@ -134,7 +133,7 @@ jobs:
 
     - name: Run tests
       run: |
-        cabal test -j1 --test-show-details=direct all
+        cabal test -j1 --test-show-details=direct all --project-file="${{ matrix.cabal-project-file }}"
 
     - name: cabal-docspec
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -184,7 +183,8 @@ jobs:
         cabal-update: false
 
     - name: Cabal update
-      run: cabal update
+      run: |
+        cabal update --ignore-project
 
     - name: Setup cabal bin path
       run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -200,7 +200,8 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install stylish-haskell
-      run: cabal install --ignore-project --index-state="${{ env.hackage-index-state }}" stylish-haskell --constraint 'stylish-haskell == 0.14.6.0'
+      run: |
+        cabal install --ignore-project --index-state="${{ env.hackage-index-state }}" stylish-haskell --constraint 'stylish-haskell == 0.14.6.0'
 
     - name: Record stylish-haskell version
       run: |
@@ -246,7 +247,8 @@ jobs:
         cabal-update: false
 
     - name: Cabal update
-      run: cabal update
+      run: |
+        cabal update --ignore-project
 
     - name: Setup cabal bin path
       run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -262,7 +264,8 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install cabal-fmt
-      run: cabal install --ignore-project cabal-fmt --index-state="${{ env.hackage-index-state }}" --constraint 'cabal-fmt == 0.1.11'
+      run: |
+        cabal install --ignore-project cabal-fmt --index-state="${{ env.hackage-index-state }}" --constraint 'cabal-fmt == 0.1.11'
 
     - name: Record cabal-fmt version
       run: |
@@ -298,7 +301,8 @@ jobs:
         cabal-update: false
 
     - name: Cabal update
-      run: cabal update
+      run:
+        cabal update --ignore-project
 
     - name: Run cabal check
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+cabal.project.debug

--- a/cabal.project.debug
+++ b/cabal.project.debug
@@ -1,3 +1,6 @@
+-- Import release project configuration
+import: cabal.project.release
+
 package lsm-tree
   -- apply this to all components
   -- relevant mostly only for development & testing

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -14,9 +14,6 @@ benchmarks: True
 -- Luckily, bloomfilter is not commonly used package, so this is good enough.
 constraints: bloomfilter <0
 
--- comment me if you are benchmarking
-import: cabal.project.debug
-
 -- comment me if you don't have liburing installed
 --
 -- TODO: it is slightly unfortunate that one has to manually remove this file


### PR DESCRIPTION
This PR restructures `cabal.project` into `cabal.project.release` and `cabal.project.debug` so that we can switch between release/debug builds from the command line rather than by editing a file, to avoid the need to `git stash/apply` when switching branches, and to enable an entirely programmatic `git bisect` for benchmarks. It also symlinks `cabal.project.debug` to `cabal.project` as the default configuration.