### PR TITLE
Make the different index types use a common chunk type

### DIFF
--- a/src/Database/LSMTree/Internal/Chunk.hs
+++ b/src/Database/LSMTree/Internal/Chunk.hs
@@ -5,7 +5,8 @@ module Database.LSMTree.Internal.Chunk
 (
     -- * Chunks
     Chunk (Chunk),
-    fromChunk,
+    toByteVector,
+    toByteString,
 
     -- * Balers
     Baler,
@@ -19,23 +20,31 @@ import           Prelude hiding (length)
 
 import           Control.Exception (assert)
 import           Control.Monad.ST.Strict (ST)
+import           Data.ByteString (ByteString)
 import           Data.List (scanl')
 import           Data.Primitive.PrimVar (PrimVar, newPrimVar, readPrimVar,
                      writePrimVar)
-import           Data.Vector.Primitive (Vector, length, unsafeCopy,
+import           Data.Vector.Primitive (Vector (Vector), length, unsafeCopy,
                      unsafeFreeze)
 import           Data.Vector.Primitive.Mutable (MVector)
 import qualified Data.Vector.Primitive.Mutable as Mutable (drop, length, slice,
                      take, unsafeCopy, unsafeNew)
 import           Data.Word (Word8)
+import           Database.LSMTree.Internal.ByteString (byteArrayToByteString)
 
 -- * Chunks
 
 -- | A chunk of bytes, typically output during incremental index serialisation.
-newtype Chunk = Chunk (Vector Word8)
+newtype Chunk = Chunk (Vector Word8) deriving stock (Eq, Show)
 
-fromChunk :: Chunk -> Vector Word8
-fromChunk (Chunk content) = content
+-- | Yields the contents of a chunk as a byte vector.
+toByteVector :: Chunk -> Vector Word8
+toByteVector (Chunk byteVector) = byteVector
+
+-- | Yields the contents of a chunk as a (strict) byte string.
+toByteString :: Chunk -> ByteString
+toByteString (Chunk (Vector vecOffset vecLength byteArray))
+    = byteArrayToByteString vecOffset vecLength byteArray
 
 -- * Balers
 

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -25,6 +25,8 @@ import           Data.Word (Word64)
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..), RawBlobRef)
 import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterToLBS)
+import           Database.LSMTree.Internal.Chunk (Chunk)
+import qualified Database.LSMTree.Internal.Chunk as Chunk (toByteString)
 import           Database.LSMTree.Internal.CRC32C (CRC32C)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
@@ -313,16 +315,16 @@ writeIndexHeader RunBuilder {..} =
 
 {-# SPECIALISE writeIndexChunk ::
      RunBuilder IO h
-  -> Index.Chunk
+  -> Chunk
   -> IO () #-}
 writeIndexChunk ::
      (MonadSTM m, PrimMonad m)
   => RunBuilder m h
-  -> Index.Chunk
+  -> Chunk
   -> m ()
 writeIndexChunk RunBuilder {..} chunk =
     writeToHandle runBuilderHasFS (forRunIndex runBuilderHandles) $
-      BSL.fromStrict $ Index.chunkToBS chunk
+      BSL.fromStrict $ Chunk.toByteString chunk
 
 {-# SPECIALISE writeIndexFinal ::
      RunBuilder IO h

--- a/test/Test/Database/LSMTree/Internal/IndexOrdinary.hs
+++ b/test/Test/Database/LSMTree/Internal/IndexOrdinary.hs
@@ -25,7 +25,7 @@ import qualified Data.Vector.Primitive as Primitive (Vector (Vector), concat,
 import           Data.Word (Word16, Word32, Word64, Word8)
 import           Database.LSMTree.Extras.Generators (LogicalPageSummaries,
                      toAppends)
-import           Database.LSMTree.Internal.Chunk (fromChunk)
+import qualified Database.LSMTree.Internal.Chunk as Chunk (toByteVector)
 import           Database.LSMTree.Internal.Entry (NumEntries (NumEntries))
 import           Database.LSMTree.Internal.IndexCompactAcc
                      (Append (AppendMultiPage, AppendSinglePage))
@@ -264,8 +264,9 @@ incrementalConstruction appends = runST $ do
     let
 
         serialised :: Primitive.Vector Word8
-        serialised = Primitive.concat $
-                     fromChunk <$> catMaybes (commonChunks ++ [remnant])
+        serialised = Primitive.concat                      $
+                     map Chunk.toByteVector                $
+                     catMaybes (commonChunks ++ [remnant])
 
     return (unserialised, serialised)
     where


### PR DESCRIPTION
This pull request makes the compact index use the `Chunk` type defined in `Database.LSMTree.Internal.Chunk`, which the ordinary index is already using. This paves the way to a common interface for both the ordinary and the compact index.
