### PR TITLE
Adding support for GHC-9.12 based on the alpha release

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.4.8", "9.6.4", "9.8.2", "9.10.1"]
+        # TODO: Change "9.12.0.20241031" --> "9.12.1" after official release
+        ghc: ["8.10.7", "9.2.8", "9.4.8", "9.6.4", "9.8.2", "9.10.1", "9.12.0.20241031"]
         cabal: ["3.10.2.1"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         cabal-flags: [""]
@@ -67,6 +68,8 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
         cabal-update: true
+        # TODO: remove once 9.12.1 is officially released
+        ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml
 
     - name: Install liburing (on Linux)
       id: setup-liburing

--- a/cabal.project.debug
+++ b/cabal.project.debug
@@ -26,3 +26,4 @@ if impl(ghc >=9.4.6 && <9.5 || >=9.6.3)
 
   package fs-sim
     ghc-options: -fcheck-prim-bounds
+

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -26,3 +26,6 @@ source-repository-package
   type: git
   location: https://github.com/well-typed/quickcheck-lockstep.git
   tag: 1852cf87a76dc48c71aa0d9fda3fdc7c8b965011
+
+if impl(ghc >=9.12)
+  allow-newer: base

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -13,7 +13,7 @@ build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 extra-source-files: README.md
 tested-with:
-  GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10
+  GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
 
 source-repository head
   type:     git
@@ -166,7 +166,7 @@ library
     Database.LSMTree.Normal
 
   build-depends:
-    , base                    >=4.14      && <4.21
+    , base                    >=4.14      && <4.22
     , bitvec                  ^>=1.1
     , bytestring              ^>=0.11.4.0 || ^>=0.12.1.0
     , cborg                   ^>=0.2.10.0
@@ -311,7 +311,7 @@ library extras
     Database.LSMTree.Extras.UTxO
 
   build-depends:
-    , base                    >=4.14 && <4.21
+    , base                    >=4.14 && <4.22
     , bitvec
     , bytestring
     , containers
@@ -640,7 +640,7 @@ test-suite kmerge-test
   hs-source-dirs: test
   main-is:        kmerge-test.hs
   build-depends:
-    , base              >=4.14 && <4.21
+    , base              >=4.14 && <4.22
     , deepseq
     , heaps
     , lsm-tree:kmerge
@@ -659,7 +659,7 @@ benchmark kmerge-bench
   main-is:        kmerge-test.hs
   cpp-options:    -DKMERGE_BENCHMARKS
   build-depends:
-    , base              >=4.14 && <4.21
+    , base              >=4.14 && <4.22
     , deepseq
     , heaps
     , lsm-tree:kmerge
@@ -677,7 +677,7 @@ test-suite map-range-test
   hs-source-dirs: test
   main-is:        map-range-test.hs
   build-depends:
-    , base              >=4.14 && <4.21
+    , base              >=4.14 && <4.22
     , bytestring
     , containers
     , lsm-tree
@@ -738,7 +738,7 @@ library blockio-api
     System.FS.BlockIO.Serial
 
   build-depends:
-    , base        >=4.14  && <4.21
+    , base        >=4.14  && <4.22
     , deepseq     ^>=1.4  || ^>=1.5
     , fs-api      ^>=0.3
     , io-classes  ^>=1.6  || ^>=1.7
@@ -775,7 +775,7 @@ test-suite blockio-api-test
   main-is:        Main.hs
   build-depends:
     , async
-    , base                  >=4.14      && <4.21
+    , base                  >=4.14      && <4.22
     , bytestring
     , fs-api
     , lsm-tree:blockio-api
@@ -795,7 +795,7 @@ library blockio-sim
   hs-source-dirs:  blockio-sim/src
   exposed-modules: System.FS.BlockIO.Sim
   build-depends:
-    , base                   >=4.14 && <4.21
+    , base                   >=4.14 && <4.22
     , bytestring
     , fs-api                 ^>=0.3
     , fs-sim                 ^>=0.3
@@ -810,7 +810,7 @@ test-suite blockio-sim-test
   hs-source-dirs: blockio-sim/test
   main-is:        Main.hs
   build-depends:
-    , base                   >=4.14 && <4.21
+    , base                   >=4.14 && <4.22
     , fs-api
     , fs-sim
     , io-classes:strict-stm
@@ -839,7 +839,7 @@ library control
     Control.TempRegistry
 
   build-depends:
-    , base                    >=4.14 && <4.21
+    , base                    >=4.14 && <4.22
     , containers              ^>=0.6 || ^>=0.7
     , deepseq                 ^>=1.4 || ^>=1.5
     , io-classes              ^>=1.6 || ^>=1.7


### PR DESCRIPTION
# Description

I added support for the new GHC-9.12 based on the current alpha release version. The only changes required were the bumping of version bounds and relaxing upper bound constrains on the `base` package in the project's direct and transitive dependencies. 

