### PR TITLE
Move general append utilities into general index module

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/IndexCompact.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/IndexCompact.hs
@@ -22,6 +22,7 @@ import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word
 import           Database.LSMTree.Extras
 import           Database.LSMTree.Extras.Generators
+import           Database.LSMTree.Extras.Index
 import           Database.LSMTree.Extras.Random
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.IndexCompact

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -300,6 +300,7 @@ library extras
   exposed-modules:
     Database.LSMTree.Extras
     Database.LSMTree.Extras.Generators
+    Database.LSMTree.Extras.Index
     Database.LSMTree.Extras.NoThunks
     Database.LSMTree.Extras.Orphans
     Database.LSMTree.Extras.Random

--- a/src-extras/Database/LSMTree/Extras/Generators.hs
+++ b/src-extras/Database/LSMTree/Extras/Generators.hs
@@ -48,10 +48,10 @@ import qualified Data.Vector.Primitive as VP
 import           Data.Word
 import           Database.LSMTree.Common (Range (..))
 import           Database.LSMTree.Extras
+import           Database.LSMTree.Extras.Index (Append (..))
 import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
-import           Database.LSMTree.Internal.IndexCompactAcc (Append (..))
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.Page (PageNo (..))
 import           Database.LSMTree.Internal.RawBytes as RB

--- a/src-extras/Database/LSMTree/Extras/Index.hs
+++ b/src-extras/Database/LSMTree/Extras/Index.hs
@@ -1,0 +1,72 @@
+module Database.LSMTree.Extras.Index
+(
+    Append (AppendSinglePage, AppendMultiPage),
+    append,
+    append'
+)
+where
+
+import           Control.DeepSeq (NFData (rnf))
+import           Control.Monad.ST.Strict (ST)
+import           Data.Foldable (toList)
+import           Data.Word (Word32)
+import           Database.LSMTree.Internal.Chunk (Chunk)
+import           Database.LSMTree.Internal.IndexCompactAcc (IndexCompactAcc)
+import qualified Database.LSMTree.Internal.IndexCompactAcc as IndexCompact
+                     (appendMulti, appendSingle)
+import           Database.LSMTree.Internal.IndexOrdinaryAcc (IndexOrdinaryAcc)
+import qualified Database.LSMTree.Internal.IndexOrdinaryAcc as IndexOrdinary
+                     (appendMulti, appendSingle)
+import           Database.LSMTree.Internal.Serialise (SerialisedKey)
+
+-- | Instruction for appending pages, to be used in conjunction with indexes.
+data Append
+    = {-|
+          Append a single page that fully comprises one or more key–value pairs.
+      -}
+      AppendSinglePage
+          SerialisedKey -- ^ Minimum key
+          SerialisedKey -- ^ Maximum key
+    | {-|
+          Append multiple pages that together comprise a single key–value pair.
+      -}
+      AppendMultiPage
+          SerialisedKey -- ^ Sole key
+          Word32        -- ^ Number of overflow pages
+
+instance NFData Append where
+
+    rnf (AppendSinglePage minKey maxKey)
+        = rnf minKey `seq` rnf maxKey
+    rnf (AppendMultiPage key overflowPageCount)
+        = rnf key `seq` rnf overflowPageCount
+
+{-|
+    Add information about appended pages to an index under incremental
+    construction.
+
+    Internally, 'append' uses 'IndexCompact.appendSingle' and
+    'IndexCompact.appendMulti', and the usage restrictions of those functions
+    apply also here.
+-}
+append :: Append -> IndexCompactAcc s -> ST s [Chunk]
+append instruction indexAcc = case instruction of
+    AppendSinglePage minKey maxKey
+        -> toList <$> IndexCompact.appendSingle (minKey, maxKey) indexAcc
+    AppendMultiPage key overflowPageCount
+        -> IndexCompact.appendMulti (key, overflowPageCount) indexAcc
+
+{-|
+    A variant of 'append' for ordinary indexes, which is only used temporarily
+    until there is a type class of index types.
+
+    Internally, 'append'' uses 'IndexOrdinary.appendSingle' and
+    'IndexOrdinary.appendMulti', and the usage restrictions of those functions
+    apply also here.
+-}
+append' :: Append -> IndexOrdinaryAcc s -> ST s [Chunk]
+append' instruction indexAcc = case instruction of
+    AppendSinglePage minKey maxKey
+        -> toList <$> IndexOrdinary.appendSingle (minKey, maxKey) indexAcc
+    AppendMultiPage key overflowPageCount
+        -> IndexOrdinary.appendMulti (key, overflowPageCount) indexAcc

--- a/test/Test/Database/LSMTree/Internal/IndexCompact.hs
+++ b/test/Test/Database/LSMTree/Internal/IndexCompact.hs
@@ -28,6 +28,7 @@ import qualified Data.Vector.Unboxed.Base as VU
 import           Data.Word
 import           Database.LSMTree.Extras
 import           Database.LSMTree.Extras.Generators as Gen
+import           Database.LSMTree.Extras.Index as Cons (Append (..), append)
 import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.Chunk as Chunk (toByteString)
 import           Database.LSMTree.Internal.Entry (NumEntries (..))


### PR DESCRIPTION
This pull request moves `Append` and `append` out of `Database.LSMTree.Internal.IndexCompact`. The reason is that `Append` is not specific to the compact index and `append` will not be either once the class of index types is introduced. The target of this move is a new module for indexes in general, situated in the `extras` package, as only tests and benchmarks are using `Append` and `append`.
