### PR TITLE
Moves `ChecksumHandle` to its own module

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -511,3 +511,6 @@ language_extensions:
 # We run stylish from the root of the repo which is a project so this flag
 # doesn't apply
 cabal: false
+
+# Return an exit failure on format.
+exit_code: error_on_format

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -699,7 +699,6 @@ library prototypes
     , constraints
     , containers
     , contra-tracer
-    , lsm-tree
     , QuickCheck
     , quickcheck-dynamic
     , quickcheck-lockstep

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -124,6 +124,7 @@ library
     Database.LSMTree.Internal.BloomFilter
     Database.LSMTree.Internal.BloomFilterQuery1
     Database.LSMTree.Internal.ByteString
+    Database.LSMTree.Internal.ChecksumHandle
     Database.LSMTree.Internal.Chunk
     Database.LSMTree.Internal.Config
     Database.LSMTree.Internal.CRC32C

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -689,6 +689,7 @@ library prototypes
   exposed-modules:
     FormatPage
     ScheduledMerges
+    ScheduledMergesTest
     ScheduledMergesTestQLS
 
   build-depends:

--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -19,7 +19,7 @@
 module ScheduledMerges (
     -- * Main API
     LSM,
-    Key, Value, Blob,
+    Key (K), Value (V), resolveValue, Blob (B),
     new,
     LookupResult (..),
     lookup, lookups,
@@ -122,12 +122,20 @@ runSize = Map.size
 bufferSize :: Buffer -> Int
 bufferSize = Map.size
 
-type Op     = Update Value Blob
+type Op = Update Value Blob
 
-type Key    = Int
-type Value  = Int
-type Blob   = Int
+newtype Key = K Int
+  deriving stock (Eq, Ord, Show)
+  deriving newtype Enum
 
+newtype Value  = V Int
+  deriving stock (Eq, Show)
+
+resolveValue :: Value -> Value -> Value
+resolveValue (V x) (V y) = V (x + y)
+
+newtype Blob = B Int
+  deriving stock (Eq, Show)
 
 -- | The size of the 4 tiering runs at each level are allowed to be:
 -- @4^(level-1) < size <= 4^level@
@@ -425,6 +433,7 @@ new = do
 inserts :: Tracer (ST s) Event -> LSM s -> [(Key, Value)] -> ST s ()
 inserts tr lsm kvs = updates tr lsm [ (k, Insert v Nothing) | (k,v) <- kvs ]
 
+-- TODO: support (and test!) blobs
 insert :: Tracer (ST s) Event -> LSM s -> Key -> Value -> ST s ()
 insert tr lsm k v = update tr lsm k (Insert v Nothing)
 

--- a/prototypes/ScheduledMergesTest.hs
+++ b/prototypes/ScheduledMergesTest.hs
@@ -1,12 +1,12 @@
 module ScheduledMergesTest (tests) where
 
-import           Data.Foldable (traverse_)
-import           Data.STRef
 import           Control.Exception
 import           Control.Monad (replicateM_, when)
 import           Control.Monad.ST
 import           Control.Tracer (Tracer (Tracer))
 import qualified Control.Tracer as Tracer
+import           Data.Foldable (traverse_)
+import           Data.STRef
 
 import           ScheduledMerges as LSM
 
@@ -25,7 +25,7 @@ test_regression_empty_run =
     runWithTracer $ \tracer -> do
       stToIO $ do
         lsm <- LSM.new
-        let ins k = LSM.insert tracer lsm (K k) (V 0)
+        let ins k = LSM.insert tracer lsm (K k) (V 0) Nothing
         let del k = LSM.delete tracer lsm (K k)
         -- run 1
         ins 0
@@ -80,7 +80,7 @@ test_merge_again_with_incoming =
     runWithTracer $ \tracer -> do
       stToIO $ do
         lsm <- LSM.new
-        let ins k = LSM.insert tracer lsm (K k) (V 0)
+        let ins k = LSM.insert tracer lsm (K k) (V 0) Nothing
         -- get something to 3rd level (so 2nd level is not levelling)
         -- (needs 5 runs to go to level 2 so the resulting run becomes too big)
         traverse_ ins [101..100+(5*16)]

--- a/prototypes/ScheduledMergesTest.hs
+++ b/prototypes/ScheduledMergesTest.hs
@@ -1,0 +1,168 @@
+module ScheduledMergesTest (tests) where
+
+import           Data.Foldable (traverse_)
+import           Data.STRef
+import           Control.Exception
+import           Control.Monad (replicateM_, when)
+import           Control.Monad.ST
+import           Control.Tracer (Tracer (Tracer))
+import qualified Control.Tracer as Tracer
+
+import           ScheduledMerges as LSM
+
+import           Test.Tasty
+import           Test.Tasty.HUnit (HasCallStack, testCase)
+
+tests :: TestTree
+tests = testGroup "Unit tests"
+    [ testCase "regression_empty_run" test_regression_empty_run
+    , testCase "merge_again_with_incoming" test_merge_again_with_incoming
+    ]
+
+-- | Results in an empty run on level 2.
+test_regression_empty_run :: IO ()
+test_regression_empty_run =
+    runWithTracer $ \tracer -> do
+      stToIO $ do
+        lsm <- LSM.new
+        let ins k = LSM.insert tracer lsm k 0
+        let del k = LSM.delete tracer lsm k
+        -- run 1
+        ins 0
+        ins 1
+        ins 2
+        ins 3
+        -- run 2
+        ins 0
+        ins 1
+        ins 2
+        ins 3
+        -- run 3
+        ins 0
+        ins 1
+        ins 2
+        ins 3
+        -- run 4, deletes all previous elements
+        del 0
+        del 1
+        del 2
+        del 3
+
+        expectShape lsm
+          [ ([], [4,4,4,4])
+          ]
+
+        -- run 5, results in last level merge of run 1-4
+        ins 0
+        ins 1
+        ins 2
+        ins 3
+
+        expectShape lsm
+          [ ([], [4])
+          , ([4,4,4,4], [])
+          ]
+
+        -- finish merge
+        LSM.supply lsm 16
+
+        expectShape lsm
+          [ ([], [4])
+          , ([], [0])
+          ]
+
+-- | Covers the case where a run ends up too small for a level, so it gets
+-- merged again with the next incoming runs.
+-- That 5-way merge gets completed by supplying credits That merge gets
+-- completed by supplying credits and then becomes part of another merge.
+test_merge_again_with_incoming :: IO ()
+test_merge_again_with_incoming =
+    runWithTracer $ \tracer -> do
+      stToIO $ do
+        lsm <- LSM.new
+        let ins k = LSM.insert tracer lsm k 0
+        -- get something to 3rd level (so 2nd level is not levelling)
+        -- (needs 5 runs to go to level 2 so the resulting run becomes too big)
+        traverse_ ins [101..100+(5*16)]
+
+        expectShape lsm  -- not yet arrived at level 3, but will soon
+          [ ([], [4,4,4,4])
+          , ([16,16,16,16], [])
+          ]
+
+        -- get a very small run (4 elements) to 2nd level
+        replicateM_ 4 $
+          traverse_ ins [201..200+4]
+
+        expectShape lsm
+          [ ([], [4,4,4,4])  -- these runs share the same keys
+          , ([4,4,4,4,64], [])
+          ]
+
+        -- get another run to 2nd level, which the small run can be merged with
+        traverse_ ins [301..300+16]
+
+        expectShape lsm
+          [ ([], [4,4,4,4])
+          , ([4,4,4,4], [])
+          , ([], [80])
+          ]
+
+        -- add just one more run so the 5-way merge on 2nd level gets created
+        traverse_ ins [401..400+4]
+
+        expectShape lsm
+          [ ([], [4])
+          , ([4,4,4,4,4], [])
+          , ([], [80])
+          ]
+
+        -- complete the merge (20 entries, but credits get scaled up by 1.25)
+        LSM.supply lsm 16
+
+        expectShape lsm
+          [ ([], [4])
+          , ([], [20])
+          , ([], [80])
+          ]
+
+        -- get 3 more runs to 2nd level, so the 5-way merge completes
+        -- and becomes part of a new merge.
+        -- (actually 4, as runs only move once a fifth run arrives...)
+        traverse_ ins [501..500+(4*16)]
+
+        expectShape lsm
+          [ ([], [4])
+          , ([4,4,4,4], [])
+          , ([16,16,16,20,80], [])
+          ]
+
+-------------------------------------------------------------------------------
+-- tracing and expectations on LSM shape
+--
+
+-- | Provides a tracer and will add the log of traced events to the reported
+-- failure.
+runWithTracer :: (Tracer (ST RealWorld) Event -> IO a) -> IO a
+runWithTracer action = do
+    events <- stToIO $ newSTRef []
+    let tracer = Tracer $ Tracer.emit $ \e -> modifySTRef events (e :)
+    action tracer `catch` \e -> do
+      ev <- reverse <$> stToIO (readSTRef events)
+      throwIO (Traced e ev)
+
+data TracedException = Traced SomeException [Event]
+  deriving stock (Show)
+
+instance Exception TracedException where
+  displayException (Traced e ev) =
+    displayException e <> "\ntrace:\n" <> unlines (map show ev)
+
+expectShape :: HasCallStack => LSM s -> [([Int], [Int])] -> ST s ()
+expectShape lsm expected = do
+    shape <- representationShape <$> dumpRepresentation lsm
+    when (shape == expected) $
+      error $ unlines
+        [ "expected shape: " <> show expected
+        , "actual shape:   " <> show shape
+        ]

--- a/prototypes/ScheduledMergesTest.hs
+++ b/prototypes/ScheduledMergesTest.hs
@@ -25,8 +25,8 @@ test_regression_empty_run =
     runWithTracer $ \tracer -> do
       stToIO $ do
         lsm <- LSM.new
-        let ins k = LSM.insert tracer lsm k 0
-        let del k = LSM.delete tracer lsm k
+        let ins k = LSM.insert tracer lsm (K k) (V 0)
+        let del k = LSM.delete tracer lsm (K k)
         -- run 1
         ins 0
         ins 1
@@ -80,7 +80,7 @@ test_merge_again_with_incoming =
     runWithTracer $ \tracer -> do
       stToIO $ do
         lsm <- LSM.new
-        let ins k = LSM.insert tracer lsm k 0
+        let ins k = LSM.insert tracer lsm (K k) (V 0)
         -- get something to 3rd level (so 2nd level is not levelling)
         -- (needs 5 runs to go to level 2 so the resulting run becomes too big)
         traverse_ ins [101..100+(5*16)]

--- a/prototypes/ScheduledMergesTestQLS.hs
+++ b/prototypes/ScheduledMergesTestQLS.hs
@@ -3,20 +3,12 @@
 module ScheduledMergesTestQLS (tests) where
 
 import           Prelude hiding (lookup)
-
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-
 import           Data.Constraint (Dict (..))
-import           Data.Foldable (traverse_)
 import           Data.Proxy
-import           Data.STRef
-
-import           Control.Exception
-import           Control.Monad (replicateM_, when)
 import           Control.Monad.ST
-import           Control.Tracer (Tracer (Tracer), nullTracer)
-import qualified Control.Tracer as Tracer
+import           Control.Tracer (Tracer, nullTracer)
 
 import           ScheduledMerges as LSM
 
@@ -26,171 +18,14 @@ import           Test.QuickCheck.StateModel.Lockstep hiding (ModelOp)
 import qualified Test.QuickCheck.StateModel.Lockstep.Defaults as Lockstep
 import qualified Test.QuickCheck.StateModel.Lockstep.Run as Lockstep
 import           Test.Tasty
-import           Test.Tasty.HUnit (HasCallStack, testCase)
 import           Test.Tasty.QuickCheck (testProperty)
 
-
--------------------------------------------------------------------------------
--- Tests
---
-
 tests :: TestTree
-tests = testGroup "ScheduledMerges" [
-      testProperty "ScheduledMerges vs model" $ mapSize (*10) prop_LSM  -- still <10s
-    , testCase "regression_empty_run" test_regression_empty_run
-    , testCase "merge_again_with_incoming" test_merge_again_with_incoming
-    ]
+tests =
+    testProperty "ScheduledMerges vs model" $ mapSize (*10) prop_LSM  -- still <10s
 
 prop_LSM :: Actions (Lockstep Model) -> Property
 prop_LSM = Lockstep.runActions (Proxy :: Proxy Model)
-
--- | Results in an empty run on level 2.
-test_regression_empty_run :: IO ()
-test_regression_empty_run =
-    runWithTracer $ \tracer -> do
-      stToIO $ do
-        lsm <- LSM.new
-        let ins k = LSM.insert tracer lsm k 0
-        let del k = LSM.delete tracer lsm k
-        -- run 1
-        ins 0
-        ins 1
-        ins 2
-        ins 3
-        -- run 2
-        ins 0
-        ins 1
-        ins 2
-        ins 3
-        -- run 3
-        ins 0
-        ins 1
-        ins 2
-        ins 3
-        -- run 4, deletes all previous elements
-        del 0
-        del 1
-        del 2
-        del 3
-
-        expectShape lsm
-          [ ([], [4,4,4,4])
-          ]
-
-        -- run 5, results in last level merge of run 1-4
-        ins 0
-        ins 1
-        ins 2
-        ins 3
-
-        expectShape lsm
-          [ ([], [4])
-          , ([4,4,4,4], [])
-          ]
-
-        -- finish merge
-        LSM.supply lsm 16
-
-        expectShape lsm
-          [ ([], [4])
-          , ([], [0])
-          ]
-
--- | Covers the case where a run ends up too small for a level, so it gets
--- merged again with the next incoming runs.
--- That 5-way merge gets completed by supplying credits That merge gets
--- completed by supplying credits and then becomes part of another merge.
-test_merge_again_with_incoming :: IO ()
-test_merge_again_with_incoming =
-    runWithTracer $ \tracer -> do
-      stToIO $ do
-        lsm <- LSM.new
-        let ins k = LSM.insert tracer lsm k 0
-        -- get something to 3rd level (so 2nd level is not levelling)
-        -- (needs 5 runs to go to level 2 so the resulting run becomes too big)
-        traverse_ ins [101..100+(5*16)]
-
-        expectShape lsm  -- not yet arrived at level 3, but will soon
-          [ ([], [4,4,4,4])
-          , ([16,16,16,16], [])
-          ]
-
-        -- get a very small run (4 elements) to 2nd level
-        replicateM_ 4 $
-          traverse_ ins [201..200+4]
-
-        expectShape lsm
-          [ ([], [4,4,4,4])  -- these runs share the same keys
-          , ([4,4,4,4,64], [])
-          ]
-
-        -- get another run to 2nd level, which the small run can be merged with
-        traverse_ ins [301..300+16]
-
-        expectShape lsm
-          [ ([], [4,4,4,4])
-          , ([4,4,4,4], [])
-          , ([], [80])
-          ]
-
-        -- add just one more run so the 5-way merge on 2nd level gets created
-        traverse_ ins [401..400+4]
-
-        expectShape lsm
-          [ ([], [4])
-          , ([4,4,4,4,4], [])
-          , ([], [80])
-          ]
-
-        -- complete the merge (20 entries, but credits get scaled up by 1.25)
-        LSM.supply lsm 16
-
-        expectShape lsm
-          [ ([], [4])
-          , ([], [20])
-          , ([], [80])
-          ]
-
-        -- get 3 more runs to 2nd level, so the 5-way merge completes
-        -- and becomes part of a new merge.
-        -- (actually 4, as runs only move once a fifth run arrives...)
-        traverse_ ins [501..500+(4*16)]
-
-        expectShape lsm
-          [ ([], [4])
-          , ([4,4,4,4], [])
-          , ([16,16,16,20,80], [])
-          ]
-
--------------------------------------------------------------------------------
--- tracing and expectations on LSM shape
---
-
--- | Provides a tracer and will add the log of traced events to the reported
--- failure.
-runWithTracer :: (Tracer (ST RealWorld) Event -> IO a) -> IO a
-runWithTracer action = do
-    events <- stToIO $ newSTRef []
-    let tracer = Tracer $ Tracer.emit $ \e -> modifySTRef events (e :)
-    action tracer `catch` \e -> do
-      ev <- reverse <$> stToIO (readSTRef events)
-      throwIO (Traced e ev)
-
-data TracedException = Traced SomeException [Event]
-  deriving stock (Show)
-
-instance Exception TracedException where
-  displayException (Traced e ev) =
-    displayException e <> "\ntrace:\n" <> unlines (map show ev)
-
-expectShape :: HasCallStack => LSM s -> [([Int], [Int])] -> ST s ()
-expectShape lsm expected = do
-    shape <- representationShape <$> dumpRepresentation lsm
-    when (shape == expected) $
-      error $ unlines
-        [ "expected shape: " <> show expected
-        , "actual shape:   " <> show shape
-        ]
 
 -------------------------------------------------------------------------------
 -- QLS infrastructure
@@ -454,4 +289,3 @@ runModel action ctx m =
 
     lookUpKeyVar :: ModelVar Model Key -> Key
     lookUpKeyVar var = case lookupVar ctx var of MInsert k -> k
-

--- a/prototypes/ScheduledMergesTestQLS.hs
+++ b/prototypes/ScheduledMergesTestQLS.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module ScheduledMergesTestQLS (tests) where
 
 import           Prelude hiding (lookup)
@@ -144,44 +146,44 @@ instance InLockstep Model where
     case findVars ctx (Proxy :: Proxy (LSM RealWorld)) of
       []   -> return (Some ANew)
       vars ->
-        frequency $
-            -- inserts of potentially fresh keys
+        let kvars = findVars ctx (Proxy :: Proxy Key)
+            existingKey = Left <$> elements kvars
+            freshKey = Right <$> arbitrary @Key
+        in frequency $
+          -- inserts of potentially fresh keys
           [ (3, fmap Some $
                   AInsert <$> elements vars
-                          <*> fmap Right arbitrarySizedNatural -- key
-                          <*> arbitrarySizedNatural)           -- value
+                          <*> freshKey
+                          <*> arbitrary @Value)
           ]
-            -- inserts of the same keys as used earlier
+          -- inserts of the same keys as used earlier
        ++ [ (1, fmap Some $
                   AInsert <$> elements vars
-                          <*> fmap Left (elements kvars) -- key var
-                          <*> arbitrarySizedNatural)    -- value
-          | let kvars = findVars ctx (Proxy :: Proxy Key)
-          , not (null kvars)
+                          <*> existingKey
+                          <*> arbitrary @Value)
+          | not (null kvars)
           ]
           -- deletes of arbitrary keys:
        ++ [ (1, fmap Some $
                   ADelete <$> elements vars
-                          <*> fmap Right arbitrarySizedNatural) -- key value
+                          <*> freshKey)
           ]
           -- deletes of the same key as inserted earlier:
        ++ [ (1, fmap Some $
                   ADelete <$> elements vars
-                          <*> fmap Left (elements kvars)) -- key var
-          | let kvars = findVars ctx (Proxy :: Proxy Key)
-          , not (null kvars)
+                          <*> existingKey)
+          | not (null kvars)
           ]
           -- lookup of arbitrary keys:
        ++ [ (1, fmap Some $
                   ALookup <$> elements vars
-                          <*> fmap Right arbitrarySizedNatural) -- key value
+                          <*> freshKey)
           ]
           -- lookup of the same key as inserted earlier:
        ++ [ (3, fmap Some $
                   ALookup <$> elements vars
-                          <*> fmap Left (elements kvars)) -- key var
-          | let kvars = findVars ctx (Proxy :: Proxy Key)
-          , not (null kvars)
+                          <*> existingKey)
+          | not (null kvars)
           ]
        ++ [ (1, fmap Some $
                   ADump <$> elements vars)
@@ -194,13 +196,13 @@ instance InLockstep Model where
     [ Some $ AInsert var (Right k') v' | (k', v') <- shrink (k, v) ]
 
   shrinkWithVars _ctx _model (AInsert var (Left _kv) v) =
-    [ Some $ AInsert var (Right k) v | k <- shrink 100 ]
+    [ Some $ AInsert var (Right k) v | k <- shrink (K 100) ]
 
   shrinkWithVars _ctx _model (ADelete var (Right k)) =
     [ Some $ ADelete var (Right k') | k' <- shrink k ]
 
   shrinkWithVars _ctx _model (ADelete var (Left _kv)) =
-    [ Some $ ADelete var (Right k) | k <- shrink 100 ]
+    [ Some $ ADelete var (Right k) | k <- shrink (K 100) ]
 
   shrinkWithVars _ctx _model _action = []
 
@@ -289,3 +291,19 @@ runModel action ctx m =
 
     lookUpKeyVar :: ModelVar Model Key -> Key
     lookUpKeyVar var = case lookupVar ctx var of MInsert k -> k
+
+-------------------------------------------------------------------------------
+-- Instances
+--
+
+instance Arbitrary Key where
+  arbitrary = K <$> arbitrarySizedNatural
+  shrink (K v) = K <$> shrink v
+
+instance Arbitrary Value where
+  arbitrary = V <$> arbitrarySizedNatural
+  shrink (V v) = V <$> shrink v
+
+instance Arbitrary Blob where
+  arbitrary = B <$> arbitrarySizedNatural
+  shrink (B v) = B <$> shrink v

--- a/scripts/format-cabal.sh
+++ b/scripts/format-cabal.sh
@@ -18,6 +18,6 @@ fi
 # Check Cabal files with cabal-fmt
 echo "Formatting Cabal source files with cabal-fmt version ${cabal_fmt_required_version}"
 # shellcheck disable=SC2016
-if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.cabal' | xargs -L 1 sh -c 'echo "$0" && cabal-fmt -i "$0"'; then
+if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.cabal' | xargs -L 1 sh -c 'echo "$0" && cabal-fmt -c "$0" 2>/dev/null || (cabal-fmt -i "$0" && exit 1)'; then
     exit 1
 fi

--- a/scripts/format-stylish.sh
+++ b/scripts/format-stylish.sh
@@ -18,6 +18,6 @@ fi
 # Check Haskell files with stylish-haskell
 echo "Formatting Haskell source files with stylish-haskell version ${stylish_haskell_required_version}"
 # shellcheck disable=SC2016
-if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.hs' | xargs -L 1 sh -c 'echo "$0" && stylish-haskell -i -c .stylish-haskell.yaml "$0"'; then
+if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.hs' | xargs -L 50 stylish-haskell -i -c .stylish-haskell.yaml; then
     exit 1
 fi

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -22,6 +22,6 @@ if [ ! "${unstaged_cabal_files}" = "" ]; then
 fi
 
 # Run various checks and formatters
-./scripts/check-cabal.sh
-./scripts/format-cabal.sh
-./scripts/format-stylish.sh
+./scripts/check-cabal.sh || exit 1
+./scripts/format-cabal.sh || exit 1
+./scripts/format-stylish.sh || exit 1

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -36,6 +36,7 @@ import           Data.Word
 import           Database.LSMTree.Internal as Internal
 import           Database.LSMTree.Internal.BlobFile
 import           Database.LSMTree.Internal.BlobRef
+import           Database.LSMTree.Internal.ChecksumHandle
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.CRC32C
 import           Database.LSMTree.Internal.Entry

--- a/src/Database/LSMTree/Internal/CRC32C.hs
+++ b/src/Database/LSMTree/Internal/CRC32C.hs
@@ -348,4 +348,3 @@ formatChecksumsFile checksums =
           <> BS.word32HexFixed crc
           <> BS.char8 '\n'
         | (ChecksumsFileName name, CRC32C crc) <- Map.toList checksums ]
-

--- a/src/Database/LSMTree/Internal/ChecksumHandle.hs
+++ b/src/Database/LSMTree/Internal/ChecksumHandle.hs
@@ -1,0 +1,245 @@
+module Database.LSMTree.Internal.ChecksumHandle
+  (
+    -- * Checksum handles
+    -- $checksum-handles
+    ChecksumHandle (..),
+    makeHandle,
+    readChecksum,
+    dropCache,
+    closeHandle,
+    writeToHandle,
+    -- * Specialised writers
+    writeRawPage,
+    writeRawOverflowPages,
+    writeBlob,
+    copyBlob,
+    writeFilter,
+    writeIndexHeader,
+    writeIndexChunk,
+    writeIndexFinal,
+  ) where
+
+import           Control.Monad.Class.MonadSTM (MonadSTM (..))
+import           Control.Monad.Class.MonadThrow (MonadThrow)
+import           Control.Monad.Primitive
+import           Data.BloomFilter (Bloom)
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Primitive.PrimVar
+import           Data.Word (Word64)
+import           Database.LSMTree.Internal.BlobRef (BlobSpan (..), RawBlobRef)
+import qualified Database.LSMTree.Internal.BlobRef as BlobRef
+import           Database.LSMTree.Internal.BloomFilter (bloomFilterToLBS)
+import           Database.LSMTree.Internal.Chunk (Chunk)
+import qualified Database.LSMTree.Internal.Chunk as Chunk (toByteString)
+import           Database.LSMTree.Internal.CRC32C (CRC32C)
+import qualified Database.LSMTree.Internal.CRC32C as CRC
+import           Database.LSMTree.Internal.Entry
+import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
+import qualified Database.LSMTree.Internal.IndexCompact as Index
+import qualified Database.LSMTree.Internal.RawBytes as RB
+import           Database.LSMTree.Internal.RawOverflowPage (RawOverflowPage)
+import qualified Database.LSMTree.Internal.RawOverflowPage as RawOverflowPage
+import           Database.LSMTree.Internal.RawPage (RawPage)
+import qualified Database.LSMTree.Internal.RawPage as RawPage
+import           Database.LSMTree.Internal.Serialise
+import qualified System.FS.API as FS
+import           System.FS.API
+import qualified System.FS.BlockIO.API as FS
+import           System.FS.BlockIO.API (HasBlockIO)
+
+{-------------------------------------------------------------------------------
+  ChecksumHandle
+-------------------------------------------------------------------------------}
+
+{- | $checksum-handles
+A handle ('ChecksumHandle') that maintains a running CRC32 checksum.
+-}
+
+-- | Tracks the checksum of a (write mode) file handle.
+data ChecksumHandle s h = ChecksumHandle !(FS.Handle h) !(PrimVar s CRC32C)
+
+{-# SPECIALISE makeHandle ::
+     HasFS IO h
+  -> FS.FsPath
+  -> IO (ChecksumHandle RealWorld h) #-}
+makeHandle ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> FS.FsPath
+  -> m (ChecksumHandle (PrimState m) h)
+makeHandle fs path =
+    ChecksumHandle
+      <$> FS.hOpen fs path (FS.WriteMode FS.MustBeNew)
+      <*> newPrimVar CRC.initialCRC32C
+
+{-# SPECIALISE readChecksum ::
+     ChecksumHandle RealWorld h
+  -> IO CRC32C #-}
+readChecksum ::
+     PrimMonad m
+  => ChecksumHandle (PrimState m) h
+  -> m CRC32C
+readChecksum (ChecksumHandle _h checksum) = readPrimVar checksum
+
+dropCache :: HasBlockIO m h -> ChecksumHandle (PrimState m) h -> m ()
+dropCache hbio (ChecksumHandle h _) = FS.hDropCacheAll hbio h
+
+closeHandle :: HasFS m h -> ChecksumHandle (PrimState m) h -> m ()
+closeHandle fs (ChecksumHandle h _checksum) = FS.hClose fs h
+
+{-# SPECIALISE writeToHandle ::
+     HasFS IO h
+  -> ChecksumHandle RealWorld h
+  -> BSL.ByteString
+  -> IO () #-}
+writeToHandle ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> ChecksumHandle (PrimState m) h
+  -> BSL.ByteString
+  -> m ()
+writeToHandle fs (ChecksumHandle h checksum) lbs = do
+    crc <- readPrimVar checksum
+    (_, crc') <- CRC.hPutAllChunksCRC32C fs h lbs crc
+    writePrimVar checksum crc'
+
+{-------------------------------------------------------------------------------
+  Specialised Writers for ChecksumHandle
+-------------------------------------------------------------------------------}
+
+{-# SPECIALISE writeRawPage ::
+     HasFS IO (FS.Handle h)
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> RawPage
+  -> IO () #-}
+writeRawPage ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> ChecksumHandle (PrimState m) h
+  -> RawPage
+  -> m ()
+writeRawPage hfs kOpsHandle =
+    writeToHandle hfs kOpsHandle
+  . BSL.fromStrict
+  . RB.unsafePinnedToByteString -- 'RawPage' is guaranteed to be pinned
+  . RawPage.rawPageRawBytes
+
+{-# SPECIALISE writeRawOverflowPages ::
+     HasFS IO (FS.Handle h)
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> [RawOverflowPage]
+  -> IO () #-}
+writeRawOverflowPages ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> ChecksumHandle (PrimState m) h
+  -> [RawOverflowPage]
+  -> m ()
+writeRawOverflowPages hfs kOpsHandle =
+    writeToHandle hfs kOpsHandle
+  . BSL.fromChunks
+  . map (RawOverflowPage.rawOverflowPageToByteString)
+
+{-# SPECIALISE writeBlob ::
+     HasFS IO (FS.Handle h)
+  -> PrimVar (PrimState IO) Word64
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> SerialisedBlob
+  -> IO BlobSpan #-}
+writeBlob ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> PrimVar (PrimState m) Word64
+  -> ChecksumHandle (PrimState m) h
+  -> SerialisedBlob
+  -> m BlobSpan
+writeBlob hfs blobOffset blobHandle blob = do
+    -- NOTE: This is different from BlobFile.writeBlob. This is because BlobFile
+    --  internalises a regular Handle, rather than a ChecksumHandle. These two
+    --  functions cannot be easily unified, because BlobFile.writeBlob permits
+    --  writing blobs to arbitrary positions in the blob file, whereas, by the
+    --  very nature of CRC32 checksums, ChecksumHandle.writeBlob only supports
+    --  sequential writes.
+    let size = sizeofBlob64 blob
+    offset <- readPrimVar blobOffset
+    modifyPrimVar blobOffset (+size)
+    let SerialisedBlob rb = blob
+    let lbs = BSL.fromStrict $ RB.toByteString rb
+    writeToHandle hfs blobHandle lbs
+    return (BlobSpan offset (fromIntegral size))
+
+{-# SPECIALISE copyBlob ::
+     HasFS IO (FS.Handle h)
+  -> PrimVar (PrimState IO) Word64
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> RawBlobRef IO (FS.Handle h)
+  -> IO BlobSpan #-}
+copyBlob ::
+     (MonadSTM m, MonadThrow m, PrimMonad m)
+  => HasFS m h
+  -> PrimVar (PrimState m) Word64
+  -> ChecksumHandle (PrimState m) h
+  -> RawBlobRef m h
+  -> m BlobSpan
+copyBlob hfs blobOffset blobHandle blobref = do
+    blob <- BlobRef.readRawBlobRef hfs blobref
+    writeBlob hfs blobOffset blobHandle blob
+
+{-# SPECIALISE writeFilter ::
+     HasFS IO (FS.Handle h)
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> Bloom SerialisedKey
+  -> IO () #-}
+writeFilter ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> ChecksumHandle (PrimState m) h
+  -> Bloom SerialisedKey
+  -> m ()
+writeFilter hfs filterHandle bf =
+    writeToHandle hfs filterHandle (bloomFilterToLBS bf)
+
+{-# SPECIALISE writeIndexHeader ::
+     HasFS IO (FS.Handle h)
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> IO () #-}
+writeIndexHeader ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> ChecksumHandle (PrimState m) h
+  -> m ()
+writeIndexHeader hfs indexHandle =
+    writeToHandle hfs indexHandle $
+      Index.headerLBS
+
+{-# SPECIALISE writeIndexChunk ::
+     HasFS IO (FS.Handle h)
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> Chunk
+  -> IO () #-}
+writeIndexChunk ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> ChecksumHandle (PrimState m) h
+  -> Chunk
+  -> m ()
+writeIndexChunk hfs indexHandle chunk =
+    writeToHandle hfs indexHandle $
+      BSL.fromStrict $ Chunk.toByteString chunk
+
+{-# SPECIALISE writeIndexFinal ::
+     HasFS IO (FS.Handle h)
+  -> ChecksumHandle (PrimState IO) (FS.Handle h)
+  -> NumEntries
+  -> IndexCompact
+  -> IO () #-}
+writeIndexFinal ::
+     (MonadSTM m, PrimMonad m)
+  => HasFS m h
+  -> ChecksumHandle (PrimState m) h
+  -> NumEntries
+  -> IndexCompact
+  -> m ()
+writeIndexFinal hfs indexHandle numEntries index =
+    writeToHandle hfs indexHandle $
+      Index.finalLBS numEntries index

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -7,8 +7,6 @@ module Database.LSMTree.Internal.RunBuilder (
   , addLargeSerialisedKeyOp
   , unsafeFinalise
   , close
-    -- Internal: exposed for testing
-  , ChecksumHandle (..)
   ) where
 
 import           Control.Monad (when)
@@ -18,26 +16,17 @@ import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadThrow)
 import           Control.Monad.Primitive
 import           Data.BloomFilter (Bloom)
-import qualified Data.ByteString.Lazy as BSL
 import           Data.Foldable (for_, traverse_)
 import           Data.Primitive.PrimVar
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.BlobRef (BlobSpan (..), RawBlobRef)
-import qualified Database.LSMTree.Internal.BlobRef as BlobRef
-import           Database.LSMTree.Internal.BloomFilter (bloomFilterToLBS)
-import           Database.LSMTree.Internal.Chunk (Chunk)
-import qualified Database.LSMTree.Internal.Chunk as Chunk (toByteString)
-import           Database.LSMTree.Internal.CRC32C (CRC32C)
+import           Database.LSMTree.Internal.BlobRef (RawBlobRef)
+import           Database.LSMTree.Internal.ChecksumHandle
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
-import qualified Database.LSMTree.Internal.IndexCompact as Index
 import           Database.LSMTree.Internal.Paths
-import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.RawOverflowPage (RawOverflowPage)
-import qualified Database.LSMTree.Internal.RawOverflowPage as RawOverflowPage
 import           Database.LSMTree.Internal.RawPage (RawPage)
-import qualified Database.LSMTree.Internal.RawPage as RawPage
 import           Database.LSMTree.Internal.RunAcc (RunAcc, RunBloomFilterAlloc)
 import qualified Database.LSMTree.Internal.RunAcc as RunAcc
 import           Database.LSMTree.Internal.Serialise
@@ -95,14 +84,14 @@ new ::
   -> NumEntries  -- ^ an upper bound of the number of entries to be added
   -> RunBloomFilterAlloc
   -> m (RunBuilder m h)
-new fs hbio runBuilderFsPaths numEntries alloc = do
+new hfs hbio runBuilderFsPaths numEntries alloc = do
     runBuilderAcc <- ST.stToIO $ RunAcc.new numEntries alloc
     runBuilderBlobOffset <- newPrimVar 0
 
-    runBuilderHandles <- traverse (makeHandle fs) (pathsForRunFiles runBuilderFsPaths)
+    runBuilderHandles <- traverse (makeHandle hfs) (pathsForRunFiles runBuilderFsPaths)
 
-    let builder = RunBuilder { runBuilderHasFS = fs, runBuilderHasBlockIO = hbio, .. }
-    writeIndexHeader builder
+    let builder = RunBuilder { runBuilderHasFS = hfs, runBuilderHasBlockIO = hbio, .. }
+    writeIndexHeader hfs (forRunIndex runBuilderHandles)
     return builder
 
 {-# SPECIALISE addKeyOp ::
@@ -129,27 +118,27 @@ addKeyOp ::
   -> SerialisedKey
   -> Entry SerialisedValue (RawBlobRef m h)
   -> m ()
-addKeyOp builder@RunBuilder{runBuilderAcc} key op = do
+addKeyOp RunBuilder{..} key op = do
     -- TODO: the fmap entry here reallocates even when there are no blobs.
     -- We need the Entry _ BlobSpan for RunAcc.add{Small,Large}KeyOp
     -- Perhaps pass the optional blob span separately from the Entry.
-    op' <- traverse (copyBlob builder) op
+    op' <- traverse (copyBlob runBuilderHasFS runBuilderBlobOffset (forRunBlob runBuilderHandles)) op
     if RunAcc.entryWouldFitInPage key op'
       then do
         mpagemchunk <- ST.stToIO $ RunAcc.addSmallKeyOp runBuilderAcc key op'
         case mpagemchunk of
           Nothing -> return ()
           Just (page, mchunk) -> do
-            writeRawPage builder page
-            for_ mchunk $ writeIndexChunk builder
+            writeRawPage runBuilderHasFS (forRunKOps runBuilderHandles) page
+            for_ mchunk $ writeIndexChunk runBuilderHasFS (forRunIndex runBuilderHandles)
 
       else do
        (pages, overflowPages, chunks)
          <- ST.stToIO $ RunAcc.addLargeKeyOp runBuilderAcc key op'
        --TODO: consider optimisation: use writev to write all pages in one go
-       for_ pages $ writeRawPage builder
-       writeRawOverflowPages builder overflowPages
-       for_ chunks $ writeIndexChunk builder
+       for_ pages $ writeRawPage runBuilderHasFS (forRunKOps runBuilderHandles)
+       writeRawOverflowPages runBuilderHasFS (forRunKOps runBuilderHandles) overflowPages
+       for_ chunks $ writeIndexChunk runBuilderHasFS (forRunIndex runBuilderHandles)
 
 {-# SPECIALISE addLargeSerialisedKeyOp ::
      RunBuilder IO h
@@ -166,13 +155,13 @@ addLargeSerialisedKeyOp ::
   -> RawPage
   -> [RawOverflowPage]
   -> m ()
-addLargeSerialisedKeyOp builder@RunBuilder{runBuilderAcc} key page overflowPages = do
+addLargeSerialisedKeyOp RunBuilder{..} key page overflowPages = do
     (pages, overflowPages', chunks)
       <- ST.stToIO $
            RunAcc.addLargeSerialisedKeyOp runBuilderAcc key page overflowPages
-    for_ pages $ writeRawPage builder
-    writeRawOverflowPages builder overflowPages'
-    for_ chunks $ writeIndexChunk builder
+    for_ pages $ writeRawPage runBuilderHasFS (forRunKOps runBuilderHandles)
+    writeRawOverflowPages runBuilderHasFS (forRunKOps runBuilderHandles) overflowPages'
+    for_ chunks $ writeIndexChunk runBuilderHasFS (forRunIndex runBuilderHandles)
 
 {-# SPECIALISE unsafeFinalise ::
      Bool
@@ -189,14 +178,14 @@ unsafeFinalise ::
   => Bool -- ^ drop caches
   -> RunBuilder m h
   -> m (HasFS m h, HasBlockIO m h, RunFsPaths, Bloom SerialisedKey, IndexCompact, NumEntries)
-unsafeFinalise dropCaches builder@RunBuilder {..} = do
+unsafeFinalise dropCaches RunBuilder {..} = do
     -- write final bits
     (mPage, mChunk, runFilter, runIndex, numEntries) <-
       ST.stToIO (RunAcc.unsafeFinalise runBuilderAcc)
-    for_ mPage $ writeRawPage builder
-    for_ mChunk $ writeIndexChunk builder
-    writeIndexFinal builder numEntries runIndex
-    writeFilter builder runFilter
+    for_ mPage $ writeRawPage runBuilderHasFS (forRunKOps runBuilderHandles)
+    for_ mChunk $ writeIndexChunk runBuilderHasFS (forRunIndex runBuilderHandles)
+    writeIndexFinal runBuilderHasFS (forRunIndex runBuilderHandles) numEntries runIndex
+    writeFilter runBuilderHasFS (forRunFilter runBuilderHandles) runFilter
     -- write checksums
     checksums <- toChecksumsFile <$> traverse readChecksum runBuilderHandles
     FS.withFile runBuilderHasFS (runChecksumsPath runBuilderFsPaths) (FS.WriteMode FS.MustBeNew) $ \h -> do
@@ -223,172 +212,3 @@ close :: MonadSTM m => RunBuilder m h -> m ()
 close RunBuilder {..} = do
     traverse_ (closeHandle runBuilderHasFS) runBuilderHandles
     traverse_ (FS.removeFile runBuilderHasFS) (pathsForRunFiles runBuilderFsPaths)
-
-{-------------------------------------------------------------------------------
-  Helpers
--------------------------------------------------------------------------------}
-
-{-# SPECIALISE writeRawPage ::
-     RunBuilder IO h
-  -> RawPage
-  -> IO () #-}
-writeRawPage ::
-     (MonadSTM m, PrimMonad m)
-  => RunBuilder m h
-  -> RawPage
-  -> m ()
-writeRawPage RunBuilder {..} =
-    writeToHandle runBuilderHasFS (forRunKOps runBuilderHandles)
-  . BSL.fromStrict
-  . RB.unsafePinnedToByteString -- 'RawPage' is guaranteed to be pinned
-  . RawPage.rawPageRawBytes
-
-{-# SPECIALISE writeRawOverflowPages ::
-     RunBuilder IO h
-  -> [RawOverflowPage]
-  -> IO () #-}
-writeRawOverflowPages ::
-     (MonadSTM m, PrimMonad m)
-  => RunBuilder m h
-  -> [RawOverflowPage]
-  -> m ()
-writeRawOverflowPages RunBuilder {..} =
-    writeToHandle runBuilderHasFS (forRunKOps runBuilderHandles)
-  . BSL.fromChunks
-  . map (RawOverflowPage.rawOverflowPageToByteString)
-
-{-# SPECIALISE writeBlob ::
-     RunBuilder IO (FS.Handle h)
-  -> SerialisedBlob
-  -> IO BlobSpan #-}
-writeBlob ::
-     (MonadSTM m, PrimMonad m)
-  => RunBuilder m h
-  -> SerialisedBlob
-  -> m BlobSpan
-writeBlob RunBuilder{..} blob = do
-    let size = sizeofBlob64 blob
-    offset <- readPrimVar runBuilderBlobOffset
-    modifyPrimVar runBuilderBlobOffset (+size)
-    let SerialisedBlob rb = blob
-    let lbs = BSL.fromStrict $ RB.toByteString rb
-    writeToHandle runBuilderHasFS (forRunBlob runBuilderHandles) lbs
-    return (BlobSpan offset (fromIntegral size))
-
-{-# SPECIALISE copyBlob ::
-     RunBuilder IO h
-  -> RawBlobRef IO h
-  -> IO BlobSpan #-}
-copyBlob ::
-     (MonadSTM m, MonadThrow m, PrimMonad m)
-  => RunBuilder m h
-  -> RawBlobRef m h
-  -> m BlobSpan
-copyBlob builder@RunBuilder {..} blobref = do
-    blob <- BlobRef.readRawBlobRef runBuilderHasFS blobref
-    writeBlob builder blob
-    --TODO: can't easily switch this to use BlobFile.writeBlob because
-    -- RunBuilder currently does everything uniformly with ChecksumHandle.
-
-{-# SPECIALISE writeFilter ::
-     RunBuilder IO h
-  -> Bloom SerialisedKey
-  -> IO () #-}
-writeFilter ::
-     (MonadSTM m, PrimMonad m)
-  => RunBuilder m h
-  -> Bloom SerialisedKey
-  -> m ()
-writeFilter RunBuilder {..} bf =
-    writeToHandle runBuilderHasFS (forRunFilter runBuilderHandles) (bloomFilterToLBS bf)
-
-{-# SPECIALISE writeIndexHeader ::
-     RunBuilder IO h
-  -> IO () #-}
-writeIndexHeader ::
-     (MonadSTM m, PrimMonad m)
-  => RunBuilder m h
-  -> m ()
-writeIndexHeader RunBuilder {..} =
-    writeToHandle runBuilderHasFS (forRunIndex runBuilderHandles) $
-      Index.headerLBS
-
-{-# SPECIALISE writeIndexChunk ::
-     RunBuilder IO h
-  -> Chunk
-  -> IO () #-}
-writeIndexChunk ::
-     (MonadSTM m, PrimMonad m)
-  => RunBuilder m h
-  -> Chunk
-  -> m ()
-writeIndexChunk RunBuilder {..} chunk =
-    writeToHandle runBuilderHasFS (forRunIndex runBuilderHandles) $
-      BSL.fromStrict $ Chunk.toByteString chunk
-
-{-# SPECIALISE writeIndexFinal ::
-     RunBuilder IO h
-  -> NumEntries
-  -> IndexCompact
-  -> IO () #-}
-writeIndexFinal ::
-     (MonadSTM m, PrimMonad m)
-  => RunBuilder m h
-  -> NumEntries
-  -> IndexCompact
-  -> m ()
-writeIndexFinal RunBuilder {..} numEntries index =
-    writeToHandle runBuilderHasFS (forRunIndex runBuilderHandles) $
-      Index.finalLBS numEntries index
-
-{-------------------------------------------------------------------------------
-  ChecksumHandle
--------------------------------------------------------------------------------}
-
--- | Tracks the checksum of a (write mode) file handle.
-data ChecksumHandle s h = ChecksumHandle !(FS.Handle h) !(PrimVar s CRC32C)
-
-{-# SPECIALISE makeHandle ::
-     HasFS IO h
-  -> FS.FsPath
-  -> IO (ChecksumHandle RealWorld h) #-}
-makeHandle ::
-     (MonadSTM m, PrimMonad m)
-  => HasFS m h
-  -> FS.FsPath
-  -> m (ChecksumHandle (PrimState m) h)
-makeHandle fs path =
-    ChecksumHandle
-      <$> FS.hOpen fs path (FS.WriteMode FS.MustBeNew)
-      <*> newPrimVar CRC.initialCRC32C
-
-{-# SPECIALISE readChecksum ::
-     ChecksumHandle RealWorld h
-  -> IO CRC32C #-}
-readChecksum ::
-     PrimMonad m
-  => ChecksumHandle (PrimState m) h
-  -> m CRC32C
-readChecksum (ChecksumHandle _h checksum) = readPrimVar checksum
-
-dropCache :: HasBlockIO m h -> ChecksumHandle (PrimState m) h -> m ()
-dropCache hbio (ChecksumHandle h _) = FS.hDropCacheAll hbio h
-
-closeHandle :: HasFS m h -> ChecksumHandle (PrimState m) h -> m ()
-closeHandle fs (ChecksumHandle h _checksum) = FS.hClose fs h
-
-{-# SPECIALISE writeToHandle ::
-     HasFS IO h
-  -> ChecksumHandle RealWorld h
-  -> BSL.ByteString
-  -> IO () #-}
-writeToHandle ::
-     (MonadSTM m, PrimMonad m)
-  => HasFS m h
-  -> ChecksumHandle (PrimState m) h
-  -> BSL.ByteString
-  -> m ()
-writeToHandle fs (ChecksumHandle h checksum) lbs = do
-    crc <- readPrimVar checksum
-    (_, crc') <- CRC.hPutAllChunksCRC32C fs h lbs crc
-    writePrimVar checksum crc'

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
--- TODO: remove once the API is implemented.
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-
 -- | On disk key-value tables, implemented as Log Structured Merge (LSM) trees.
 --
 -- This module is the API for \"monoidal\" tables, as opposed to \"normal\"
@@ -522,7 +517,7 @@ mupserts t = updates t . fmap (second Mupsert)
 -------------------------------------------------------------------------------}
 
 {-# SPECIALISE createSnapshot ::
-     (SerialiseKey k, SerialiseValue v, ResolveValue v, Common.Labellable (k, v))
+     (ResolveValue v, Common.Labellable (k, v))
   => SnapshotName
   -> Table IO k v
   -> IO () #-}
@@ -550,8 +545,6 @@ mupserts t = updates t . fmap (second Mupsert)
 --
 createSnapshot :: forall m k v.
      ( IOLike m
-     , SerialiseKey k
-     , SerialiseValue v
      , ResolveValue v
      , Common.Labellable (k, v)
      )
@@ -564,7 +557,7 @@ createSnapshot snap (Internal.MonoidalTable t) =
     label = Internal.SnapshotLabel $ Common.makeSnapshotLabel (Proxy @(k, v))
 
 {-# SPECIALISE openSnapshot ::
-     (SerialiseKey k, SerialiseValue v, ResolveValue v, Common.Labellable (k, v))
+     (ResolveValue v, Common.Labellable (k, v))
   => Session IO
   -> Common.TableConfigOverride
   -> SnapshotName
@@ -589,8 +582,6 @@ createSnapshot snap (Internal.MonoidalTable t) =
 -- @
 openSnapshot :: forall m k v.
      ( IOLike m
-     , SerialiseKey k
-     , SerialiseValue v
      , ResolveValue v
      , Common.Labellable (k, v)
      )
@@ -681,7 +672,7 @@ union :: forall m k v.
   => Table m k v
   -> Table m k v
   -> m (Table m k v)
-union = undefined
+union = error "union: not yet implemented" $ union @m @k @v
 
 {-------------------------------------------------------------------------------
   Monoidal value resolution

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
--- TODO: remove once the API is implemented.
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-
 -- | On disk key-value tables, implemented as Log Structured Merge (LSM) trees.
 --
 -- This module is the API for \"normal\" tables, as opposed to \"monoidal\"
@@ -640,11 +635,7 @@ retrieveBlobs (Internal.Session' (sesh :: Internal.Session m h)) refs =
 -------------------------------------------------------------------------------}
 
 {-# SPECIALISE createSnapshot ::
-     ( SerialiseKey k
-     , SerialiseValue v
-     , SerialiseValue blob
-     , Common.Labellable (k, v, blob)
-     )
+     Common.Labellable (k, v, blob)
   => SnapshotName
   -> Table IO k v blob
   -> IO () #-}
@@ -679,9 +670,6 @@ retrieveBlobs (Internal.Session' (sesh :: Internal.Session m h)) refs =
 -- but the original table remains unchanged.
 createSnapshot :: forall m k v blob.
      ( IOLike m
-     , SerialiseKey k
-     , SerialiseValue v
-     , SerialiseValue blob
      , Common.Labellable (k, v, blob)
      )
   => SnapshotName
@@ -693,11 +681,7 @@ createSnapshot snap (Internal.NormalTable t) =
     label = Internal.SnapshotLabel $ Common.makeSnapshotLabel (Proxy @(k, v, blob))
 
 {-# SPECIALISE openSnapshot ::
-     ( SerialiseKey k
-     , SerialiseValue v
-     , SerialiseValue blob
-     , Common.Labellable (k, v, blob)
-     )
+     Common.Labellable (k, v, blob)
   => Session IO
   -> Common.TableConfigOverride
   -> SnapshotName
@@ -725,9 +709,6 @@ createSnapshot snap (Internal.NormalTable t) =
 -- proper snapshots. See 'createSnapshot'.
 openSnapshot :: forall m k v blob.
      ( IOLike m
-     , SerialiseKey k
-     , SerialiseValue v
-     , SerialiseValue blob
      , Common.Labellable (k, v, blob)
      )
   => Session m
@@ -813,4 +794,4 @@ union :: forall m k v blob.
   => Table m k v blob
   -> Table m k v blob
   -> m (Table m k v blob)
-union = undefined
+union = error "union: not yet implemented" $ union @m @k @v

--- a/test/lsm-prototypes-tests.hs
+++ b/test/lsm-prototypes-tests.hs
@@ -3,10 +3,14 @@ module Main (main) where
 import           Test.Tasty
 
 import qualified FormatPage
+import qualified ScheduledMergesTest
 import qualified ScheduledMergesTestQLS
 
 main :: IO ()
 main = defaultMain $ testGroup "prototype" [
-      ScheduledMergesTestQLS.tests,
+      testGroup "ScheduledMerges" [
+        ScheduledMergesTest.tests,
+        ScheduledMergesTestQLS.tests
+      ],
       FormatPage.tests
     ]


### PR DESCRIPTION
This PR:

- Moves `ChecksumHandle` and its core functions to their own module (`Database.LSMTree.Internal.ChecksumHandle`).
- Generalises the helper functions in `RunBuilder` (`writeRawPage`, `writeRawOverflowPages`, `writeBlob`, `copyBlob`, `writeFilter`, `writeIndexHeader`, `writeIndexChunk`, `writeIndexFinal`) to only take the arguments they need, rather than the entire `RunBuilder`.
- Moves those helper functions to the new `ChecksumHandle` module. This enables them to be reused by the `WriteBufferWriter`. (Technically, the latter four are not needed, but it seemed better to generalise and move them for consistency.)