### PR TITLE
Restore uniqueness of GHA cache names per configuration

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -93,10 +93,10 @@ jobs:
         cache-name: cache-cabal-build-130824
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}-${{ hashFiles('**/cabal.project.debug') }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('*.cabal') }}-${{ hashFiles('cabal.project*') }}-${{ matrix.cabal-project-file }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('*.cabal') }}-${{ hashFiles('cabal.project*') }}
+          ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-${{ hashFiles('*.cabal') }}-
           ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install cabal dependencies


### PR DESCRIPTION
And make sure to hash all configuration files (like `*.cabal*` and `cabal.project*`) correctly, and include those hahses in the GHA cache names too. We no longer hash put `**` in front of the globs, because that matches on files in `dist-newstyle` as well.

This is a follow-up to #450, which broke uniqueness 

Note that changes to *any* `cabal.project*` file will lead to a changed hash name, but I'd prefer that over the more involved approach of determining exactly which config files are in use by a job, and only hash those. It's also not really a problem if the hash name changes: it just means we store a new cache and the old one at some point gets evicted when it hasn't been used in a while.