### PR TITLE
Introduce classes for indexes and their accumulators

### DIFF
--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -25,7 +25,7 @@ import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Entry (Entry (Insert),
                      NumEntries (..))
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
+import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
 import           Database.LSMTree.Internal.Lookup
 import           Database.LSMTree.Internal.Paths (RunFsPaths (RunFsPaths))
 import           Database.LSMTree.Internal.Run (Run)

--- a/bench/micro/Bench/Database/LSMTree/Internal/Index/Compact.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Index/Compact.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeApplications   #-}
 {- HLINT ignore "Eta reduce" -}
 
-module Bench.Database.LSMTree.Internal.IndexCompact (
+module Bench.Database.LSMTree.Internal.Index.Compact (
     benchmarks
     -- * Benchmarked functions
   , searches
@@ -25,15 +25,15 @@ import           Database.LSMTree.Extras.Generators
 import           Database.LSMTree.Extras.Index
 import           Database.LSMTree.Extras.Random
 import           Database.LSMTree.Extras.UTxO
-import           Database.LSMTree.Internal.IndexCompact
-import           Database.LSMTree.Internal.IndexCompactAcc
+import           Database.LSMTree.Internal.Index.Compact
+import           Database.LSMTree.Internal.Index.CompactAcc
 import           Database.LSMTree.Internal.Serialise (SerialisedKey,
                      serialiseKey)
 import           System.Random
 import           Test.QuickCheck (generate)
 
 benchmarks :: Benchmark
-benchmarks = bgroup "Bench.Database.LSMTree.Internal.IndexCompact" [
+benchmarks = bgroup "Bench.Database.LSMTree.Internal.Index.Compact" [
       env (searchEnv 10000 1000) $ \ ~(ic, ks) ->
         bench "searches-10-1k" $ whnf (searches ic) ks
     , bgroup "construction" [

--- a/bench/micro/Main.hs
+++ b/bench/micro/Main.hs
@@ -4,7 +4,7 @@
 module Main (main) where
 
 import qualified Bench.Database.LSMTree.Internal.BloomFilter
-import qualified Bench.Database.LSMTree.Internal.IndexCompact
+import qualified Bench.Database.LSMTree.Internal.Index.Compact
 import qualified Bench.Database.LSMTree.Internal.Lookup
 import qualified Bench.Database.LSMTree.Internal.Merge
 import qualified Bench.Database.LSMTree.Internal.RawPage
@@ -21,7 +21,7 @@ main = do
 #endif
     defaultMain [
         Bench.Database.LSMTree.Internal.BloomFilter.benchmarks
-      , Bench.Database.LSMTree.Internal.IndexCompact.benchmarks
+      , Bench.Database.LSMTree.Internal.Index.Compact.benchmarks
       , Bench.Database.LSMTree.Internal.Lookup.benchmarks
       , Bench.Database.LSMTree.Internal.Merge.benchmarks
       , Bench.Database.LSMTree.Internal.RawPage.benchmarks

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -130,10 +130,10 @@ library
     Database.LSMTree.Internal.CRC32C
     Database.LSMTree.Internal.Cursor
     Database.LSMTree.Internal.Entry
-    Database.LSMTree.Internal.IndexCompact
-    Database.LSMTree.Internal.IndexCompactAcc
-    Database.LSMTree.Internal.IndexOrdinary
-    Database.LSMTree.Internal.IndexOrdinaryAcc
+    Database.LSMTree.Internal.Index.Compact
+    Database.LSMTree.Internal.Index.CompactAcc
+    Database.LSMTree.Internal.Index.Ordinary
+    Database.LSMTree.Internal.Index.OrdinaryAcc
     Database.LSMTree.Internal.Lookup
     Database.LSMTree.Internal.Merge
     Database.LSMTree.Internal.MergeSchedule
@@ -356,8 +356,8 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Chunk
     Test.Database.LSMTree.Internal.CRC32C
     Test.Database.LSMTree.Internal.Entry
-    Test.Database.LSMTree.Internal.IndexCompact
-    Test.Database.LSMTree.Internal.IndexOrdinary
+    Test.Database.LSMTree.Internal.Index.Compact
+    Test.Database.LSMTree.Internal.Index.Ordinary
     Test.Database.LSMTree.Internal.Lookup
     Test.Database.LSMTree.Internal.Merge
     Test.Database.LSMTree.Internal.Monkey
@@ -452,7 +452,7 @@ benchmark lsm-tree-micro-bench
   main-is:        Main.hs
   other-modules:
     Bench.Database.LSMTree.Internal.BloomFilter
-    Bench.Database.LSMTree.Internal.IndexCompact
+    Bench.Database.LSMTree.Internal.Index.Compact
     Bench.Database.LSMTree.Internal.Lookup
     Bench.Database.LSMTree.Internal.Merge
     Bench.Database.LSMTree.Internal.RawPage

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -130,6 +130,7 @@ library
     Database.LSMTree.Internal.CRC32C
     Database.LSMTree.Internal.Cursor
     Database.LSMTree.Internal.Entry
+    Database.LSMTree.Internal.Index
     Database.LSMTree.Internal.Index.Compact
     Database.LSMTree.Internal.Index.CompactAcc
     Database.LSMTree.Internal.Index.Ordinary

--- a/src-extras/Database/LSMTree/Extras/Index.hs
+++ b/src-extras/Database/LSMTree/Extras/Index.hs
@@ -11,11 +11,11 @@ import           Control.Monad.ST.Strict (ST)
 import           Data.Foldable (toList)
 import           Data.Word (Word32)
 import           Database.LSMTree.Internal.Chunk (Chunk)
-import           Database.LSMTree.Internal.IndexCompactAcc (IndexCompactAcc)
-import qualified Database.LSMTree.Internal.IndexCompactAcc as IndexCompact
+import           Database.LSMTree.Internal.Index.CompactAcc (IndexCompactAcc)
+import qualified Database.LSMTree.Internal.Index.CompactAcc as IndexCompact
                      (appendMulti, appendSingle)
-import           Database.LSMTree.Internal.IndexOrdinaryAcc (IndexOrdinaryAcc)
-import qualified Database.LSMTree.Internal.IndexOrdinaryAcc as IndexOrdinary
+import           Database.LSMTree.Internal.Index.OrdinaryAcc (IndexOrdinaryAcc)
+import qualified Database.LSMTree.Internal.Index.OrdinaryAcc as IndexOrdinary
                      (appendMulti, appendSingle)
 import           Database.LSMTree.Internal.Serialise (SerialisedKey)
 

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -40,8 +40,8 @@ import           Database.LSMTree.Internal.ChecksumHandle
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.CRC32C
 import           Database.LSMTree.Internal.Entry
-import           Database.LSMTree.Internal.IndexCompact
-import           Database.LSMTree.Internal.IndexCompactAcc
+import           Database.LSMTree.Internal.Index.Compact
+import           Database.LSMTree.Internal.Index.CompactAcc
 import           Database.LSMTree.Internal.Merge hiding (Level)
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule

--- a/src/Database/LSMTree/Internal/ChecksumHandle.hs
+++ b/src/Database/LSMTree/Internal/ChecksumHandle.hs
@@ -34,8 +34,8 @@ import qualified Database.LSMTree.Internal.Chunk as Chunk (toByteString)
 import           Database.LSMTree.Internal.CRC32C (CRC32C)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
-import qualified Database.LSMTree.Internal.IndexCompact as Index
+import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
+import qualified Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Paths (ForBlob (..), ForFilter (..),
                      ForIndex (..), ForKOps (..))
 import qualified Database.LSMTree.Internal.RawBytes as RB

--- a/src/Database/LSMTree/Internal/Index.hs
+++ b/src/Database/LSMTree/Internal/Index.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE TypeFamilies #-}
+
+{-|
+    Provides a common interface to different types of fence pointer indexes and
+    their accumulators.
+-}
+module Database.LSMTree.Internal.Index
+(
+    Index (search, sizeInPages, fromSBS),
+    IndexAcc (ResultingIndex, appendSingle, appendMulti, unsafeEnd)
+)
+where
+
+import           Control.Monad.ST.Strict (ST)
+import           Data.ByteString.Short (ShortByteString)
+import           Data.Word (Word32)
+import           Database.LSMTree.Internal.Chunk (Chunk)
+import           Database.LSMTree.Internal.Entry (NumEntries)
+import           Database.LSMTree.Internal.Page (NumPages, PageSpan)
+import           Database.LSMTree.Internal.Serialise (SerialisedKey)
+
+-- | The class of index types.
+class Index i where
+
+    {-|
+        Searches for a page span that contains a key–value pair with the given
+        key. If there is indeed such a pair, the result is the corresponding
+        page span; if there is no such pair, the result is an arbitrary but
+        valid page span.
+    -}
+    search :: SerialisedKey -> i -> PageSpan
+
+    -- | Yields the number of pages covered by an index.
+    sizeInPages :: i -> NumPages
+
+    {-|
+        Reads an index along with the number of entries of the respective run
+        from a byte string.
+
+        The byte string must contain the serialised index exactly, with no
+        leading or trailing space. Furthermore, its contents must be stored
+        64-bit-aligned.
+
+        The contents of the byte string may be directly used as the backing
+        memory for the constructed index. Currently, this is done for compact
+        indexes.
+
+        For deserialising numbers, the endianness of the host system is used. If
+        serialisation has been done with a different endianness, this mismatch
+        is detected by looking at the type–version indicator.
+    -}
+    fromSBS :: ShortByteString -> Either String (NumEntries, i)
+
+{-|
+    The class of index accumulator types, where an index accumulator denotes an
+    index under incremental construction.
+
+    Incremental index construction is only guaranteed to work correctly when the
+    following conditions are met:
+
+      * The supplied key ranges do not overlap and are given in ascending order.
+
+      * Each supplied key is at least 8 and at most 65535 bytes long.
+        (Currently, construction of compact indexes needs the former and
+        construction of ordinary indexes needs the latter bound.)
+-}
+class Index (ResultingIndex j) => IndexAcc j where
+
+    -- | The type of indexes constructed by accumulators of a certain type
+    type ResultingIndex j
+
+    {-|
+        Adds information about a single page that fully comprises one or more
+        key–value pairs to an index and outputs newly available chunks.
+
+        See the documentation of the 'IndexAcc' class for constraints to adhere
+        to.
+    -}
+    appendSingle :: (SerialisedKey, SerialisedKey) -> j s -> ST s (Maybe Chunk)
+
+    {-|
+        Adds information about multiple pages that together comprise a single
+        key–value pair to an index and outputs newly available chunks.
+
+        The provided 'Word32' value denotes the number of /overflow/ pages, so
+        that the number of pages that comprise the key–value pair is the
+        successor of that number.
+
+        See the documentation of the 'IndexAcc' class for constraints to adhere
+        to.
+    -}
+    appendMulti :: (SerialisedKey, Word32) -> j s -> ST s [Chunk]
+
+    {-|
+        Returns the constructed index, along with a final chunk in case the
+        serialised key list has not been fully output yet, thereby invalidating
+        the index under construction. Executing @unsafeEnd index@ is only safe
+        when @index@ is not used afterwards.
+    -}
+    unsafeEnd :: j s -> ST s (Maybe Chunk, ResultingIndex j)

--- a/src/Database/LSMTree/Internal/Index/Compact.hs
+++ b/src/Database/LSMTree/Internal/Index/Compact.hs
@@ -2,7 +2,7 @@
 --
 -- TODO: add utility functions for clash probability calculations
 --
-module Database.LSMTree.Internal.IndexCompact (
+module Database.LSMTree.Internal.Index.Compact (
     -- $compact
     IndexCompact (..)
     -- * Queries
@@ -59,7 +59,7 @@ import           Database.LSMTree.Internal.Vector
   @i@, to min-max information for keys on that page.
 
   Fence-pointer indexes can be constructed and serialised incrementally, see
-  module "Database.LSMTree.Internal.IndexCompactAcc".
+  module "Database.LSMTree.Internal.Index.CompactAcc".
 
   Given a serialised target key @k@, an index can be 'search'ed to find a disk
   page @i@ that /might/ contain @k@. Fence-pointer indices offer no guarantee of
@@ -468,7 +468,7 @@ toLBS numEntries index =
   by using 'headerLBS'. Each yielded chunk can then be written using
   'Chunk.toByteString'. Once construction is completed, 'finalLBS' will
   serialise the remaining parts of the compact index.
-  Also see module "Database.LSMTree.Internal.IndexCompactAcc".
+  Also see module "Database.LSMTree.Internal.Index.CompactAcc".
 -}
 
 -- | By writing out the type–version indicator in host endianness, we also

--- a/src/Database/LSMTree/Internal/Index/CompactAcc.hs
+++ b/src/Database/LSMTree/Internal/Index/CompactAcc.hs
@@ -9,7 +9,7 @@
   Incremental construction can be finalised with 'unsafeEnd', which yields both
   a 'Chunk' (possibly) and the `IndexCompact'.
 -}
-module Database.LSMTree.Internal.IndexCompactAcc (
+module Database.LSMTree.Internal.Index.CompactAcc (
     -- * Construction
     -- $construction-invariants
     IndexCompactAcc (..)
@@ -45,7 +45,7 @@ import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word
 import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.Chunk (Chunk)
-import           Database.LSMTree.Internal.IndexCompact
+import           Database.LSMTree.Internal.Index.Compact
 import           Database.LSMTree.Internal.Page
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.Unsliced

--- a/src/Database/LSMTree/Internal/Index/CompactAcc.hs
+++ b/src/Database/LSMTree/Internal/Index/CompactAcc.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE TypeFamilies #-}
 {- |
   Incremental construction of a compact index yields chunks of the primary array
   that can be serialised incrementally.
@@ -11,12 +12,11 @@
 -}
 module Database.LSMTree.Internal.Index.CompactAcc (
     -- * Construction
-    -- $construction-invariants
     IndexCompactAcc (..)
   , new
-  , appendSingle
-  , appendMulti
-  , unsafeEnd
+  , Index.appendSingle
+  , Index.appendMulti
+  , Index.unsafeEnd
     -- * Internal: exported for testing and benchmarking
   , SMaybe (..)
   , unsafeWriteRange
@@ -45,6 +45,9 @@ import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word
 import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.Chunk (Chunk)
+import           Database.LSMTree.Internal.Index (IndexAcc, ResultingIndex)
+import qualified Database.LSMTree.Internal.Index as Index (appendMulti,
+                     appendSingle, unsafeEnd)
 import           Database.LSMTree.Internal.Index.Compact
 import           Database.LSMTree.Internal.Page
 import           Database.LSMTree.Internal.Serialise
@@ -53,15 +56,6 @@ import           Database.LSMTree.Internal.Unsliced
 {-------------------------------------------------------------------------------
   Construction
 -------------------------------------------------------------------------------}
-
-{- $construction-invariants #construction-invariants#
-
-  Constructing a compact index can go wrong, unless the following conditions are
-  met:
-
-  [Sorted] pages must be appended in sorted order according to the keys they
-    contain.
--}
 
 -- | A mutable version of 'IndexCompact'. See [incremental
 -- construction](#incremental).
@@ -122,9 +116,10 @@ newPinnedMVec64 lenWords = do
     setByteArray mba 0 lenWords (0 :: Word64)
     return (VUM.MV_Word64 (VPM.MVector 0 lenWords mba))
 
--- | Append a single page to a mutable compact index.
---
--- INVARIANTS: see [construction invariants](#construction-invariants).
+{-|
+    For a specification of this operation, see the documentation of [its
+    polymorphic version]('Index.appendSingle').
+-}
 appendSingle :: forall s. (SerialisedKey, SerialisedKey) -> IndexCompactAcc s -> ST s (Maybe Chunk)
 appendSingle (minKey, maxKey) ica@IndexCompactAcc{..} = do
 #ifdef NO_IGNORE_ASSERTS
@@ -172,13 +167,10 @@ appendSingle (minKey, maxKey) ica@IndexCompactAcc{..} = do
             when (clash && not ltp) $
               modifySTRef' icaTieBreaker (Map.insert (makeUnslicedKey minKey) (PageNo pageNo))
 
--- | Append multiple pages to the index. The minimum keys and maximum keys for
--- all these pages are set to the same key.
---
--- @appendMulti (k, n)@ is equivalent to @replicateM (n + 1) (appendSingle (k,
--- k))@, but the former should be faster faster.
---
--- INVARIANTS: see [construction invariants](#construction-invariants).
+{-|
+    For a specification of this operation, see the documentation of [its
+    polymorphic version]('Index.appendMulti').
+-}
 appendMulti :: forall s. (SerialisedKey, Word32) -> IndexCompactAcc s -> ST s [Chunk]
 appendMulti (k, n0) ica@IndexCompactAcc{..} =
     maybe id (:) <$> appendSingle (k, k) ica <*> overflows (fromIntegral n0)
@@ -223,12 +215,10 @@ yield IndexCompactAcc{..} = do
     else -- the current chunk is not yet full
       pure Nothing
 
--- | Finalise incremental construction, yielding final chunks.
---
--- This function is unsafe, so do /not/ modify the 'IndexCompactAcc' after using
--- 'unsafeEnd'.
---
--- INVARIANTS: see [construction invariants](#construction-invariants).
+{-|
+    For a specification of this operation, see the documentation of [its
+    polymorphic version]('Index.unsafeEnd').
+-}
 unsafeEnd :: IndexCompactAcc s -> ST s (Maybe Chunk, IndexCompact)
 unsafeEnd IndexCompactAcc{..} = do
     pageNo <- readSTRef icaCurrentPageNumber
@@ -258,6 +248,26 @@ unsafeEnd IndexCompactAcc{..} = do
     sliceCurrent ix (c NE.:| cs)
       | ix == 0 = cs  -- current chunk is completely empty, just ignore it
       | otherwise = VUM.slice 0 ix c : cs
+
+{-------------------------------------------------------------------------------
+  Type class instantiation
+-------------------------------------------------------------------------------}
+
+instance IndexAcc IndexCompactAcc where
+
+    type ResultingIndex IndexCompactAcc = IndexCompact
+
+    appendSingle :: (SerialisedKey, SerialisedKey)
+                 -> IndexCompactAcc s
+                 -> ST s (Maybe Chunk)
+    appendSingle = appendSingle
+
+    appendMulti :: (SerialisedKey, Word32) -> IndexCompactAcc s -> ST s [Chunk]
+    appendMulti = appendMulti
+
+    unsafeEnd :: IndexCompactAcc s
+              -> ST s (Maybe Chunk, ResultingIndex IndexCompactAcc)
+    unsafeEnd = unsafeEnd
 
 {-------------------------------------------------------------------------------
   Strict 'Maybe'

--- a/src/Database/LSMTree/Internal/Index/Ordinary.hs
+++ b/src/Database/LSMTree/Internal/Index/Ordinary.hs
@@ -1,7 +1,7 @@
 {- HLINT ignore "Avoid restricted alias" -}
 
 -- | A general-purpose fence pointer index.
-module Database.LSMTree.Internal.IndexOrdinary
+module Database.LSMTree.Internal.Index.Ordinary
 (
     IndexOrdinary (IndexOrdinary),
     toLastKeys,

--- a/src/Database/LSMTree/Internal/Index/OrdinaryAcc.hs
+++ b/src/Database/LSMTree/Internal/Index/OrdinaryAcc.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeFamilies #-}
+
 {- HLINT ignore "Avoid restricted alias" -}
 
 {-|
@@ -23,6 +25,8 @@ import qualified Data.Vector.Primitive as Primitive (Vector, length)
 import           Data.Word (Word16, Word32, Word8)
 import           Database.LSMTree.Internal.Chunk (Baler, Chunk, createBaler,
                      feedBaler, unsafeEndBaler)
+import           Database.LSMTree.Internal.Index
+                     (IndexAcc (ResultingIndex, appendMulti, appendSingle, unsafeEnd))
 import           Database.LSMTree.Internal.Index.Ordinary
                      (IndexOrdinary (IndexOrdinary))
 import           Database.LSMTree.Internal.Serialise
@@ -65,53 +69,35 @@ keyListElem (SerialisedKey' keyBytes) = [keySizeBytes, keyBytes] where
     keySizeBytes :: Primitive.Vector Word8
     !keySizeBytes = byteVectorFromPrim keySizeAsWord16
 
-{-|
-    Adds information about a single page that fully comprises one or more
-    key–value pairs to an index and outputs newly available chunks of the
-    serialised key list.
+instance IndexAcc IndexOrdinaryAcc where
 
-    __Warning:__ Using keys whose length cannot be represented by a 16-bit word
-    may result in a corrupted serialised key list.
--}
-appendSingle :: (SerialisedKey, SerialisedKey)
-             -> IndexOrdinaryAcc s
-             -> ST s (Maybe Chunk)
-appendSingle (_, key) (IndexOrdinaryAcc lastKeys baler)
-    = do
-          Growing.append lastKeys 1 key
-          feedBaler (keyListElem key) baler
+    type ResultingIndex IndexOrdinaryAcc = IndexOrdinary
 
-{-|
-    Adds information about multiple pages that together comprise a single
-    key–value pair to an index and outputs newly available chunks of the
-    serialised key list.
+    appendSingle :: (SerialisedKey, SerialisedKey)
+                 -> IndexOrdinaryAcc s
+                 -> ST s (Maybe Chunk)
+    appendSingle (_, key) (IndexOrdinaryAcc lastKeys baler)
+        = do
+              Growing.append lastKeys 1 key
+              feedBaler (keyListElem key) baler
 
-    __Warning:__ Using keys whose length cannot be represented by a 16-bit word
-    may result in a corrupted serialised key list.
--}
-appendMulti :: (SerialisedKey, Word32)
-            -> IndexOrdinaryAcc s
-            -> ST s [Chunk]
-appendMulti (key, overflowPageCount) (IndexOrdinaryAcc lastKeys baler)
-    = do
-          Growing.append lastKeys pageCount key
-          maybeToList <$> feedBaler keyListElems baler
-    where
+    appendMulti :: (SerialisedKey, Word32)
+                -> IndexOrdinaryAcc s
+                -> ST s [Chunk]
+    appendMulti (key, overflowPageCount) (IndexOrdinaryAcc lastKeys baler)
+        = do
+              Growing.append lastKeys pageCount key
+              maybeToList <$> feedBaler keyListElems baler
+        where
 
-    pageCount :: Int
-    !pageCount = succ (fromIntegral overflowPageCount)
+        pageCount :: Int
+        !pageCount = succ (fromIntegral overflowPageCount)
 
-    keyListElems :: [Primitive.Vector Word8]
-    keyListElems = concat (replicate pageCount (keyListElem key))
+        keyListElems :: [Primitive.Vector Word8]
+        keyListElems = concat (replicate pageCount (keyListElem key))
 
-{-|
-    Returns the constructed index, along with a final chunk in case the
-    serialised key list has not been fully output yet, thereby invalidating the
-    index under construction. Executing @unsafeEnd index@ is only safe when
-    @index@ is not used afterwards.
--}
-unsafeEnd :: IndexOrdinaryAcc s -> ST s (Maybe Chunk, IndexOrdinary)
-unsafeEnd (IndexOrdinaryAcc lastKeys baler) = do
-    keys <- Growing.freeze lastKeys
-    remnant <- unsafeEndBaler baler
-    return (remnant, IndexOrdinary keys)
+    unsafeEnd :: IndexOrdinaryAcc s -> ST s (Maybe Chunk, IndexOrdinary)
+    unsafeEnd (IndexOrdinaryAcc lastKeys baler) = do
+        keys <- Growing.freeze lastKeys
+        remnant <- unsafeEndBaler baler
+        return (remnant, IndexOrdinary keys)

--- a/src/Database/LSMTree/Internal/Index/OrdinaryAcc.hs
+++ b/src/Database/LSMTree/Internal/Index/OrdinaryAcc.hs
@@ -4,7 +4,7 @@
     Incremental construction functionality for the general-purpose fence pointer
     index.
 -}
-module Database.LSMTree.Internal.IndexOrdinaryAcc
+module Database.LSMTree.Internal.Index.OrdinaryAcc
 (
     IndexOrdinaryAcc,
     new,
@@ -23,7 +23,7 @@ import qualified Data.Vector.Primitive as Primitive (Vector, length)
 import           Data.Word (Word16, Word32, Word8)
 import           Database.LSMTree.Internal.Chunk (Baler, Chunk, createBaler,
                      feedBaler, unsafeEndBaler)
-import           Database.LSMTree.Internal.IndexOrdinary
+import           Database.LSMTree.Internal.Index.Ordinary
                      (IndexOrdinary (IndexOrdinary))
 import           Database.LSMTree.Internal.Serialise
                      (SerialisedKey (SerialisedKey'))

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -40,8 +40,8 @@ import           Control.Monad.ST.Strict
 
 import           Database.LSMTree.Internal.BlobRef (WeakBlobRef (..))
 import           Database.LSMTree.Internal.Entry
+import qualified Database.LSMTree.Internal.Index as Index (search)
 import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
-import qualified Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Page (PageSpan (..), getNumPages,
                      pageSpanSize, unPageNo)
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -40,8 +40,8 @@ import           Control.Monad.ST.Strict
 
 import           Database.LSMTree.Internal.BlobRef (WeakBlobRef (..))
 import           Database.LSMTree.Internal.Entry
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
-import qualified Database.LSMTree.Internal.IndexCompact as Index
+import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
+import qualified Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Page (PageSpan (..), getNumPages,
                      pageSpanSize, unPageNo)
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -63,7 +63,7 @@ import           Database.LSMTree.Internal.Assertions (assert)
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry (Entry, NumEntries (..),
                      unNumEntries)
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
+import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
 import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.Merge (Merge, StepResult (..))
 import qualified Database.LSMTree.Internal.Merge as Merge

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -46,8 +46,8 @@ import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..),
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterFromSBS)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
-import qualified Database.LSMTree.Internal.IndexCompact as Index
+import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
+import qualified Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Page (NumPages)
 import           Database.LSMTree.Internal.Paths
 import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc)

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -46,8 +46,8 @@ import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..),
 import           Database.LSMTree.Internal.BloomFilter (bloomFilterFromSBS)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
+import qualified Database.LSMTree.Internal.Index as Index (fromSBS, sizeInPages)
 import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
-import qualified Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Page (NumPages)
 import           Database.LSMTree.Internal.Paths
 import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc)

--- a/src/Database/LSMTree/Internal/RunAcc.hs
+++ b/src/Database/LSMTree/Internal/RunAcc.hs
@@ -44,9 +44,11 @@ import           Database.LSMTree.Internal.Assertions (fromIntegralChecked)
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Chunk (Chunk)
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
+import qualified Database.LSMTree.Internal.Index as Index (appendMulti,
+                     appendSingle, unsafeEnd)
 import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
 import           Database.LSMTree.Internal.Index.CompactAcc (IndexCompactAcc)
-import qualified Database.LSMTree.Internal.Index.CompactAcc as Index
+import qualified Database.LSMTree.Internal.Index.CompactAcc as IndexCompact
 import           Database.LSMTree.Internal.PageAcc (PageAcc)
 import qualified Database.LSMTree.Internal.PageAcc as PageAcc
 import qualified Database.LSMTree.Internal.PageAcc1 as PageAcc
@@ -102,7 +104,7 @@ new (NumEntries nentries) alloc = do
         MBloom.new
           (fromIntegralChecked $ Monkey.numHashFunctions (fromIntegral nbits) (fromIntegral nentries))
           nbits
-    mindex <- Index.new 1024 -- TODO(optimise): tune chunk size
+    mindex <- IndexCompact.new 1024 -- TODO(optimise): tune chunk size
     mpageacc <- PageAcc.newPageAcc
     entryCount <- newPrimVar 0
     pure RunAcc{..}

--- a/src/Database/LSMTree/Internal/RunAcc.hs
+++ b/src/Database/LSMTree/Internal/RunAcc.hs
@@ -44,9 +44,9 @@ import           Database.LSMTree.Internal.Assertions (fromIntegralChecked)
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Chunk (Chunk)
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
-import           Database.LSMTree.Internal.IndexCompactAcc (IndexCompactAcc)
-import qualified Database.LSMTree.Internal.IndexCompactAcc as Index
+import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
+import           Database.LSMTree.Internal.Index.CompactAcc (IndexCompactAcc)
+import qualified Database.LSMTree.Internal.Index.CompactAcc as Index
 import           Database.LSMTree.Internal.PageAcc (PageAcc)
 import qualified Database.LSMTree.Internal.PageAcc as PageAcc
 import qualified Database.LSMTree.Internal.PageAcc1 as PageAcc

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -23,7 +23,7 @@ import           Database.LSMTree.Internal.BlobRef (RawBlobRef)
 import           Database.LSMTree.Internal.ChecksumHandle
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.Entry
-import           Database.LSMTree.Internal.IndexCompact (IndexCompact)
+import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
 import           Database.LSMTree.Internal.Paths
 import           Database.LSMTree.Internal.RawOverflowPage (RawOverflowPage)
 import           Database.LSMTree.Internal.RawPage (RawPage)

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -31,7 +31,7 @@ import           Database.LSMTree.Internal.BitMath (ceilDivPageSize,
                      mulPageSize, roundUpToPageSize)
 import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..))
 import qualified Database.LSMTree.Internal.Entry as E
-import qualified Database.LSMTree.Internal.Index.Compact as Index
+import qualified Database.LSMTree.Internal.Index as Index (search)
 import           Database.LSMTree.Internal.Page (PageNo (..), PageSpan (..),
                      getNumPages, nextPageNo)
 import           Database.LSMTree.Internal.Paths

--- a/src/Database/LSMTree/Internal/RunReader.hs
+++ b/src/Database/LSMTree/Internal/RunReader.hs
@@ -31,7 +31,7 @@ import           Database.LSMTree.Internal.BitMath (ceilDivPageSize,
                      mulPageSize, roundUpToPageSize)
 import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..))
 import qualified Database.LSMTree.Internal.Entry as E
-import qualified Database.LSMTree.Internal.IndexCompact as Index
+import qualified Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Page (PageNo (..), PageSpan (..),
                      getNumPages, nextPageNo)
 import           Database.LSMTree.Internal.Paths

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,8 +11,8 @@ import qualified Test.Database.LSMTree.Internal.BloomFilter
 import qualified Test.Database.LSMTree.Internal.Chunk
 import qualified Test.Database.LSMTree.Internal.CRC32C
 import qualified Test.Database.LSMTree.Internal.Entry
-import qualified Test.Database.LSMTree.Internal.IndexCompact
-import qualified Test.Database.LSMTree.Internal.IndexOrdinary
+import qualified Test.Database.LSMTree.Internal.Index.Compact
+import qualified Test.Database.LSMTree.Internal.Index.Ordinary
 import qualified Test.Database.LSMTree.Internal.Lookup
 import qualified Test.Database.LSMTree.Internal.Merge
 import qualified Test.Database.LSMTree.Internal.Monkey
@@ -60,8 +60,8 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Internal.RunBuilder.tests
     , Test.Database.LSMTree.Internal.RunReader.tests
     , Test.Database.LSMTree.Internal.RunReaders.tests
-    , Test.Database.LSMTree.Internal.IndexCompact.tests
-    , Test.Database.LSMTree.Internal.IndexOrdinary.tests
+    , Test.Database.LSMTree.Internal.Index.Compact.tests
+    , Test.Database.LSMTree.Internal.Index.Ordinary.tests
     , Test.Database.LSMTree.Internal.Serialise.tests
     , Test.Database.LSMTree.Internal.Serialise.Class.tests
     , Test.Database.LSMTree.Internal.Snapshot.Codec.tests

--- a/test/Test/Database/LSMTree/Internal/Index/Compact.hs
+++ b/test/Test/Database/LSMTree/Internal/Index/Compact.hs
@@ -3,7 +3,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {- HLINT ignore "Eta reduce" -}
 
-module Test.Database.LSMTree.Internal.IndexCompact (tests) where
+module Test.Database.LSMTree.Internal.Index.Compact (tests) where
 
 import           Control.DeepSeq (deepseq)
 import           Control.Monad (foldM)
@@ -32,8 +32,8 @@ import           Database.LSMTree.Extras.Index as Cons (Append (..), append)
 import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.Chunk as Chunk (toByteString)
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
-import           Database.LSMTree.Internal.IndexCompact as Index
-import           Database.LSMTree.Internal.IndexCompactAcc as Cons
+import           Database.LSMTree.Internal.Index.Compact as Index
+import           Database.LSMTree.Internal.Index.CompactAcc as Cons
 import           Database.LSMTree.Internal.Page (PageNo (PageNo), PageSpan,
                      multiPage, singlePage)
 import           Database.LSMTree.Internal.Serialise
@@ -48,7 +48,7 @@ import           Test.Util.Orphans ()
 import           Text.Printf (printf)
 
 tests :: TestTree
-tests = testGroup "Test.Database.LSMTree.Internal.IndexCompact" [
+tests = testGroup "Test.Database.LSMTree.Internal.Index.Compact" [
     testProperty "prop_distribution @KeyForIndexCompact" $
       prop_distribution @KeyForIndexCompact
   , testProperty "prop_searchMinMaxKeysAfterConstruction" $

--- a/test/Test/Database/LSMTree/Internal/Index/Compact.hs
+++ b/test/Test/Database/LSMTree/Internal/Index/Compact.hs
@@ -28,12 +28,12 @@ import qualified Data.Vector.Unboxed.Base as VU
 import           Data.Word
 import           Database.LSMTree.Extras
 import           Database.LSMTree.Extras.Generators as Gen
-import           Database.LSMTree.Extras.Index as Cons (Append (..), append)
+import           Database.LSMTree.Extras.Index as Index (Append (..), append)
 import           Database.LSMTree.Internal.BitMath
 import           Database.LSMTree.Internal.Chunk as Chunk (toByteString)
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
-import           Database.LSMTree.Internal.Index.Compact as Index
-import           Database.LSMTree.Internal.Index.CompactAcc as Cons
+import           Database.LSMTree.Internal.Index.Compact as IndexCompact
+import           Database.LSMTree.Internal.Index.CompactAcc as IndexCompact
 import           Database.LSMTree.Internal.Page (PageNo (PageNo), PageSpan,
                      multiPage, singlePage)
 import           Database.LSMTree.Internal.Serialise
@@ -69,9 +69,9 @@ tests = testGroup "Test.Database.LSMTree.Internal.Index.Compact" [
           let k2 = SerialisedKey' (VP.replicate 16 0x11)
           let k3 = SerialisedKey' (VP.replicate 15 0x11 <> VP.replicate 1 0x12)
           let (chunks, index) = runST $ do
-                ica <- Cons.new 16
-                ch1 <- flip Cons.append ica $ AppendSinglePage k1 k2
-                ch2 <- flip Cons.append ica $ AppendSinglePage k3 k3
+                ica <- IndexCompact.new 16
+                ch1 <- flip Index.append ica $ AppendSinglePage k1 k2
+                ch2 <- flip Index.append ica $ AppendSinglePage k3 k3
                 (mCh3, idx) <- unsafeEnd ica
                 return (ch1 <> ch2 <> toList mCh3, idx)
 
@@ -289,7 +289,7 @@ prop_total_deserialisation_whitebox numEntries numPages word32s =
 
 writeIndexCompact :: SerialiseKey k => NumEntries -> ChunkSize -> LogicalPageSummaries k -> (LBS.ByteString, LBS.ByteString, LBS.ByteString)
 writeIndexCompact numEntries (ChunkSize csize) ps = runST $ do
-    ica <- Cons.new csize
+    ica <- IndexCompact.new csize
     cs <- mapM (`append` ica) (toAppends ps)
     (c, index) <- unsafeEnd ica
     return
@@ -325,7 +325,7 @@ labelIndex ic =
     . QC.tabulate "Length of contiguous clash runs" (fmap (showPowersOf10 . snd) nscontig)
     . QC.tabulate "Contiguous clashes contain multi-page values" (fmap (show . fst) nscontig)
     . QC.classify (multiPageValuesClash ic) "Has clashing multi-page values"
-  where nclashes       = Index.countClashes ic
+  where nclashes       = IndexCompact.countClashes ic
         nscontig       = countContiguousClashes ic
 
 multiPageValuesClash :: IndexCompact -> Bool

--- a/test/Test/Database/LSMTree/Internal/Index/Ordinary.hs
+++ b/test/Test/Database/LSMTree/Internal/Index/Ordinary.hs
@@ -4,7 +4,7 @@
 
 {- HLINT ignore "Avoid restricted alias" -}
 
-module Test.Database.LSMTree.Internal.IndexOrdinary (tests) where
+module Test.Database.LSMTree.Internal.Index.Ordinary (tests) where
 
 import           Prelude hiding (all, head, last, length, notElem, splitAt,
                      tail, takeWhile)
@@ -29,10 +29,10 @@ import           Database.LSMTree.Extras.Index
                      (Append (AppendMultiPage, AppendSinglePage), append')
 import qualified Database.LSMTree.Internal.Chunk as Chunk (toByteVector)
 import           Database.LSMTree.Internal.Entry (NumEntries (NumEntries))
-import           Database.LSMTree.Internal.IndexOrdinary
+import           Database.LSMTree.Internal.Index.Ordinary
                      (IndexOrdinary (IndexOrdinary), fromSBS, search,
                      toLastKeys)
-import           Database.LSMTree.Internal.IndexOrdinaryAcc (new, unsafeEnd)
+import           Database.LSMTree.Internal.Index.OrdinaryAcc (new, unsafeEnd)
 import           Database.LSMTree.Internal.Page (PageNo (PageNo),
                      PageSpan (PageSpan))
 import           Database.LSMTree.Internal.Serialise
@@ -52,7 +52,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 -- * Tests
 
 tests :: TestTree
-tests = testGroup "Test.Database.LSMTree.Internal.IndexOrdinary" $
+tests = testGroup "Test.Database.LSMTree.Internal.Index.Ordinary" $
         [
             testGroup "Search" $
             [

--- a/test/Test/Database/LSMTree/Internal/Index/Ordinary.hs
+++ b/test/Test/Database/LSMTree/Internal/Index/Ordinary.hs
@@ -26,7 +26,7 @@ import           Data.Word (Word16, Word32, Word64, Word8)
 import           Database.LSMTree.Extras.Generators (LogicalPageSummaries,
                      toAppends)
 import           Database.LSMTree.Extras.Index
-                     (Append (AppendMultiPage, AppendSinglePage), append')
+                     (Append (AppendMultiPage, AppendSinglePage), append)
 import qualified Database.LSMTree.Internal.Chunk as Chunk (toByteVector)
 import           Database.LSMTree.Internal.Entry (NumEntries (NumEntries))
 import           Database.LSMTree.Internal.Index.Ordinary
@@ -258,7 +258,7 @@ lastKeysBlockFromAppends appends = lastKeysBlock where
 incrementalConstruction :: [Append] -> (IndexOrdinary, Primitive.Vector Word8)
 incrementalConstruction appends = runST $ do
     acc <- new initialKeyBufferSize minChunkSize
-    commonChunks <- concat <$> mapM (flip append' acc) appends
+    commonChunks <- concat <$> mapM (flip append acc) appends
     (remnant, unserialised) <- unsafeEnd acc
     let
 
@@ -362,7 +362,8 @@ prop_numberOfEntriesFromSerialisedIndexWorks entryCount lastKeys
     where
 
     errorMsgOrEntryCount :: Either String NumEntries
-    errorMsgOrEntryCount = fst <$> fromSBS (serialisedIndex entryCount lastKeys)
+    errorMsgOrEntryCount
+        = fst <$> fromSBS @IndexOrdinary (serialisedIndex entryCount lastKeys)
 
     noErrorMsgButCorrectEntryCount :: Either String NumEntries
     noErrorMsgButCorrectEntryCount = Right entryCount
@@ -380,7 +381,7 @@ prop_indexFromSerialisedIndexWorks entryCount lastKeys
 
 prop_tooShortInputMakesDeserialisationFail :: TooShortByteString -> Bool
 prop_tooShortInputMakesDeserialisationFail
-    = isLeft . fromSBS . fromTooShortByteString
+    = isLeft . fromSBS @IndexOrdinary . fromTooShortByteString
 
 prop_typeAndVersionErrorMakesDeserialisationFail :: Word32
                                                  -> [SerialisedKey]
@@ -407,7 +408,7 @@ prop_partialKeySizeBlockMakesDeserialisationFail lastKeys
                                                  partialKeySizeByte
                                                  entryCount
     = isLeft $
-      fromSBS $
+      fromSBS @IndexOrdinary $
       potentialSerialisedIndex
           testedTypeAndVersionBlock
           (lastKeysBlocks lastKeys ++ [Primitive.singleton partialKeySizeByte])
@@ -423,7 +424,7 @@ prop_partialKeyBlockMakesDeserialisationFail lastKeys
                                              partialKeyBlock
                                              entryCount
     = fromIntegral statedSize > Primitive.length partialKeyBlock ==>
-      isLeft (fromSBS input)
+      isLeft (fromSBS @IndexOrdinary input)
     where
 
     statedSizeBlock :: Primitive.Vector Word8

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -46,7 +46,7 @@ import           Database.LSMTree.Extras.RunData (RunData (..),
                      unsafeFlushAsWriteBuffer)
 import           Database.LSMTree.Internal.BlobRef
 import           Database.LSMTree.Internal.Entry as Entry
-import           Database.LSMTree.Internal.IndexCompact as Index
+import           Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Lookup
 import           Database.LSMTree.Internal.Page (PageNo (PageNo), PageSpan (..))
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -46,7 +46,7 @@ import           Database.LSMTree.Extras.RunData (RunData (..),
                      unsafeFlushAsWriteBuffer)
 import           Database.LSMTree.Internal.BlobRef
 import           Database.LSMTree.Internal.Entry as Entry
-import           Database.LSMTree.Internal.Index.Compact as Index
+import           Database.LSMTree.Internal.Index.Compact
 import           Database.LSMTree.Internal.Lookup
 import           Database.LSMTree.Internal.Page (PageNo (PageNo), PageSpan (..))
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
@@ -169,7 +169,7 @@ indexSearchesModel cs ks rkixs =
     flip fmap rkixs $ \(rix, kix) ->
       let c = cs List.!! rix
           k = ks List.!! kix
-      in  Index.search k c
+      in  search k c
 
 prop_prepLookupsModel ::
      SmallList (InMemLookupData SerialisedKey SerialisedValue BlobSpan)
@@ -200,7 +200,7 @@ prepLookupsModel rs ks = unzip
     | (rix, (b, c)) <- zip [0..] rs
     , (kix, k) <- zip [0..] ks
     , Bloom.elem k b
-    , let pspan = Index.search k c
+    , let pspan = search k c
     ]
 
 {-------------------------------------------------------------------------------

--- a/test/Test/Database/LSMTree/Internal/RunAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/RunAcc.hs
@@ -15,7 +15,7 @@ import           Data.Maybe
 import qualified Data.Vector.Primitive as VP
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry
-import qualified Database.LSMTree.Internal.IndexCompact as Index
+import qualified Database.LSMTree.Internal.Index.Compact as Index
 import           Database.LSMTree.Internal.Page (PageNo (PageNo), singlePage)
 import qualified Database.LSMTree.Internal.PageAcc as PageAcc
 import qualified Database.LSMTree.Internal.PageAcc1 as PageAcc

--- a/test/Test/Database/LSMTree/Internal/RunAcc.hs
+++ b/test/Test/Database/LSMTree/Internal/RunAcc.hs
@@ -15,7 +15,7 @@ import           Data.Maybe
 import qualified Data.Vector.Primitive as VP
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry
-import qualified Database.LSMTree.Internal.Index.Compact as Index
+import qualified Database.LSMTree.Internal.Index as Index
 import           Database.LSMTree.Internal.Page (PageNo (PageNo), singlePage)
 import qualified Database.LSMTree.Internal.PageAcc as PageAcc
 import qualified Database.LSMTree.Internal.PageAcc1 as PageAcc

--- a/test/Test/Database/LSMTree/Internal/Vector.hs
+++ b/test/Test/Database/LSMTree/Internal/Vector.hs
@@ -9,7 +9,7 @@ import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Data.Word
 import           Database.LSMTree.Extras
-import           Database.LSMTree.Internal.IndexCompactAcc as Cons
+import           Database.LSMTree.Internal.Index.CompactAcc as Cons
 import           Prelude hiding (max, min, pi)
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()


### PR DESCRIPTION
This pull request introduces type classes that provide a common interface to different types of indexes and their accumulators and instantiates these type classes for the compact and the ordinary index.
