### PR TITLE
Clarify warning when benchmarking in debug mode

### DIFF
--- a/bench/macro/lsm-tree-bench-bloomfilter.hs
+++ b/bench/macro/lsm-tree-bench-bloomfilter.hs
@@ -66,7 +66,9 @@ benchmarkNumBitsPerEntry = 10
 benchmarks :: IO ()
 benchmarks = do
 #ifdef NO_IGNORE_ASSERTS
-    putStrLn "BENCHMARKING A BUILD WITH -fno-ignore-asserts"
+    putStrLn "WARNING: Benchmarking in debug mode."
+    putStrLn "         To benchmark in release mode, pass:"
+    putStrLn "         --project-file=cabal.project.release"
 #endif
 
     enabled <- getRTSStatsEnabled

--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -130,7 +130,9 @@ numEntriesFitInPage = fromIntegral unusedPageBits / fromIntegral entryBitsWithOv
 benchmarks :: Run.RunDataCaching -> IO ()
 benchmarks !caching = withFS $ \hfs hbio -> do
 #ifdef NO_IGNORE_ASSERTS
-    putStrLn "BENCHMARKING A BUILD WITH -fno-ignore-asserts"
+    putStrLn "WARNING: Benchmarking in debug mode."
+    putStrLn "         To benchmark in release mode, pass:"
+    putStrLn "         --project-file=cabal.project.release"
 #endif
     arenaManager <- newArenaManager
     enabled <- getRTSStatsEnabled

--- a/bench/macro/lsm-tree-bench-wp8.hs
+++ b/bench/macro/lsm-tree-bench-wp8.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -869,6 +870,11 @@ batchOverlaps initialSize batchSize batchCount seed =
 main :: IO ()
 main = do
     hSetBuffering stdout NoBuffering
+#ifdef NO_IGNORE_ASSERTS
+    putStrLn "WARNING: Benchmarking in debug mode."
+    putStrLn "         To benchmark in release mode, pass:"
+    putStrLn "         --project-file=cabal.project.release"
+#endif
     (gopts, cmd) <- O.customExecParser prefs cliP
     print gopts
     print cmd

--- a/bench/macro/rocksdb-bench-wp8.hs
+++ b/bench/macro/rocksdb-bench-wp8.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE DuplicateRecordFields    #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 {-# LANGUAGE OverloadedStrings        #-}
@@ -387,6 +388,11 @@ doRun' gopts opts =
 
 main :: IO ()
 main = do
+#ifdef NO_IGNORE_ASSERTS
+    putStrLn "WARNING: Benchmarking in debug mode."
+    putStrLn "         To benchmark in release mode, pass:"
+    putStrLn "         --project-file=cabal.project.release"
+#endif
     (gopts, cmd) <- O.customExecParser prefs cliP
     print gopts
     print cmd


### PR DESCRIPTION
Depends on #450. Consistently adds the warning and includes instructions to run in release mode.