### PR TITLE
Infrastructure for hard linking run files in the snapshot directory

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1117,7 +1117,7 @@ createSnapshot resolve snap label tableType t = do
       -- point, we'll take that loss, as the inner state of the table is still
       -- consistent.
 
-      snappedLevels <- snapLevels (tableLevels content)
+      snappedLevels <- snapLevels snapDir (tableLevels content)
       let snapMetaData = SnapshotMetaData label tableType (tableConfig t) snappedLevels
           SnapshotMetaDataFile contentPath = Paths.snapshotMetaDataFile snapDir
           SnapshotMetaDataChecksumFile checksumPath = Paths.snapshotMetaDataChecksumFile snapDir


### PR DESCRIPTION
Currently, the temporary snapshot implementation relies on the fact that files are never deleted, such that a snapshot metadata file can reference these files. The proper way we plan to implement snapshots is to create hard links for run files in the snapshot directory, so that we can safely remove runs and their files from the active directory. This commit provides the infrastructure for hard linking run files into the snapshot directory. The actual hard link function is emulated by copying file contents, since the functionality to create hard links has not landed in the `HasBlockIO` interface just yet. It should be relatively simple switch from emulated hard links to proper hard links

Note that these "hard linked" files are not used for anything yet, not even snapshot `open`
