### PR TITLE
Fix haddock in CRC32C

### DIFF
--- a/src/Database/LSMTree/Internal/CRC32C.hs
+++ b/src/Database/LSMTree/Internal/CRC32C.hs
@@ -238,7 +238,7 @@ hGetAllCRC32C' hfs h (ChunkSize !chunkSize) !crc0
           go bs buf crc'
 
 
-{- | $checksum-files
+{- $checksum-files
 We use @.checksum@ files to help verify the integrity of on disk snapshots.
 Each .checksum file lists the CRC-32C (Castagnoli) of other files. For further
 details see @doc/format-directory.md@.
@@ -348,4 +348,3 @@ formatChecksumsFile checksums =
           <> BS.word32HexFixed crc
           <> BS.char8 '\n'
         | (ChecksumsFileName name, CRC32C crc) <- Map.toList checksums ]
-


### PR DESCRIPTION
Just fixing the haddock comment:
```diff
- {- | $checksum-files
+ {- $checksum-files
```