### PR TITLE
Speed up `scripts/format-stylish.sh`

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -511,3 +511,6 @@ language_extensions:
 # We run stylish from the root of the repo which is a project so this flag
 # doesn't apply
 cabal: false
+
+# Return an exit failure on format.
+exit_code: error_on_format

--- a/scripts/format-cabal.sh
+++ b/scripts/format-cabal.sh
@@ -18,6 +18,6 @@ fi
 # Check Cabal files with cabal-fmt
 echo "Formatting Cabal source files with cabal-fmt version ${cabal_fmt_required_version}"
 # shellcheck disable=SC2016
-if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.cabal' | xargs -L 1 sh -c 'echo "$0" && cabal-fmt -i "$0"'; then
+if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.cabal' | xargs -L 1 sh -c 'echo "$0" && cabal-fmt -c "$0" 2>/dev/null || (cabal-fmt -i "$0" && exit 1)'; then
     exit 1
 fi

--- a/scripts/format-stylish.sh
+++ b/scripts/format-stylish.sh
@@ -18,6 +18,6 @@ fi
 # Check Haskell files with stylish-haskell
 echo "Formatting Haskell source files with stylish-haskell version ${stylish_haskell_required_version}"
 # shellcheck disable=SC2016
-if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.hs' | xargs -L 1 sh -c 'echo "$0" && stylish-haskell -i -c .stylish-haskell.yaml "$0"'; then
+if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.hs' | xargs -L 50 stylish-haskell -i -c .stylish-haskell.yaml; then
     exit 1
 fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -22,6 +22,6 @@ if [ ! "${unstaged_cabal_files}" = "" ]; then
 fi
 
 # Run various checks and formatters
-./scripts/check-cabal.sh
-./scripts/format-cabal.sh
-./scripts/format-stylish.sh
+./scripts/check-cabal.sh || exit 1
+./scripts/format-cabal.sh || exit 1
+./scripts/format-stylish.sh || exit 1


### PR DESCRIPTION
Supersedes #461. Turns out Git does not enjoy squashing across merge commits.