### PR TITLE
Separate utilities related to pages

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -21,9 +21,9 @@ import           Database.LSMTree.Extras.Random (frequency,
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry (Entry (..), unNumEntries)
-import           Database.LSMTree.Internal.IndexCompact (getNumPages)
 import           Database.LSMTree.Internal.Lookup (bloomQueries, indexSearches,
                      intraPageLookups, lookupsIO, prepLookups)
+import           Database.LSMTree.Internal.Page (getNumPages)
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -135,6 +135,7 @@ library
     Database.LSMTree.Internal.Lookup
     Database.LSMTree.Internal.Merge
     Database.LSMTree.Internal.MergeSchedule
+    Database.LSMTree.Internal.Page
     Database.LSMTree.Internal.PageAcc
     Database.LSMTree.Internal.PageAcc1
     Database.LSMTree.Internal.Paths

--- a/src-extras/Database/LSMTree/Extras/Generators.hs
+++ b/src-extras/Database/LSMTree/Extras/Generators.hs
@@ -51,9 +51,9 @@ import           Database.LSMTree.Extras
 import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
-import           Database.LSMTree.Internal.IndexCompact (PageNo (..))
 import           Database.LSMTree.Internal.IndexCompactAcc (Append (..))
 import qualified Database.LSMTree.Internal.Merge as Merge
+import           Database.LSMTree.Internal.Page (PageNo (..))
 import           Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Serialise
 import qualified Database.LSMTree.Internal.Serialise.Class as S.Class

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -43,6 +43,7 @@ import           Database.LSMTree.Internal.IndexCompactAcc
 import           Database.LSMTree.Internal.Merge hiding (Level)
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule
+import           Database.LSMTree.Internal.Page
 import           Database.LSMTree.Internal.PageAcc
 import           Database.LSMTree.Internal.Paths
 import           Database.LSMTree.Internal.RawBytes

--- a/src/Database/LSMTree/Internal/IndexCompact.hs
+++ b/src/Database/LSMTree/Internal/IndexCompact.hs
@@ -5,15 +5,7 @@
 module Database.LSMTree.Internal.IndexCompact (
     -- $compact
     IndexCompact (..)
-  , PageNo (..)
-  , nextPageNo
-  , NumPages
-  , getNumPages
     -- * Queries
-  , PageSpan (..)
-  , singlePage
-  , multiPage
-  , pageSpanSize
   , search
   , countClashes
   , hasClashes
@@ -57,6 +49,7 @@ import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.ByteString (byteArrayFromTo,
                      byteArrayToByteString)
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
+import           Database.LSMTree.Internal.Page
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.Unsliced
 import           Database.LSMTree.Internal.Vector
@@ -382,59 +375,9 @@ instance NFData IndexCompact where
   rnf ic = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
     where IndexCompact a b c d = ic
 
--- | A 0-based number identifying a disk page.
-newtype PageNo = PageNo { unPageNo :: Int }
-  deriving stock (Show, Eq, Ord)
-  deriving newtype NFData
-
--- | Increment the page number.
---
--- Note: This does not encure that the incremented page number exists within a given page span.
-{-# INLINE nextPageNo #-}
-nextPageNo :: PageNo -> PageNo
-nextPageNo = PageNo . succ . unPageNo
-
--- | The number of pages contained by an index or other paging data-structure.
---
--- Note: This is a 0-based number; take care to ensure arithmetic underflow
--- does not occur during subtraction operations!
-newtype NumPages = NumPages Word
-  deriving stock (Eq, Ord, Show)
-  deriving newtype (NFData)
-
--- | A type-safe "unwrapper" for 'NumPages'. Use this accessor whenever you want
--- to convert 'NumPages' to a more versatile number type.
-{-# INLINE getNumPages #-}
-getNumPages :: Integral i => NumPages -> i
-getNumPages (NumPages w) = fromIntegral w
-
 {-------------------------------------------------------------------------------
   Queries
 -------------------------------------------------------------------------------}
-
--- | A span of pages, representing an inclusive interval of page numbers.
---
--- Typlically used to denote the contiguous page span for a database entry.
-data PageSpan = PageSpan {
-    pageSpanStart :: {-# UNPACK #-} !PageNo
-  , pageSpanEnd   :: {-# UNPACK #-} !PageNo
-  }
-  deriving stock (Show, Eq)
-
-instance NFData PageSpan where
-  rnf (PageSpan x y) = rnf x `seq` rnf y
-
-{-# INLINE singlePage #-}
-singlePage :: PageNo -> PageSpan
-singlePage i = PageSpan i i
-
-{-# INLINE multiPage #-}
-multiPage :: PageNo -> PageNo -> PageSpan
-multiPage i j = PageSpan i j
-
-pageSpanSize :: PageSpan -> NumPages
-pageSpanSize pspan = NumPages . toEnum $
-    unPageNo (pageSpanEnd pspan) - unPageNo (pageSpanStart pspan) + 1
 
 -- |  Searches for a page span that contains a key–value pair with the given key.
 --

--- a/src/Database/LSMTree/Internal/IndexCompactAcc.hs
+++ b/src/Database/LSMTree/Internal/IndexCompactAcc.hs
@@ -13,7 +13,6 @@ module Database.LSMTree.Internal.IndexCompactAcc (
     -- * Construction
     -- $construction-invariants
     IndexCompactAcc (..)
-  , PageNo (..)
   , new
   , Append (..)
   , Chunk (..)
@@ -51,6 +50,7 @@ import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word
 import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.IndexCompact
+import           Database.LSMTree.Internal.Page
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.Unsliced
 

--- a/src/Database/LSMTree/Internal/IndexOrdinary.hs
+++ b/src/Database/LSMTree/Internal/IndexOrdinary.hs
@@ -28,7 +28,7 @@ import qualified Data.Vector.Primitive as Primitive (Vector (Vector), drop,
                      force, length, null, splitAt, take)
 import           Data.Word (Word16, Word32, Word64, Word8, byteSwap32)
 import           Database.LSMTree.Internal.Entry (NumEntries (NumEntries))
-import           Database.LSMTree.Internal.IndexCompact (PageNo (PageNo),
+import           Database.LSMTree.Internal.Page (PageNo (PageNo),
                      PageSpan (PageSpan))
 import           Database.LSMTree.Internal.Serialise
                      (SerialisedKey (SerialisedKey'))

--- a/src/Database/LSMTree/Internal/Page.hs
+++ b/src/Database/LSMTree/Internal/Page.hs
@@ -1,0 +1,64 @@
+-- | Utilities related to pages.
+module Database.LSMTree.Internal.Page (
+    PageNo (..)
+  , nextPageNo
+  , NumPages (..)
+  , getNumPages
+  , PageSpan (..)
+  , singlePage
+  , multiPage
+  , pageSpanSize
+  ) where
+
+import           Control.DeepSeq (NFData (..))
+
+-- | A 0-based number identifying a disk page.
+newtype PageNo = PageNo { unPageNo :: Int }
+  deriving stock (Show, Eq, Ord)
+  deriving newtype NFData
+
+-- | Increment the page number.
+--
+-- Note: This does not ensure that the incremented page number exists within a given page span.
+{-# INLINE nextPageNo #-}
+nextPageNo :: PageNo -> PageNo
+nextPageNo = PageNo . succ . unPageNo
+
+-- | The number of pages contained by an index or other paging data-structure.
+--
+-- Note: This is a 0-based number; take care to ensure arithmetic underflow
+-- does not occur during subtraction operations!
+newtype NumPages = NumPages Word
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (NFData)
+
+-- | A type-safe "unwrapper" for 'NumPages'. Use this accessor whenever you want
+-- to convert 'NumPages' to a more versatile number type.
+{-# INLINE getNumPages #-}
+getNumPages :: Integral i => NumPages -> i
+getNumPages (NumPages w) = fromIntegral w
+
+-- | A span of pages, representing an inclusive interval of page numbers.
+--
+-- Typlically used to denote the contiguous page span for a database entry.
+data PageSpan = PageSpan {
+    pageSpanStart :: {-# UNPACK #-} !PageNo
+  , pageSpanEnd   :: {-# UNPACK #-} !PageNo
+  }
+  deriving stock (Show, Eq)
+
+instance NFData PageSpan where
+  rnf (PageSpan x y) = rnf x `seq` rnf y
+
+{-# INLINE singlePage #-}
+singlePage :: PageNo -> PageSpan
+singlePage i = PageSpan i i
+
+{-# INLINE multiPage #-}
+multiPage :: PageNo -> PageNo -> PageSpan
+multiPage i j = PageSpan i j
+
+{-# INLINE pageSpanSize #-}
+pageSpanSize :: PageSpan -> NumPages
+pageSpanSize pspan = NumPages . toEnum $
+    unPageNo (pageSpanEnd pspan) - unPageNo (pageSpanStart pspan) + 1

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -70,8 +70,9 @@ import           Database.LSMTree.Internal.BlobRef (BlobRef (..), BlobSpan (..))
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterFromSBS)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact, NumPages)
+import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
 import qualified Database.LSMTree.Internal.IndexCompact as Index
+import           Database.LSMTree.Internal.Page (NumPages)
 import           Database.LSMTree.Internal.Paths
 import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc)
 import           Database.LSMTree.Internal.RunBuilder (RunBuilder)

--- a/test/Test/Database/LSMTree/Internal/IndexCompact.hs
+++ b/test/Test/Database/LSMTree/Internal/IndexCompact.hs
@@ -32,6 +32,8 @@ import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import           Database.LSMTree.Internal.IndexCompact as Index
 import           Database.LSMTree.Internal.IndexCompactAcc as Cons
+import           Database.LSMTree.Internal.Page (PageNo (PageNo), PageSpan,
+                     multiPage, singlePage)
 import           Database.LSMTree.Internal.Serialise
 import           Numeric (showHex)
 import           Prelude hiding (max, min, pi)

--- a/test/Test/Database/LSMTree/Internal/IndexOrdinary.hs
+++ b/test/Test/Database/LSMTree/Internal/IndexOrdinary.hs
@@ -27,8 +27,6 @@ import           Database.LSMTree.Extras.Generators (LogicalPageSummaries,
                      toAppends)
 import           Database.LSMTree.Internal.Chunk (fromChunk)
 import           Database.LSMTree.Internal.Entry (NumEntries (NumEntries))
-import           Database.LSMTree.Internal.IndexCompact (PageNo (PageNo),
-                     PageSpan (PageSpan))
 import           Database.LSMTree.Internal.IndexCompactAcc
                      (Append (AppendMultiPage, AppendSinglePage))
 import           Database.LSMTree.Internal.IndexOrdinary
@@ -36,6 +34,8 @@ import           Database.LSMTree.Internal.IndexOrdinary
                      toLastKeys)
 import           Database.LSMTree.Internal.IndexOrdinaryAcc (append, new,
                      unsafeEnd)
+import           Database.LSMTree.Internal.Page (PageNo (PageNo),
+                     PageSpan (PageSpan))
 import           Database.LSMTree.Internal.Serialise
                      (SerialisedKey (SerialisedKey'))
 import           Database.LSMTree.Internal.Vector (byteVectorFromPrim)

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -49,6 +49,7 @@ import           Database.LSMTree.Internal.BlobRef (BlobSpan, WeakBlobRef,
 import           Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.IndexCompact as Index
 import           Database.LSMTree.Internal.Lookup
+import           Database.LSMTree.Internal.Page (PageNo (PageNo), PageSpan (..))
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.RawOverflowPage

--- a/test/Test/Database/LSMTree/Internal/RunAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/RunAcc.hs
@@ -16,6 +16,7 @@ import qualified Data.Vector.Primitive as VP
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.IndexCompact as Index
+import           Database.LSMTree.Internal.Page (PageNo (PageNo), singlePage)
 import qualified Database.LSMTree.Internal.PageAcc as PageAcc
 import qualified Database.LSMTree.Internal.PageAcc1 as PageAcc
 import qualified Database.LSMTree.Internal.RawBytes as RB
@@ -63,7 +64,7 @@ test_singleKeyRun =  do
     Just (fst (PageAcc.singletonPage k e)) @=? mp
     isJust mc @? "expected a chunk"
     True @=? Bloom.elem k b
-    Index.singlePage (Index.PageNo 0) @=? Index.search k ic
+    singlePage (PageNo 0) @=? Index.search k ic
 
 {-------------------------------------------------------------------------------
   PageAcc


### PR DESCRIPTION
This pull request moves `PageNo`, `NumPages`, and `PageSpan` along with the operations associated with them out of `Database.LSMTree.Internal.IndexCompact` and into a new, dedicated module. The reason for this change is that those things are not specific to the compact index, not even to indexes at all. This pull request is not least part of the preparations for making index types selectable.
