### PR TITLE
Re-enable NoThunks tests (#444) 

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -320,6 +320,7 @@ library extras
     , contra-tracer
     , deepseq
     , fs-api
+    , fs-sim
     , io-classes:strict-mvar
     , io-classes:strict-stm
     , lsm-tree

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -957,8 +957,7 @@ runIO action lookUp = ReaderT $ \(session, handler) -> do
     x <- aux (unwrapSession session) handler action
     case session of
       WrapSession sesh ->
-        -- TODO: Re-enable NoThunks assertions. See lsm-tree#444.
-        const id (assertNoThunks sesh) $ pure ()
+        assertNoThunks sesh $ pure ()
     pure x
   where
     aux ::


### PR DESCRIPTION
The `NoThunks` assertions are re-enabled, but in cases where I expect failures related to `StrictMVar`s, we ignore the thunk and keep checking further into the `MVar` contents.

This is arguably better than not checking `NoThunks` at all, though still unfortunate.