### PR TITLE
Refactor blob refs

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -119,6 +119,7 @@ library
     Database.LSMTree.Internal
     Database.LSMTree.Internal.Assertions
     Database.LSMTree.Internal.BitMath
+    Database.LSMTree.Internal.BlobFile
     Database.LSMTree.Internal.BlobRef
     Database.LSMTree.Internal.BloomFilter
     Database.LSMTree.Internal.BloomFilterQuery1

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -395,9 +395,9 @@ deriving stock instance Generic (RunReader m h)
 deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
                         => NoThunks (RunReader m h)
 
-deriving stock instance Generic (Reader.Entry m (Handle h))
+deriving stock instance Generic (Reader.Entry m h)
 deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
-                        => NoThunks (Reader.Entry m (Handle h))
+                        => NoThunks (Reader.Entry m h)
 
 {-------------------------------------------------------------------------------
   RawPage
@@ -418,7 +418,7 @@ deriving anyclass instance NoThunks RawOverflowPage
 -------------------------------------------------------------------------------}
 
 deriving stock instance Generic (BlobRef m h)
-deriving anyclass instance (NoThunks h, Typeable (PrimState m))
+deriving anyclass instance (Typeable h, Typeable (PrimState m))
                         => NoThunks (BlobRef m h)
 
 deriving stock instance Generic BlobSpan

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -417,16 +417,20 @@ deriving anyclass instance NoThunks RawOverflowPage
   BlobRef
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (RawBlobRef m h)
-deriving anyclass instance (Typeable h, Typeable (PrimState m))
-                        => NoThunks (RawBlobRef m h)
-
 deriving stock instance Generic BlobSpan
 deriving anyclass instance NoThunks BlobSpan
 
 deriving stock instance Generic (BlobFile m h)
 deriving anyclass instance (Typeable h, Typeable (PrimState m))
                         => NoThunks (BlobFile m h)
+
+deriving stock instance Generic (RawBlobRef m h)
+deriving anyclass instance (Typeable h, Typeable (PrimState m))
+                        => NoThunks (RawBlobRef m h)
+
+deriving stock instance Generic (WeakBlobRef m h)
+deriving anyclass instance (Typeable h, Typeable (PrimState m))
+                        => NoThunks (WeakBlobRef m h)
 
 {-------------------------------------------------------------------------------
   Arena

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -34,6 +34,7 @@ import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word
 import           Database.LSMTree.Internal as Internal
+import           Database.LSMTree.Internal.BlobFile
 import           Database.LSMTree.Internal.BlobRef
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.CRC32C
@@ -422,6 +423,10 @@ deriving anyclass instance (NoThunks h, Typeable (PrimState m))
 
 deriving stock instance Generic BlobSpan
 deriving anyclass instance NoThunks BlobSpan
+
+deriving stock instance Generic (BlobFile m h)
+deriving anyclass instance (Typeable h, Typeable (PrimState m))
+                        => NoThunks (BlobFile m h)
 
 {-------------------------------------------------------------------------------
   Arena

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -417,9 +417,9 @@ deriving anyclass instance NoThunks RawOverflowPage
   BlobRef
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (BlobRef m h)
+deriving stock instance Generic (RawBlobRef m h)
 deriving anyclass instance (Typeable h, Typeable (PrimState m))
-                        => NoThunks (BlobRef m h)
+                        => NoThunks (RawBlobRef m h)
 
 deriving stock instance Generic BlobSpan
 deriving anyclass instance NoThunks BlobSpan

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -63,7 +63,7 @@ import qualified Database.LSMTree.Internal.MergeSchedule as Internal
 import qualified Database.LSMTree.Internal.Paths as Internal
 import qualified Database.LSMTree.Internal.Range as Internal
 import           Database.LSMTree.Internal.Serialise.Class
-import           System.FS.API (FsPath, Handle, HasFS)
+import           System.FS.API (FsPath, HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
 import           System.FS.IO (HandleIO)
 
@@ -268,7 +268,7 @@ type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal
 data BlobRef m blob where
     BlobRef :: Typeable h
-            => Internal.WeakBlobRef m (Handle h)
+            => Internal.WeakBlobRef m h
             -> BlobRef m blob
 
 instance Show (BlobRef m blob) where

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -116,8 +116,7 @@ import           Database.LSMTree.Internal.UniqCounter
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import qualified Database.LSMTree.Internal.WriteBufferBlobs as WBB
 import qualified System.FS.API as FS
-import           System.FS.API (FsError, FsErrorPath (..), FsPath, Handle,
-                     HasFS)
+import           System.FS.API (FsError, FsErrorPath (..), FsPath, HasFS)
 import qualified System.FS.API.Lazy as FS
 import qualified System.FS.BlockIO.API as FS
 import           System.FS.BlockIO.API (HasBlockIO)
@@ -724,14 +723,14 @@ close t = do
      ResolveSerialisedValue
   -> V.Vector SerialisedKey
   -> Table IO h
-  -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO (Handle h))))) #-}
+  -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO h)))) #-}
 -- | See 'Database.LSMTree.Normal.lookups'.
 lookups ::
      (MonadST m, MonadSTM m, MonadThrow m)
   => ResolveSerialisedValue
   -> V.Vector SerialisedKey
   -> Table m h
-  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h)))))
+  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m h))))
 lookups resolve ks t = do
     traceWith (tableTracer t) $ TraceLookups (V.length ks)
     withOpenTable t $ \thEnv ->
@@ -753,7 +752,7 @@ lookups resolve ks t = do
      ResolveSerialisedValue
   -> Range SerialisedKey
   -> Table IO h
-  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef IO (Handle h)) -> res)
+  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef IO h) -> res)
   -> IO (V.Vector res) #-}
 -- | See 'Database.LSMTree.Normal.rangeLookup'.
 rangeLookup ::
@@ -761,7 +760,7 @@ rangeLookup ::
   => ResolveSerialisedValue
   -> Range SerialisedKey
   -> Table m h
-  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m (Handle h)) -> res)
+  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m h) -> res)
      -- ^ How to map to a query result, different for normal/monoidal
   -> m (V.Vector res)
 rangeLookup resolve range t fromEntry = do
@@ -828,12 +827,12 @@ updates resolve es t = do
 
 {-# SPECIALISE retrieveBlobs ::
      Session IO h
-  -> V.Vector (WeakBlobRef IO (FS.Handle h))
+  -> V.Vector (WeakBlobRef IO h)
   -> IO (V.Vector SerialisedBlob) #-}
 retrieveBlobs ::
-     (MonadFix m, MonadMask m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadST m, MonadSTM m)
   => Session m h
-  -> V.Vector (WeakBlobRef m (FS.Handle h))
+  -> V.Vector (WeakBlobRef m h)
   -> m (V.Vector SerialisedBlob)
 retrieveBlobs sesh wrefs =
     withOpenSession sesh $ \seshEnv ->
@@ -1023,7 +1022,7 @@ closeCursor Cursor {..} = do
      ResolveSerialisedValue
   -> Int
   -> Cursor IO h
-  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef IO (Handle h)) -> res)
+  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef IO h) -> res)
   -> IO (V.Vector res) #-}
 -- | See 'Database.LSMTree.Normal.readCursor'.
 readCursor ::
@@ -1032,7 +1031,7 @@ readCursor ::
   => ResolveSerialisedValue
   -> Int  -- ^ Maximum number of entries to read
   -> Cursor m h
-  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m (Handle h)) -> res)
+  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m h) -> res)
      -- ^ How to map to a query result, different for normal/monoidal
   -> m (V.Vector res)
 readCursor resolve n cursor fromEntry =
@@ -1043,7 +1042,7 @@ readCursor resolve n cursor fromEntry =
   -> (SerialisedKey -> Bool)
   -> Int
   -> Cursor IO h
-  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef IO (Handle h)) -> res)
+  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef IO h) -> res)
   -> IO (V.Vector res) #-}
 -- | @readCursorWhile _ p n cursor _@ reads elements until either:
 --
@@ -1060,7 +1059,7 @@ readCursorWhile ::
   -> (SerialisedKey -> Bool)  -- ^ Only read as long as this predicate holds
   -> Int  -- ^ Maximum number of entries to read
   -> Cursor m h
-  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m (Handle h)) -> res)
+  -> (SerialisedKey -> SerialisedValue -> Maybe (WeakBlobRef m h) -> res)
      -- ^ How to map to a query result, different for normal/monoidal
   -> m (V.Vector res)
 readCursorWhile resolve keyIsWanted n Cursor {..} fromEntry = do

--- a/src/Database/LSMTree/Internal/BlobFile.hs
+++ b/src/Database/LSMTree/Internal/BlobFile.hs
@@ -14,7 +14,7 @@ module Database.LSMTree.Internal.BlobFile (
 
 import           Control.DeepSeq (NFData (..))
 import           Control.Monad (unless)
-import           Control.Monad.Class.MonadThrow (MonadThrow, MonadMask)
+import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
 import           Control.Monad.Primitive (PrimMonad)
 import           Control.RefCount (RefCounter)
 import qualified Control.RefCount as RC

--- a/src/Database/LSMTree/Internal/BlobFile.hs
+++ b/src/Database/LSMTree/Internal/BlobFile.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{- HLINT ignore "Use unless" -}
+
+module Database.LSMTree.Internal.BlobFile (
+    BlobFile (..)
+  , BlobSpan (..)
+  , removeReference
+  , newBlobFile
+  , readBlobFile
+  ) where
+
+import           Control.DeepSeq (NFData (..))
+import           Control.Monad.Class.MonadThrow (MonadThrow, MonadMask)
+import           Control.Monad.Primitive (PrimMonad)
+import           Control.RefCount (RefCounter)
+import qualified Control.RefCount as RC
+import qualified Data.Primitive.ByteArray as P (newPinnedByteArray,
+                     unsafeFreezeByteArray)
+import           Data.Word (Word32, Word64)
+import qualified Database.LSMTree.Internal.RawBytes as RB
+import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..))
+import qualified System.FS.API as FS
+import           System.FS.API (HasFS)
+import qualified System.FS.BlockIO.API as FS
+
+-- | An open handle to a file containing blobs.
+--
+-- This is a reference counted object. Upon finalisation, the file is closed
+-- and deleted.
+--
+data BlobFile m h = BlobFile {
+       blobFileHandle     :: {-# UNPACK #-} !(FS.Handle h),
+       blobFileRefCounter :: {-# UNPACK #-} !(RefCounter m)
+     }
+  deriving stock (Show)
+
+instance NFData h => NFData (BlobFile m h) where
+  rnf (BlobFile a b) = rnf a `seq` rnf b
+
+-- | The location of a blob inside a blob file.
+data BlobSpan = BlobSpan {
+    blobSpanOffset :: {-# UNPACK #-} !Word64
+  , blobSpanSize   :: {-# UNPACK #-} !Word32
+  }
+  deriving stock (Show, Eq)
+
+instance NFData BlobSpan where
+  rnf (BlobSpan a b) = rnf a `seq` rnf b
+
+removeReference ::
+     (MonadMask m, PrimMonad m)
+  => BlobFile m h
+  -> m ()
+removeReference BlobFile{blobFileRefCounter} =
+    RC.removeReference blobFileRefCounter
+
+-- | Adopt an existing open file handle to make a 'BlobFile'. The file must at
+-- least be open for reading (but may or may not be open for writing).
+--
+-- The finaliser will close and delete the file.
+--
+newBlobFile ::
+     PrimMonad m
+  => HasFS m h
+  -> FS.Handle h
+  -> m (BlobFile m h)
+newBlobFile fs blobFileHandle = do
+    let finaliser = do
+          FS.hClose fs blobFileHandle
+          FS.removeFile fs (FS.handlePath blobFileHandle)
+    blobFileRefCounter <- RC.mkRefCounter1 (Just finaliser)
+    return BlobFile {
+      blobFileHandle,
+      blobFileRefCounter
+    }
+
+{-# SPECIALISE readBlobFile :: HasFS IO h -> BlobFile IO h -> BlobSpan -> IO SerialisedBlob #-}
+readBlobFile ::
+     (MonadThrow m, PrimMonad m)
+  => HasFS m h
+  -> BlobFile m h
+  -> BlobSpan
+  -> m SerialisedBlob
+readBlobFile fs BlobFile {blobFileHandle}
+                BlobSpan {blobSpanOffset, blobSpanSize} = do
+    let off = FS.AbsOffset blobSpanOffset
+        len :: Int
+        len = fromIntegral blobSpanSize
+    mba <- P.newPinnedByteArray len
+    _ <- FS.hGetBufExactlyAt fs blobFileHandle mba 0
+                             (fromIntegral len :: FS.ByteCount) off
+    ba <- P.unsafeFreezeByteArray mba
+    let !rb = RB.fromByteArray 0 len ba
+    return (SerialisedBlob rb)

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -30,7 +30,7 @@ import           Data.Coerce (coerce)
 import qualified Data.Primitive.ByteArray as P (MutableByteArray,
                      newPinnedByteArray, unsafeFreezeByteArray)
 import qualified Data.Vector as V
-import           Data.Word (Word32, Word64)
+import           Database.LSMTree.Internal.BlobFile (BlobSpan (..))
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..))
 import qualified System.FS.API as FS
@@ -50,16 +50,6 @@ data BlobRef m h = BlobRef {
 
 instance NFData h => NFData (BlobRef m h) where
   rnf (BlobRef a b c) = rnf a `seq` rnf b `seq` rnf c
-
--- | Location of a blob inside a blob file.
-data BlobSpan = BlobSpan {
-    blobSpanOffset :: {-# UNPACK #-} !Word64
-  , blobSpanSize   :: {-# UNPACK #-} !Word32
-  }
-  deriving stock (Show, Eq)
-
-instance NFData BlobSpan where
-  rnf (BlobSpan a b) = rnf a `seq` rnf b
 
 blobRefSpanSize :: BlobRef m h -> Int
 blobRefSpanSize = fromIntegral . blobSpanSize . blobRefSpan

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -23,7 +23,8 @@ import qualified Data.Primitive.ByteArray as P (newPinnedByteArray,
                      unsafeFreezeByteArray)
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM
-import           Database.LSMTree.Internal.BlobFile (BlobFile (..), BlobSpan (..))
+import           Database.LSMTree.Internal.BlobFile (BlobFile (..),
+                     BlobSpan (..))
 import qualified Database.LSMTree.Internal.BlobFile as BlobFile
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..))

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -141,7 +141,7 @@ readRawBlobRef ::
   -> RawBlobRef m h
   -> m SerialisedBlob
 readRawBlobRef fs RawBlobRef {rawBlobRefFile, rawBlobRefSpan} =
-    BlobFile.readBlobFile fs rawBlobRefFile rawBlobRefSpan
+    BlobFile.readBlob fs rawBlobRefFile rawBlobRefSpan
 
 {-# SPECIALISE readWeakBlobRef :: HasFS IO h -> WeakBlobRef IO h -> IO SerialisedBlob #-}
 readWeakBlobRef ::
@@ -152,7 +152,7 @@ readWeakBlobRef ::
 readWeakBlobRef fs wref =
     bracket (deRefWeakBlobRef wref) removeReference $
       \StrongBlobRef {strongBlobRefFile, strongBlobRefSpan} ->
-        BlobFile.readBlobFile fs strongBlobRefFile strongBlobRefSpan
+        BlobFile.readBlob fs strongBlobRefFile strongBlobRefSpan
 
 {-# SPECIALISE readWeakBlobRefs :: HasBlockIO IO h -> V.Vector (WeakBlobRef IO h) -> IO (V.Vector SerialisedBlob) #-}
 readWeakBlobRefs ::

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -42,7 +42,7 @@ import qualified System.FS.BlockIO.API as FS
 --
 -- See 'Database.LSMTree.Common.BlobRef' for more info.
 data BlobRef m h = BlobRef {
-      blobRefFile  :: !h
+      blobRefFile  :: !(FS.Handle h)
     , blobRefCount :: {-# UNPACK #-} !(RefCounter m)
     , blobRefSpan  :: {-# UNPACK #-} !BlobSpan
     }
@@ -141,12 +141,12 @@ removeReferences = V.mapM_ removeReference
 
 {-# SPECIALISE readBlob ::
      HasFS IO h
-  -> BlobRef IO (FS.Handle h)
+  -> BlobRef IO h
   -> IO SerialisedBlob #-}
 readBlob ::
      (MonadThrow m, PrimMonad m)
   => HasFS m h
-  -> BlobRef m (FS.Handle h)
+  -> BlobRef m h
   -> m SerialisedBlob
 readBlob fs BlobRef {
               blobRefFile,
@@ -164,7 +164,7 @@ readBlob fs BlobRef {
 
 readBlobIOOp ::
      P.MutableByteArray s -> Int
-  -> BlobRef m (FS.Handle h)
+  -> BlobRef m h
   -> FS.IOOp s h
 readBlobIOOp buf bufoff
              BlobRef {

--- a/src/Database/LSMTree/Internal/CRC32C.hs
+++ b/src/Database/LSMTree/Internal/CRC32C.hs
@@ -13,6 +13,7 @@
 -- * Support for verifying checksums of files.
 -- * Support for a text file format listing file checksums.
 --
+-- TODO: specialise all the functions here to IO
 module Database.LSMTree.Internal.CRC32C (
 
   CRC32C(..),

--- a/src/Database/LSMTree/Internal/Cursor.hs
+++ b/src/Database/LSMTree/Internal/Cursor.hs
@@ -9,7 +9,7 @@ import           Control.Monad.Class.MonadST (MonadST (..))
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Fix (MonadFix)
 import qualified Data.Vector as V
-import           Database.LSMTree.Internal.BlobRef (BlobRef,
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef,
                      WeakBlobRef (..))
 import           Database.LSMTree.Internal.Entry (Entry)
 import qualified Database.LSMTree.Internal.Entry as Entry
@@ -106,7 +106,7 @@ readEntriesWhile resolve keyIsWanted fromEntry readers n =
     -- Once we have a resolved entry, we still have to make sure it's not
     -- a 'Delete', since we only want to write values to the result vector.
     handleResolved :: SerialisedKey
-                   -> Entry SerialisedValue (BlobRef m h)
+                   -> Entry SerialisedValue (RawBlobRef m h)
                    -> Readers.HasMore
                    -> m (Maybe res, Readers.HasMore)
     handleResolved key entry hasMore =
@@ -122,7 +122,7 @@ readEntriesWhile resolve keyIsWanted fromEntry readers n =
               Readers.Drained -> return (Nothing, Readers.Drained)
 
     toResult :: SerialisedKey
-             -> Entry SerialisedValue (BlobRef m h)
+             -> Entry SerialisedValue (RawBlobRef m h)
              -> Maybe res
     toResult key = \case
         Entry.Insert v -> Just $ fromEntry key v Nothing

--- a/src/Database/LSMTree/Internal/Cursor.hs
+++ b/src/Database/LSMTree/Internal/Cursor.hs
@@ -11,6 +11,7 @@ import           Control.Monad.Fix (MonadFix)
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.BlobRef (RawBlobRef,
                      WeakBlobRef (..))
+import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.Entry (Entry)
 import qualified Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
@@ -126,6 +127,6 @@ readEntriesWhile resolve keyIsWanted fromEntry readers n =
              -> Maybe res
     toResult key = \case
         Entry.Insert v -> Just $ fromEntry key v Nothing
-        Entry.InsertWithBlob v b -> Just $ fromEntry key v (Just (WeakBlobRef b))
+        Entry.InsertWithBlob v b -> Just $ fromEntry key v (Just (BlobRef.rawToWeakBlobRef b))
         Entry.Mupdate v -> Just $ fromEntry key v Nothing
         Entry.Delete -> Nothing

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -163,7 +163,7 @@ data ByteCountDiscrepancy = ByteCountDiscrepancy {
     -> V.Vector IndexCompact
     -> V.Vector (Handle h)
     -> V.Vector SerialisedKey
-    -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO (Handle h)))))
+    -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO h))))
   #-}
 -- | Batched lookups in I\/O.
 --
@@ -183,7 +183,7 @@ lookupsIO ::
   -> V.Vector IndexCompact -- ^ The indexes inside @rs@
   -> V.Vector (Handle h) -- ^ The file handles to the key\/value files inside @rs@
   -> V.Vector SerialisedKey
-  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h)))))
+  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m h))))
 lookupsIO !hbio !mgr !resolveV !wb !wbblobs !rs !blooms !indexes !kopsFiles !ks =
     assert precondition $
     withArena mgr $ \arena -> do
@@ -208,7 +208,7 @@ lookupsIO !hbio !mgr !resolveV !wb !wbblobs !rs !blooms !indexes !kopsFiles !ks 
     -> VP.Vector RunIxKeyIx
     -> V.Vector (IOOp RealWorld h)
     -> VU.Vector IOResult
-    -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO (Handle h)))))
+    -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO h))))
   #-}
 -- | Intra-page lookups, and combining lookup results from multiple runs and
 -- the write buffer.
@@ -227,7 +227,7 @@ intraPageLookups ::
   -> VP.Vector RunIxKeyIx
   -> V.Vector (IOOp (PrimState m) h)
   -> VU.Vector IOResult
-  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h)))))
+  -> m (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m h))))
 intraPageLookups !resolveV !wb !wbblobs !rs !ks !rkixs !ioops !ioress = do
     -- We accumulate results into the 'res' vector. When there are several
     -- lookup hits for the same key then we combine the results. The combining
@@ -256,7 +256,7 @@ intraPageLookups !resolveV !wb !wbblobs !rs !ks !rkixs !ioops !ioress = do
 
     loop ::
          VM.MVector (PrimState m)
-                    (Maybe (Entry SerialisedValue (WeakBlobRef m (Handle h))))
+                    (Maybe (Entry SerialisedValue (WeakBlobRef m h)))
       -> Int
       -> m ()
     loop !res !ioopix

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -33,7 +33,7 @@ import           Data.Primitive.MutVar
 import           Data.Traversable (for)
 import qualified Data.Vector as V
 import           Data.Word
-import           Database.LSMTree.Internal.BlobRef (BlobRef)
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef)
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Run (Run, RunDataCaching)
 import qualified Database.LSMTree.Internal.Run as Run
@@ -396,14 +396,14 @@ writeReaderEntry level builder key entry@(Reader.EntryOverflow prefix page _ ove
      Level
   -> RunBuilder IO h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef IO h)
+  -> Entry SerialisedValue (RawBlobRef IO h)
   -> IO () #-}
 writeSerialisedEntry ::
      (MonadSTM m, MonadST m, MonadThrow m)
   => Level
   -> RunBuilder m h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef m h)
+  -> Entry SerialisedValue (RawBlobRef m h)
   -> m ()
 writeSerialisedEntry level builder key entry =
     when (shouldWriteEntry level entry) $

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -190,7 +190,7 @@ finaliser var b rs = do
 -- this function with async exceptions masked. Otherwise, these resources can
 -- leak.
 complete ::
-     (MonadFix m, MonadSTM m, MonadST m, MonadThrow m)
+     (MonadFix m, MonadSTM m, MonadST m, MonadMask m)
   => Merge m h
   -> m (Run m h)
 complete Merge{..} = do
@@ -218,7 +218,7 @@ complete Merge{..} = do
 --
 -- Note: run with async exceptions masked. See 'complete'.
 stepsToCompletion ::
-      (MonadCatch m, MonadFix m, MonadSTM m, MonadST m)
+      (MonadMask m, MonadFix m, MonadSTM m, MonadST m)
    => Merge m h
    -> Int
    -> m (Run m h)
@@ -237,7 +237,7 @@ stepsToCompletion m stepBatchSize = go
 --
 -- Note: run with async exceptions masked. See 'complete'.
 stepsToCompletionCounted ::
-     (MonadCatch m, MonadFix m, MonadSTM m, MonadST m)
+     (MonadMask m, MonadFix m, MonadSTM m, MonadST m)
   => Merge m h
   -> Int
   -> m (Int, Run m h)

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -45,7 +45,6 @@ import           Database.LSMTree.Internal.RunReaders (Readers)
 import qualified Database.LSMTree.Internal.RunReaders as Readers
 import           Database.LSMTree.Internal.Serialise
 import           GHC.Stack (HasCallStack)
-import qualified System.FS.API as FS
 import           System.FS.API (HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
 
@@ -357,14 +356,14 @@ steps Merge {..} requestedSteps = assertStepsInvariant <$> do
      Level
   -> RunBuilder IO h
   -> SerialisedKey
-  -> Reader.Entry IO (FS.Handle h)
+  -> Reader.Entry IO h
   -> IO () #-}
 writeReaderEntry ::
      (MonadSTM m, MonadST m, MonadThrow m)
   => Level
   -> RunBuilder m h
   -> SerialisedKey
-  -> Reader.Entry m (FS.Handle h)
+  -> Reader.Entry m h
   -> m ()
 writeReaderEntry level builder key (Reader.Entry entryFull) =
       -- Small entry.
@@ -397,14 +396,14 @@ writeReaderEntry level builder key entry@(Reader.EntryOverflow prefix page _ ove
      Level
   -> RunBuilder IO h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef IO (FS.Handle h))
+  -> Entry SerialisedValue (BlobRef IO h)
   -> IO () #-}
 writeSerialisedEntry ::
      (MonadSTM m, MonadST m, MonadThrow m)
   => Level
   -> RunBuilder m h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef m (FS.Handle h))
+  -> Entry SerialisedValue (BlobRef m h)
   -> m ()
 writeSerialisedEntry level builder key entry =
     when (shouldWriteEntry level entry) $

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -869,7 +869,7 @@ levelIsFull sr rs = V.length rs + 1 >= (sizeRatioInt sr)
 
 {-# SPECIALISE mergeRuns :: ResolveSerialisedValue -> HasFS IO h -> HasBlockIO IO h -> RunDataCaching -> RunBloomFilterAlloc -> RunFsPaths -> Merge.Level -> V.Vector (Run IO h) -> IO (Run IO h) #-}
 mergeRuns ::
-     (MonadCatch m, MonadFix m, MonadST m, MonadSTM m)
+     (MonadMask m, MonadFix m, MonadST m, MonadSTM m)
   => ResolveSerialisedValue
   -> HasFS m h
   -> HasBlockIO m h

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -145,11 +145,10 @@ removeReferenceN r = RC.removeReferenceN (runRefCounter r)
 
 -- | Helper function to make a 'BlobRef' that points into a 'Run'.
 mkBlobRefForRun :: Run m h -> BlobSpan -> RawBlobRef m h
-mkBlobRefForRun Run{runBlobFile} blobRefSpan =
+mkBlobRefForRun Run{runBlobFile} blobspan =
     RawBlobRef {
-      blobRefFile  = blobFileHandle runBlobFile,
-      blobRefCount = blobFileRefCounter runBlobFile,
-      blobRefSpan
+      rawBlobRefFile = runBlobFile,
+      rawBlobRefSpan = blobspan
     }
 
 {-# SPECIALISE close ::

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -144,7 +144,7 @@ removeReferenceN :: (PrimMonad m, MonadMask m) => Run m h -> Word64 -> m ()
 removeReferenceN r = RC.removeReferenceN (runRefCounter r)
 
 -- | Helper function to make a 'BlobRef' that points into a 'Run'.
-mkBlobRefForRun :: Run m h -> BlobSpan -> BlobRef m (FS.Handle h)
+mkBlobRefForRun :: Run m h -> BlobSpan -> BlobRef m h
 mkBlobRefForRun Run{runBlobFile} blobRefSpan =
     BlobRef {
       blobRefFile  = blobFileHandle runBlobFile,

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -169,7 +169,7 @@ mkWeakBlobRef Run{runBlobFile} blobspan =
 --
 -- TODO: Once snapshots are implemented, files should get removed, but for now
 -- we want to be able to re-open closed runs from disk.
--- TODO: see newBlobFile DoNotRemoveFileOnClose. This can be dropped at the
+-- TODO: see openBlobFile DoNotRemoveFileOnClose. This can be dropped at the
 -- same once when snapshots are implemented.
 close :: (MonadSTM m, MonadMask m, PrimMonad m) => Run m h -> m ()
 close Run {..} = do
@@ -227,8 +227,8 @@ fromMutable runRunDataCaching refCount builder = do
     (runHasFS, runHasBlockIO, runRunFsPaths, runFilter, runIndex, runNumEntries) <-
       Builder.unsafeFinalise (runRunDataCaching == NoCacheRunData) builder
     runKOpsFile <- FS.hOpen runHasFS (runKOpsPath runRunFsPaths) FS.ReadMode
-    runBlobFile <- newBlobFile runHasFS DoNotRemoveFileOnClose
-               =<< FS.hOpen runHasFS (runBlobPath runRunFsPaths) FS.ReadMode
+    runBlobFile <- openBlobFile runHasFS (runBlobPath runRunFsPaths) FS.ReadMode
+                                DoNotRemoveFileOnClose
     setRunDataCaching runHasBlockIO runKOpsFile runRunDataCaching
     rec runRefCounter <- RC.unsafeMkRefCounterN refCount (Just $ close r)
         let !r = Run { .. }
@@ -313,8 +313,8 @@ openFromDisk fs hbio runRunDataCaching runRunFsPaths = do
         =<< readCRC (forRunIndex expectedChecksums) (forRunIndex paths)
 
     runKOpsFile <- FS.hOpen fs (runKOpsPath runRunFsPaths) FS.ReadMode
-    runBlobFile <- newBlobFile fs DoNotRemoveFileOnClose
-               =<< FS.hOpen fs (runBlobPath runRunFsPaths) FS.ReadMode
+    runBlobFile <- openBlobFile fs (runBlobPath runRunFsPaths) FS.ReadMode
+                                DoNotRemoveFileOnClose
     setRunDataCaching hbio runKOpsFile runRunDataCaching
     rec runRefCounter <- RC.unsafeMkRefCounterN (RefCount 1) (Just $ close r)
         let !r = Run

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -69,7 +69,8 @@ import           Data.Foldable (for_)
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.BlobFile hiding (removeReference)
 import qualified Database.LSMTree.Internal.BlobFile as BlobFile
-import           Database.LSMTree.Internal.BlobRef  (RawBlobRef (..), WeakBlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..),
+                     WeakBlobRef (..))
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterFromSBS)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry (NumEntries (..))

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -144,9 +144,9 @@ removeReferenceN :: (PrimMonad m, MonadMask m) => Run m h -> Word64 -> m ()
 removeReferenceN r = RC.removeReferenceN (runRefCounter r)
 
 -- | Helper function to make a 'BlobRef' that points into a 'Run'.
-mkBlobRefForRun :: Run m h -> BlobSpan -> BlobRef m h
+mkBlobRefForRun :: Run m h -> BlobSpan -> RawBlobRef m h
 mkBlobRefForRun Run{runBlobFile} blobRefSpan =
-    BlobRef {
+    RawBlobRef {
       blobRefFile  = blobFileHandle runBlobFile,
       blobRefCount = blobFileRefCounter runBlobFile,
       blobRefSpan

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -285,8 +285,8 @@ copyBlob ::
 copyBlob builder@RunBuilder {..} blobref = do
     blob <- BlobRef.readRawBlobRef runBuilderHasFS blobref
     writeBlob builder blob
-    --TODO: consier adding write blob functions to BlobFile
-    -- variants: at offset, at file pointer with CRC update.
+    --TODO: can't easily switch this to use BlobFile.writeBlob because
+    -- RunBuilder currently does everything uniformly with ChecksumHandle.
 
 {-# SPECIALISE writeFilter ::
      RunBuilder IO h

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -283,7 +283,7 @@ copyBlob ::
   -> RawBlobRef m h
   -> m BlobSpan
 copyBlob builder@RunBuilder {..} blobref = do
-    blob <- BlobRef.readBlob runBuilderHasFS blobref
+    blob <- BlobRef.readRawBlobRef runBuilderHasFS blobref
     writeBlob builder blob
 
 {-# SPECIALISE writeFilter ::

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -22,7 +22,7 @@ import qualified Data.ByteString.Lazy as BSL
 import           Data.Foldable (for_, traverse_)
 import           Data.Primitive.PrimVar
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.BlobRef (RawBlobRef, BlobSpan (..))
+import           Database.LSMTree.Internal.BlobRef (BlobSpan (..), RawBlobRef)
 import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterToLBS)
 import           Database.LSMTree.Internal.CRC32C (CRC32C)

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -285,6 +285,8 @@ copyBlob ::
 copyBlob builder@RunBuilder {..} blobref = do
     blob <- BlobRef.readRawBlobRef runBuilderHasFS blobref
     writeBlob builder blob
+    --TODO: consier adding write blob functions to BlobFile
+    -- variants: at offset, at file pointer with CRC update.
 
 {-# SPECIALISE writeFilter ::
      RunBuilder IO h

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -22,7 +22,7 @@ import qualified Data.ByteString.Lazy as BSL
 import           Data.Foldable (for_, traverse_)
 import           Data.Primitive.PrimVar
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.BlobRef (BlobRef, BlobSpan (..))
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef, BlobSpan (..))
 import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterToLBS)
 import           Database.LSMTree.Internal.CRC32C (CRC32C)
@@ -106,11 +106,11 @@ new fs hbio runBuilderFsPaths numEntries alloc = do
 {-# SPECIALISE addKeyOp ::
      RunBuilder IO h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef IO h)
+  -> Entry SerialisedValue (RawBlobRef IO h)
   -> IO () #-}
 -- | Add a key\/op pair.
 --
--- In the 'InsertWithBlob' case, the 'BlobRef' identifies where the blob can be
+-- In the 'InsertWithBlob' case, the 'RawBlobRef' identifies where the blob can be
 -- found (which is either from a write buffer or another run). The blobs will
 -- be copied from their existing blob file into the new run's blob file.
 --
@@ -125,7 +125,7 @@ addKeyOp ::
      (MonadST m, MonadSTM m, MonadThrow m)
   => RunBuilder m h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef m h)
+  -> Entry SerialisedValue (RawBlobRef m h)
   -> m ()
 addKeyOp builder@RunBuilder{runBuilderAcc} key op = do
     -- TODO: the fmap entry here reallocates even when there are no blobs.
@@ -275,12 +275,12 @@ writeBlob RunBuilder{..} blob = do
 
 {-# SPECIALISE copyBlob ::
      RunBuilder IO h
-  -> BlobRef IO h
+  -> RawBlobRef IO h
   -> IO BlobSpan #-}
 copyBlob ::
      (MonadSTM m, MonadThrow m, PrimMonad m)
   => RunBuilder m h
-  -> BlobRef m h
+  -> RawBlobRef m h
   -> m BlobSpan
 copyBlob builder@RunBuilder {..} blobref = do
     blob <- BlobRef.readBlob runBuilderHasFS blobref

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -106,7 +106,7 @@ new fs hbio runBuilderFsPaths numEntries alloc = do
 {-# SPECIALISE addKeyOp ::
      RunBuilder IO h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef IO (FS.Handle h))
+  -> Entry SerialisedValue (BlobRef IO h)
   -> IO () #-}
 -- | Add a key\/op pair.
 --
@@ -125,7 +125,7 @@ addKeyOp ::
      (MonadST m, MonadSTM m, MonadThrow m)
   => RunBuilder m h
   -> SerialisedKey
-  -> Entry SerialisedValue (BlobRef m (FS.Handle h))
+  -> Entry SerialisedValue (BlobRef m h)
   -> m ()
 addKeyOp builder@RunBuilder{runBuilderAcc} key op = do
     -- TODO: the fmap entry here reallocates even when there are no blobs.
@@ -275,13 +275,13 @@ writeBlob RunBuilder{..} blob = do
 
 {-# SPECIALISE copyBlob ::
      RunBuilder IO h
-  -> BlobRef IO (FS.Handle h)
-  -> IO BlobRef.BlobSpan #-}
+  -> BlobRef IO h
+  -> IO BlobSpan #-}
 copyBlob ::
      (MonadSTM m, MonadThrow m, PrimMonad m)
   => RunBuilder m h
-  -> BlobRef m (FS.Handle h)
-  -> m BlobRef.BlobSpan
+  -> BlobRef m h
+  -> m BlobSpan
 copyBlob builder@RunBuilder {..} blobref = do
     blob <- BlobRef.readBlob runBuilderHasFS blobref
     writeBlob builder blob

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -246,14 +246,14 @@ next reader@RunReader {..} = do
                 go 0 p  -- try again on the new page
           IndexEntry key entry -> do
             modifyPrimVar readerCurrentEntryNo (+1)
-            let entry' = fmap (Run.mkBlobRefForRun readerRun) entry
+            let entry' = fmap (Run.mkRawBlobRef readerRun) entry
             let rawEntry = Entry entry'
             return (ReadEntry key rawEntry)
           IndexEntryOverflow key entry lenSuffix -> do
             -- TODO: we know that we need the next page, could already load?
             modifyPrimVar readerCurrentEntryNo (+1)
             let entry' :: E.Entry SerialisedValue (RawBlobRef m h)
-                entry' = fmap (Run.mkBlobRefForRun readerRun) entry
+                entry' = fmap (Run.mkRawBlobRef readerRun) entry
             overflowPages <- readOverflowPages readerHasFS readerKOpsHandle lenSuffix
             let rawEntry = mkEntryOverflow entry' page lenSuffix overflowPages
             return (ReadEntry key rawEntry)

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -29,7 +29,7 @@ import           Data.Primitive.PrimVar
 import           Data.Word (Word16, Word32)
 import           Database.LSMTree.Internal.BitMath (ceilDivPageSize,
                      mulPageSize, roundUpToPageSize)
-import           Database.LSMTree.Internal.BlobRef (BlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..))
 import qualified Database.LSMTree.Internal.Entry as E
 import qualified Database.LSMTree.Internal.IndexCompact as Index
 import           Database.LSMTree.Internal.Page (PageNo (..), PageSpan (..),
@@ -167,12 +167,12 @@ data Result m h
 
 data Entry m h =
     Entry
-      !(E.Entry SerialisedValue (BlobRef m h))
+      !(E.Entry SerialisedValue (RawBlobRef m h))
   | -- | A large entry. The caller might be interested in various different
     -- (redundant) representation, so we return all of them.
     EntryOverflow
       -- | The value is just a prefix, with the remainder in the overflow pages.
-      !(E.Entry SerialisedValue (BlobRef m h))
+      !(E.Entry SerialisedValue (RawBlobRef m h))
       -- | A page containing the single entry (or rather its prefix).
       !RawPage
       -- | Non-zero length of the overflow in bytes.
@@ -186,7 +186,7 @@ data Entry m h =
       ![RawOverflowPage]
 
 mkEntryOverflow ::
-     E.Entry SerialisedValue (BlobRef m h)
+     E.Entry SerialisedValue (RawBlobRef m h)
   -> RawPage
   -> Word32
   -> [RawOverflowPage]
@@ -198,7 +198,7 @@ mkEntryOverflow entryPrefix page len overflowPages =
       EntryOverflow entryPrefix page len overflowPages
 
 {-# INLINE toFullEntry #-}
-toFullEntry :: Entry m h -> E.Entry SerialisedValue (BlobRef m h)
+toFullEntry :: Entry m h -> E.Entry SerialisedValue (RawBlobRef m h)
 toFullEntry = \case
     Entry e ->
       e
@@ -252,7 +252,7 @@ next reader@RunReader {..} = do
           IndexEntryOverflow key entry lenSuffix -> do
             -- TODO: we know that we need the next page, could already load?
             modifyPrimVar readerCurrentEntryNo (+1)
-            let entry' :: E.Entry SerialisedValue (BlobRef m h)
+            let entry' :: E.Entry SerialisedValue (RawBlobRef m h)
                 entry' = fmap (Run.mkBlobRefForRun readerRun) entry
             overflowPages <- readOverflowPages readerHasFS readerKOpsHandle lenSuffix
             let rawEntry = mkEntryOverflow entry' page lenSuffix overflowPages

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -73,7 +73,7 @@ data ReadCtx m h = ReadCtx {
       -- Using an 'STRef' could avoid reallocating the record for every entry,
       -- but that might not be straightforward to integrate with the heap.
       readCtxHeadKey   :: !SerialisedKey
-    , readCtxHeadEntry :: !(Reader.Entry m (FS.Handle h))
+    , readCtxHeadEntry :: !(Reader.Entry m h)
       -- We could get rid of this by making 'LoserTree' stable (for which there
       -- is a prototype already).
       -- Alternatively, if we decide to have an invariant that the number in
@@ -103,7 +103,7 @@ data Reader m h =
     -- having to find the next entry in the Map again (requiring key
     -- comparisons) or having to copy out all entries.
     -- TODO: more efficient representation? benchmark!
-  | ReadBuffer !(MutVar (PrimState m) [KOp m (FS.Handle h)])
+  | ReadBuffer !(MutVar (PrimState m) [KOp m h])
 
 type KOp m h = (SerialisedKey, Entry SerialisedValue (BlobRef m h))
 
@@ -184,11 +184,11 @@ data HasMore = HasMore | Drained
 
 {-# SPECIALISE pop ::
     Readers IO h
-  -> IO (SerialisedKey, Reader.Entry IO (FS.Handle h), HasMore) #-}
+  -> IO (SerialisedKey, Reader.Entry IO h, HasMore) #-}
 pop ::
      (MonadCatch m, MonadSTM m, MonadST m)
   => Readers m h
-  -> m (SerialisedKey, Reader.Entry m (FS.Handle h), HasMore)
+  -> m (SerialisedKey, Reader.Entry m h, HasMore)
 pop r@Readers {..} = do
     ReadCtx {..} <- readMutVar readersNext
     hasMore <- dropOne r readCtxNumber readCtxReader

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -26,7 +26,7 @@ import           Data.Maybe (catMaybes)
 import           Data.Primitive.MutVar
 import           Data.Traversable (for)
 import qualified Data.Vector as V
-import           Database.LSMTree.Internal.BlobRef (BlobRef)
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef)
 import           Database.LSMTree.Internal.Entry (Entry (..))
 import           Database.LSMTree.Internal.Run (Run)
 import           Database.LSMTree.Internal.RunReader (OffsetKey (..),
@@ -105,7 +105,7 @@ data Reader m h =
     -- TODO: more efficient representation? benchmark!
   | ReadBuffer !(MutVar (PrimState m) [KOp m h])
 
-type KOp m h = (SerialisedKey, Entry SerialisedValue (BlobRef m h))
+type KOp m h = (SerialisedKey, Entry SerialisedValue (RawBlobRef m h))
 
 {-# SPECIALISE new ::
      OffsetKey

--- a/src/Database/LSMTree/Internal/RunReaders.hs
+++ b/src/Database/LSMTree/Internal/RunReaders.hs
@@ -132,7 +132,7 @@ new !offsetKey wbs runs = do
            -> m (Maybe (ReadCtx m h))
     fromWB wb wbblobs = do
         --TODO: this BlobSpan to BlobRef conversion involves quite a lot of allocation
-        kops <- newMutVar $ map (fmap (fmap (WB.mkBlobRef wbblobs))) $
+        kops <- newMutVar $ map (fmap (fmap (WB.mkRawBlobRef wbblobs))) $
                   Map.toList $ filterWB $ WB.toMap wb
         nextReadCtx (ReaderNumber 0) (ReadBuffer kops)
       where

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -121,9 +121,9 @@ new :: PrimMonad m
 new fs blobFileName = do
     -- Must use read/write mode because we write blobs when adding, but
     -- we can also be asked to retrieve blobs at any time.
-    blobFileHandle <- FS.hOpen fs blobFileName (FS.ReadWriteMode FS.MustBeNew)
+    blobFile <- openBlobFile fs blobFileName (FS.ReadWriteMode FS.MustBeNew)
+                                RemoveFileOnClose
     blobFilePointer <- newFilePointer
-    blobFile <- newBlobFile fs RemoveFileOnClose blobFileHandle
     return WriteBufferBlobs {
       blobFile,
       blobFilePointer

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -43,7 +43,7 @@ import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.BlobFile hiding (removeReference)
 import qualified Database.LSMTree.Internal.BlobFile as BlobFile
-import           Database.LSMTree.Internal.BlobRef (BlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..))
 import           Database.LSMTree.Internal.Serialise
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS)
@@ -181,9 +181,9 @@ readBlob fs WriteBufferBlobs {blobFile} blobspan =
 -- | Helper function to make a 'BlobRef' that points into a 'WriteBufferBlobs'.
 mkBlobRef :: WriteBufferBlobs m h
           -> BlobSpan
-          -> BlobRef m h
+          -> RawBlobRef m h
 mkBlobRef WriteBufferBlobs {blobFile} blobRefSpan =
-    BlobRef {
+    RawBlobRef {
       blobRefFile  = blobFileHandle blobFile,
       blobRefCount = blobFileRefCounter blobFile,
       blobRefSpan

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -27,7 +27,6 @@ module Database.LSMTree.Internal.WriteBufferBlobs (
     addReference,
     removeReference,
     addBlob,
-    readBlob,
     mkRawBlobRef,
     mkWeakBlobRef,
     -- * For tests
@@ -169,15 +168,6 @@ writeBlobAtOffset fs h (SerialisedBlob' (VP.Vector boff blen ba)) off = do
              (fromIntegral blen :: FS.ByteCount)
              (FS.AbsOffset off)
     return ()
-
-{-# SPECIALISE readBlob :: HasFS IO h -> WriteBufferBlobs IO h -> BlobSpan -> IO SerialisedBlob #-}
-readBlob :: (PrimMonad m, MonadThrow m)
-         => HasFS m h
-         -> WriteBufferBlobs m h
-         -> BlobSpan
-         -> m SerialisedBlob
-readBlob fs WriteBufferBlobs {blobFile} blobspan =
-    readBlobFile fs blobFile blobspan
 
 -- | Helper function to make a 'RawBlobRef' that points into a
 -- 'WriteBufferBlobs'.

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -43,7 +43,8 @@ import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.BlobFile hiding (removeReference)
 import qualified Database.LSMTree.Internal.BlobFile as BlobFile
-import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..), WeakBlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..),
+                     WeakBlobRef (..))
 import           Database.LSMTree.Internal.Serialise
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS)

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -182,11 +182,10 @@ readBlob fs WriteBufferBlobs {blobFile} blobspan =
 mkBlobRef :: WriteBufferBlobs m h
           -> BlobSpan
           -> RawBlobRef m h
-mkBlobRef WriteBufferBlobs {blobFile} blobRefSpan =
+mkBlobRef WriteBufferBlobs {blobFile} blobspan =
     RawBlobRef {
-      blobRefFile  = blobFileHandle blobFile,
-      blobRefCount = blobFileRefCounter blobFile,
-      blobRefSpan
+      rawBlobRefFile = blobFile,
+      rawBlobRefSpan = blobspan
     }
 
 

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -181,7 +181,7 @@ readBlob fs WriteBufferBlobs {blobFile} blobspan =
 -- | Helper function to make a 'BlobRef' that points into a 'WriteBufferBlobs'.
 mkBlobRef :: WriteBufferBlobs m h
           -> BlobSpan
-          -> BlobRef m (FS.Handle h)
+          -> BlobRef m h
 mkBlobRef WriteBufferBlobs {blobFile} blobRefSpan =
     BlobRef {
       blobRefFile  = blobFileHandle blobFile,

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -122,7 +122,7 @@ new fs blobFileName = do
     -- we can also be asked to retrieve blobs at any time.
     blobFileHandle <- FS.hOpen fs blobFileName (FS.ReadWriteMode FS.MustBeNew)
     blobFilePointer <- newFilePointer
-    blobFile <- newBlobFile fs blobFileHandle
+    blobFile <- newBlobFile fs RemoveFileOnClose blobFileHandle
     return WriteBufferBlobs {
       blobFile,
       blobFilePointer

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -28,7 +28,8 @@ module Database.LSMTree.Internal.WriteBufferBlobs (
     removeReference,
     addBlob,
     readBlob,
-    mkBlobRef,
+    mkRawBlobRef,
+    mkWeakBlobRef,
     -- * For tests
     FilePointer (..)
   ) where
@@ -43,7 +44,7 @@ import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.BlobFile hiding (removeReference)
 import qualified Database.LSMTree.Internal.BlobFile as BlobFile
-import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..))
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..), WeakBlobRef (..))
 import           Database.LSMTree.Internal.Serialise
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS)
@@ -178,14 +179,26 @@ readBlob :: (PrimMonad m, MonadThrow m)
 readBlob fs WriteBufferBlobs {blobFile} blobspan =
     readBlobFile fs blobFile blobspan
 
--- | Helper function to make a 'BlobRef' that points into a 'WriteBufferBlobs'.
-mkBlobRef :: WriteBufferBlobs m h
-          -> BlobSpan
-          -> RawBlobRef m h
-mkBlobRef WriteBufferBlobs {blobFile} blobspan =
+-- | Helper function to make a 'RawBlobRef' that points into a
+-- 'WriteBufferBlobs'.
+mkRawBlobRef :: WriteBufferBlobs m h
+             -> BlobSpan
+             -> RawBlobRef m h
+mkRawBlobRef WriteBufferBlobs {blobFile} blobspan =
     RawBlobRef {
       rawBlobRefFile = blobFile,
       rawBlobRefSpan = blobspan
+    }
+
+-- | Helper function to make a 'WeakBlobRef' that points into a
+-- 'WriteBufferBlobs'.
+mkWeakBlobRef :: WriteBufferBlobs m h
+              -> BlobSpan
+              -> WeakBlobRef m h
+mkWeakBlobRef WriteBufferBlobs {blobFile} blobspan =
+    WeakBlobRef {
+      weakBlobRefFile = blobFile,
+      weakBlobRefSpan = blobspan
     }
 
 

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -130,7 +130,6 @@ import qualified Database.LSMTree.Internal.Entry as Entry
 import qualified Database.LSMTree.Internal.Serialise as Internal
 import qualified Database.LSMTree.Internal.Snapshot as Internal
 import qualified Database.LSMTree.Internal.Vector as V
-import qualified System.FS.API as FS
 
 -- $resource-management
 -- Sessions, tables and cursors use resources and as such need to be
@@ -629,8 +628,8 @@ retrieveBlobs (Internal.Session' (sesh :: Internal.Session m h)) refs =
     V.map Internal.deserialiseBlob <$>
       Internal.retrieveBlobs sesh (V.imap checkBlobRefType refs)
   where
-    checkBlobRefType _ (BlobRef (ref :: Internal.WeakBlobRef m (FS.Handle h')))
-      | Just Refl <- eqT @(FS.Handle h) @(FS.Handle h') = ref
+    checkBlobRefType _ (BlobRef (ref :: Internal.WeakBlobRef m h'))
+      | Just Refl <- eqT @h @h' = ref
     checkBlobRefType i _ = throw (Internal.ErrBlobRefInvalid i)
 
 {-------------------------------------------------------------------------------

--- a/test/Test/Database/LSMTree/Internal.hs
+++ b/test/Test/Database/LSMTree/Internal.hs
@@ -195,7 +195,7 @@ prop_interimOpenTable dat = ioProperty $
     conf = testTableConfig
 
     fetchBlobs :: FS.HasFS IO h
-               ->    (V.Vector (Maybe (Entry v (WeakBlobRef IO (FS.Handle h)))))
+               ->    (V.Vector (Maybe (Entry v (WeakBlobRef IO h))))
                -> IO (V.Vector (Maybe (Entry v SerialisedBlob)))
     fetchBlobs hfs = traverse (traverse (traverse (fetchBlob hfs)))
 
@@ -240,7 +240,7 @@ prop_roundtripCursor lb ub kops = ioProperty $
     conf = testTableConfig
 
     fetchBlobs :: FS.HasFS IO h
-             ->     V.Vector (k, (v, Maybe (WeakBlobRef IO (FS.Handle h))))
+             ->     V.Vector (k, (v, Maybe (WeakBlobRef IO h)))
              -> IO (V.Vector (k, (v, Maybe SerialisedBlob)))
     fetchBlobs hfs = traverse (traverse (traverse (traverse (fetchBlob hfs))))
 
@@ -272,7 +272,7 @@ readCursorUntil ::
   -> Cursor IO h
   -> IO (V.Vector (KeyForIndexCompact,
                    (SerialisedValue,
-                    Maybe (WeakBlobRef IO (FS.Handle h)))))
+                    Maybe (WeakBlobRef IO h))))
 readCursorUntil resolve ub cursor = go V.empty
   where
     chunkSize = 50
@@ -289,5 +289,5 @@ appendSerialisedValue :: ResolveSerialisedValue
 appendSerialisedValue (SerialisedValue x) (SerialisedValue y) =
     SerialisedValue (x <> y)
 
-fetchBlob :: FS.HasFS IO h -> WeakBlobRef IO (FS.Handle h) -> IO SerialisedBlob
+fetchBlob :: FS.HasFS IO h -> WeakBlobRef IO h -> IO SerialisedBlob
 fetchBlob hfs bref = withWeakBlobRef bref (readBlob hfs)

--- a/test/Test/Database/LSMTree/Internal.hs
+++ b/test/Test/Database/LSMTree/Internal.hs
@@ -197,7 +197,7 @@ prop_interimOpenTable dat = ioProperty $
     fetchBlobs :: FS.HasFS IO h
                ->    (V.Vector (Maybe (Entry v (WeakBlobRef IO h))))
                -> IO (V.Vector (Maybe (Entry v SerialisedBlob)))
-    fetchBlobs hfs = traverse (traverse (traverse (fetchBlob hfs)))
+    fetchBlobs hfs = traverse (traverse (traverse (readWeakBlobRef hfs)))
 
     Test.InMemLookupData { runData, lookups = keysToLookup } = dat
     ks = V.map serialiseKey (V.fromList keysToLookup)
@@ -242,7 +242,7 @@ prop_roundtripCursor lb ub kops = ioProperty $
     fetchBlobs :: FS.HasFS IO h
              ->     V.Vector (k, (v, Maybe (WeakBlobRef IO h)))
              -> IO (V.Vector (k, (v, Maybe SerialisedBlob)))
-    fetchBlobs hfs = traverse (traverse (traverse (traverse (fetchBlob hfs))))
+    fetchBlobs hfs = traverse (traverse (traverse (traverse (readWeakBlobRef hfs))))
 
     toOffsetKey = maybe NoOffsetKey (OffsetKey . coerce)
 
@@ -288,6 +288,3 @@ readCursorUntil resolve ub cursor = go V.empty
 appendSerialisedValue :: ResolveSerialisedValue
 appendSerialisedValue (SerialisedValue x) (SerialisedValue y) =
     SerialisedValue (x <> y)
-
-fetchBlob :: FS.HasFS IO h -> WeakBlobRef IO h -> IO SerialisedBlob
-fetchBlob hfs bref = withWeakBlobRef bref (readBlob hfs)

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -323,7 +323,7 @@ prop_roundtripFromWriteBufferLookupIO (SmallList dats) =
     resolveV = \(SerialisedValue v1) (SerialisedValue v2) -> SerialisedValue (v1 <> v2)
 
     fetchBlobs :: FS.HasFS IO h
-               ->    (V.Vector (Maybe (Entry v (WeakBlobRef IO (FS.Handle h)))))
+               ->    (V.Vector (Maybe (Entry v (WeakBlobRef IO h))))
                -> IO (V.Vector (Maybe (Entry v SerialisedBlob)))
     fetchBlobs hfs = traverse (traverse (traverse fetchBlob))
       where

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -44,8 +44,7 @@ import           Database.LSMTree.Extras.Generators
 import           Database.LSMTree.Extras.RunData (RunData (..),
                      liftArbitrary2Map, liftShrink2Map,
                      unsafeFlushAsWriteBuffer)
-import           Database.LSMTree.Internal.BlobRef (BlobSpan, WeakBlobRef,
-                     readBlob, withWeakBlobRef)
+import           Database.LSMTree.Internal.BlobRef
 import           Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.IndexCompact as Index
 import           Database.LSMTree.Internal.Lookup
@@ -325,9 +324,7 @@ prop_roundtripFromWriteBufferLookupIO (SmallList dats) =
     fetchBlobs :: FS.HasFS IO h
                ->    (V.Vector (Maybe (Entry v (WeakBlobRef IO h))))
                -> IO (V.Vector (Maybe (Entry v SerialisedBlob)))
-    fetchBlobs hfs = traverse (traverse (traverse fetchBlob))
-      where
-        fetchBlob bref = withWeakBlobRef bref (readBlob hfs)
+    fetchBlobs hfs = traverse (traverse (traverse (readWeakBlobRef hfs)))
 
 -- | Given a bunch of 'InMemLookupData', prepare the data into the form needed
 -- for 'lookupsIO': a write buffer (and blobs) and a vector of on-disk runs.

--- a/test/Test/Database/LSMTree/Internal/Merge.hs
+++ b/test/Test/Database/LSMTree/Internal/Merge.hs
@@ -12,6 +12,7 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Extras
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact)
 import           Database.LSMTree.Extras.RunData
+import qualified Database.LSMTree.Internal.BlobFile as BlobFile
 import qualified Database.LSMTree.Internal.Entry as Entry
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.PageAcc (entryWouldFitInPage)
@@ -73,9 +74,9 @@ prop_MergeDistributes fs hbio level stepSize (SmallList rds) =
       withRun fs hbio (simplePath 1) (RunData $ mergeWriteBuffers level $ fmap unRunData rds') $ \rhs -> do
 
         lhsKOpsFile <- FS.hGetAll fs (Run.runKOpsFile lhs)
-        lhsBlobFile <- FS.hGetAll fs (Run.runBlobFile lhs)
+        lhsBlobFile <- FS.hGetAll fs (BlobFile.blobFileHandle (Run.runBlobFile lhs))
         rhsKOpsFile <- FS.hGetAll fs (Run.runKOpsFile rhs)
-        rhsBlobFile <- FS.hGetAll fs (Run.runBlobFile rhs)
+        rhsBlobFile <- FS.hGetAll fs (BlobFile.blobFileHandle (Run.runBlobFile rhs))
 
         lhsKOps <- readKOps Nothing lhs
         rhsKOps <- readKOps Nothing rhs

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -25,6 +25,7 @@ import           Test.Tasty.QuickCheck
 import           Control.RefCount (RefCount (..), readRefCount)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..))
 import           Database.LSMTree.Extras.RunData
+import           Database.LSMTree.Internal.BlobFile (BlobFile (..))
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
@@ -195,8 +196,8 @@ prop_WriteAndOpen fs hbio wb =
         (FS.handlePath (runKOpsFile written))
         (FS.handlePath (runKOpsFile loaded))
       assertEqual "blob file"
-        (FS.handlePath (runBlobFile written))
-        (FS.handlePath (runBlobFile loaded))
+        (FS.handlePath (blobFileHandle (runBlobFile written)))
+        (FS.handlePath (blobFileHandle (runBlobFile loaded)))
 
       -- make sure runs get closed again
       removeReference loaded

--- a/test/Test/Database/LSMTree/Internal/RunReader.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReader.hs
@@ -9,7 +9,7 @@ import           Data.Coerce (coerce)
 import qualified Data.Map as Map
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..))
 import           Database.LSMTree.Extras.RunData
-import           Database.LSMTree.Internal.BlobRef (readBlob)
+import           Database.LSMTree.Internal.BlobRef
 import           Database.LSMTree.Internal.Entry (Entry)
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.RunReader as Reader
@@ -179,6 +179,6 @@ readKOps offset run = do
         Reader.Empty -> return []
         Reader.ReadEntry key e -> do
           let fs = Reader.readerHasFS reader
-          e' <- traverse (readBlob fs) $ Reader.toFullEntry e
+          e' <- traverse (readRawBlobRef fs) $ Reader.toFullEntry e
           ((key, e') :) <$> go reader
 

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -18,7 +18,7 @@ import           Data.Word (Word64)
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact (..))
 import           Database.LSMTree.Extras.RunData
-import           Database.LSMTree.Internal.BlobRef (readBlob)
+import           Database.LSMTree.Internal.BlobRef
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Paths as Paths
 import qualified Database.LSMTree.Internal.Run as Run
@@ -391,4 +391,4 @@ runIO act lu = case act of
                   return (Right x)
 
     toMockEntry :: FS.HasFS IO MockFS.HandleMock -> Reader.Entry IO MockFS.HandleMock -> IO SerialisedEntry
-    toMockEntry hfs = traverse (readBlob hfs) . Reader.toFullEntry
+    toMockEntry hfs = traverse (readRawBlobRef hfs) . Reader.toFullEntry

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -390,5 +390,5 @@ runIO act lu = case act of
                   put (RealState n Nothing)
                   return (Right x)
 
-    toMockEntry :: FS.HasFS IO MockFS.HandleMock -> Reader.Entry IO (FS.Handle MockFS.HandleMock) -> IO SerialisedEntry
+    toMockEntry :: FS.HasFS IO MockFS.HandleMock -> Reader.Entry IO MockFS.HandleMock -> IO SerialisedEntry
     toMockEntry hfs = traverse (readBlob hfs) . Reader.toFullEntry


### PR DESCRIPTION
PR designed to be reviewed patch by patch.

Overall, this is a refactoring in preparation for changes to the ref counting API. The ref counting change will be about making things follow a model of there being singular references, rather than manipulating raw reference counts. This changes the BlobRef representation so that it follows this style: it now holds a reference to a BlobFile (which is itself a reference counted object). Previously it was more ad-hoc. Also more cleanly separate three kinds of reference: raw, weak and strong.