### PR TITLE
Rename `blob` and `blobref` type variables to `b`

### DIFF
--- a/bench/macro/lsm-tree-bench-wp8.hs
+++ b/bench/macro/lsm-tree-bench-wp8.hs
@@ -857,7 +857,7 @@ pureReference !initialSize !batchSize !batchCount !seed =
         Nothing -> (,) k LSM.NotFound
         Just u  -> (,) k $! updateToLookupResult u
 
-updateToLookupResult :: LSM.Update v blob -> LSM.LookupResult v ()
+updateToLookupResult :: LSM.Update v b -> LSM.LookupResult v ()
 updateToLookupResult (LSM.Insert v Nothing)  = LSM.Found v
 updateToLookupResult (LSM.Insert v (Just _)) = LSM.FoundWithBlob v ()
 updateToLookupResult  LSM.Delete             = LSM.NotFound

--- a/src-extras/Database/LSMTree/Extras/Generators.hs
+++ b/src-extras/Database/LSMTree/Extras/Generators.hs
@@ -76,7 +76,7 @@ import           Test.QuickCheck.Instances ()
   Common LSMTree types
 -------------------------------------------------------------------------------}
 
-instance (Arbitrary v, Arbitrary blob) => Arbitrary (Unified.Update v blob) where
+instance (Arbitrary v, Arbitrary b) => Arbitrary (Unified.Update v b) where
   arbitrary = QC.arbitrary2
   shrink = QC.shrink2
 
@@ -95,7 +95,7 @@ instance Arbitrary2 Unified.Update where
     Unified.Mupsert v -> Unified.Insert v Nothing : map Unified.Mupsert (shrinkVal v)
     Unified.Delete -> []
 
-instance (Arbitrary v, Arbitrary blob) => Arbitrary (Normal.Update v blob) where
+instance (Arbitrary v, Arbitrary b) => Arbitrary (Normal.Update v b) where
   arbitrary = QC.arbitrary2
   shrink = QC.shrink2
 
@@ -152,7 +152,7 @@ instance (Arbitrary k, Ord k) => Arbitrary (Range k) where
   Entry
 -------------------------------------------------------------------------------}
 
-instance (Arbitrary v, Arbitrary blob) => Arbitrary (Entry v blob) where
+instance (Arbitrary v, Arbitrary b) => Arbitrary (Entry v b) where
   arbitrary = QC.arbitrary2
   shrink = QC.shrink2
 

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -99,8 +99,8 @@ instance (NoThunksIOLike m, Typeable m, Typeable (PrimState m))
 -- | Does not check 'NoThunks' for the 'Common.Session' that this
 -- 'Normal.Table' belongs to.
 instance (NoThunksIOLike m, Typeable m, Typeable (PrimState m))
-      => NoThunks (NormalTable m k v blob) where
-  showTypeOf (_ :: Proxy (NormalTable m k v blob)) = "NormalTable"
+      => NoThunks (NormalTable m k v b) where
+  showTypeOf (_ :: Proxy (NormalTable m k v b)) = "NormalTable"
   wNoThunks ctx (NormalTable t) = wNoThunks ctx t
 
 {-------------------------------------------------------------------------------

--- a/src-extras/Database/LSMTree/Extras/RunData.hs
+++ b/src-extras/Database/LSMTree/Extras/RunData.hs
@@ -149,11 +149,11 @@ instance ( Ord k, Arbitrary k, Arbitrary v, Arbitrary b
   shrink = shrinkRunData shrink shrink shrink
 
 genRunData ::
-     forall k v blob. Ord k
+     forall k v b. Ord k
   => Gen k
   -> Gen v
-  -> Gen blob
-  -> Gen (RunData k v blob)
+  -> Gen b
+  -> Gen (RunData k v b)
 genRunData genKey genVal genBlob =
     RunData <$> liftArbitrary2Map genKey (liftArbitrary2 genVal genBlob)
 
@@ -161,9 +161,9 @@ shrinkRunData ::
      Ord k
   => (k -> [k])
   -> (v -> [v])
-  -> (blob -> [blob])
-  -> RunData k v blob
-  -> [RunData k v blob]
+  -> (b -> [b])
+  -> RunData k v b
+  -> [RunData k v b]
 shrinkRunData shrinkKey shrinkVal shrinkBlob =
       fmap RunData
     . liftShrink2Map shrinkKey (liftShrink2 shrinkVal shrinkBlob)

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -252,10 +252,10 @@ listSnapshots (Internal.Session' sesh) = Internal.listSnapshots sesh
 -- TODO: get rid of the @m@ parameter?
 type BlobRef :: (Type -> Type) -> Type -> Type
 type role BlobRef nominal nominal
-data BlobRef m blob where
+data BlobRef m b where
     BlobRef :: Typeable h
             => Internal.WeakBlobRef m h
-            -> BlobRef m blob
+            -> BlobRef m b
 
-instance Show (BlobRef m blob) where
+instance Show (BlobRef m b) where
     showsPrec d (BlobRef b) = showsPrec d b

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -150,7 +150,7 @@ instance NFData (NormalTable m k v b) where
   rnf (NormalTable t) = rnf t
 
 type NormalCursor :: (Type -> Type) -> Type -> Type -> Type -> Type
-data NormalCursor m k v blob = forall h. Typeable h =>
+data NormalCursor m k v b = forall h. Typeable h =>
     NormalCursor !(Cursor m h)
 
 instance NFData (NormalCursor m k v b) where

--- a/src/Database/LSMTree/Internal/Entry.hs
+++ b/src/Database/LSMTree/Internal/Entry.hs
@@ -14,33 +14,33 @@ import           Control.DeepSeq (NFData (..))
 import           Data.Bifoldable (Bifoldable (..))
 import           Data.Bifunctor (Bifunctor (..))
 
-data Entry v blobref
+data Entry v b
     = Insert !v
-    | InsertWithBlob !v !blobref
+    | InsertWithBlob !v !b
     | Mupdate !v
     | Delete
   deriving stock (Eq, Show, Functor, Foldable, Traversable)
 
-hasBlob :: Entry v blobref -> Bool
+hasBlob :: Entry v b -> Bool
 hasBlob Insert{}         = False
 hasBlob InsertWithBlob{} = True
 hasBlob Mupdate{}        = False
 hasBlob Delete{}         = False
 
-instance (NFData v, NFData blobref) => NFData (Entry v blobref) where
+instance (NFData v, NFData b) => NFData (Entry v b) where
     rnf (Insert v)            = rnf v
     rnf (InsertWithBlob v br) = rnf v `seq` rnf br
     rnf (Mupdate v)           = rnf v
     rnf Delete                = ()
 
-onValue :: v' -> (v -> v') -> Entry v blobref -> v'
+onValue :: v' -> (v -> v') -> Entry v b -> v'
 onValue def f = \case
     Insert v           -> f v
     InsertWithBlob v _ -> f v
     Mupdate v          -> f v
     Delete             -> def
 
-onBlobRef :: blobref' -> (blobref -> blobref') -> Entry v blobref -> blobref'
+onBlobRef :: b' -> (b -> b') -> Entry v b -> b'
 onBlobRef def g = \case
     Insert{}            -> def
     InsertWithBlob _ br -> g br
@@ -87,11 +87,11 @@ unNumEntries (NumEntries x) = x
 -------------------------------------------------------------------------------}
 
 -- | As long as values are a semigroup, an Entry is too
-instance Semigroup v => Semigroup (Entry v blob) where
+instance Semigroup v => Semigroup (Entry v b) where
   e1 <> e2 = combine (<>) e1 e2
 
 -- | Given a value-merge function, combine entries
-combine :: (v -> v -> v) -> Entry v blobref -> Entry v blobref -> Entry v blobref
+combine :: (v -> v -> v) -> Entry v b -> Entry v b -> Entry v b
 combine _ e@Delete            _                       = e
 combine _ e@Insert {}         _                       = e
 combine _ e@InsertWithBlob {} _                       = e
@@ -100,7 +100,7 @@ combine f   (Mupdate u)       (Insert v)              = Insert (f u v)
 combine f   (Mupdate u)       (InsertWithBlob v blob) = InsertWithBlob (f u v) blob
 combine f   (Mupdate u)       (Mupdate v)             = Mupdate (f u v)
 
-combineMaybe :: (v -> v -> v) -> Maybe (Entry v blobref) -> Maybe (Entry v blobref) -> Maybe (Entry v blobref)
+combineMaybe :: (v -> v -> v) -> Maybe (Entry v b) -> Maybe (Entry v b) -> Maybe (Entry v b)
 combineMaybe _ e1 Nothing          = e1
 combineMaybe _ Nothing e2          = e2
 combineMaybe f (Just e1) (Just e2) = Just $! combine f e1 e2

--- a/src/Database/LSMTree/Internal/PageAcc.hs
+++ b/src/Database/LSMTree/Internal/PageAcc.hs
@@ -132,7 +132,7 @@ maxBlobRefsMap = 12 -- 768 / 64
 -- Checking entry size allows us to use 'Word16' arithmetic, we don't need to
 -- worry about overflows.
 --
-sizeofEntry :: SerialisedKey -> Entry SerialisedValue blob -> Int
+sizeofEntry :: SerialisedKey -> Entry SerialisedValue b -> Int
 sizeofEntry k Delete               = sizeofKey k
 sizeofEntry k (Mupdate v)          = sizeofKey k + sizeofValue v
 sizeofEntry k (Insert v)           = sizeofKey k + sizeofValue v
@@ -145,7 +145,7 @@ sizeofEntry k (InsertWithBlob v _) = sizeofKey k + sizeofValue v + 12
 -- If 'entryWouldFitInPage' is @True@ and the 'PageAcc' is empty (i.e. using
 --'resetPageAcc') then 'pageAccAddElem' is guaranteed to succeed.
 --
-entryWouldFitInPage :: SerialisedKey -> Entry SerialisedValue blob -> Bool
+entryWouldFitInPage :: SerialisedKey -> Entry SerialisedValue b -> Bool
 entryWouldFitInPage k e = sizeofEntry k e + 32 <= pageSize
 
 -- | Whether 'Entry' adds a blob reference

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -449,7 +449,7 @@ updates (Internal.MonoidalTable t) es = do
     serialiseEntry = bimap Internal.serialiseKey serialiseOp
     serialiseOp = first Internal.serialiseValue . updateToEntry
 
-    updateToEntry :: Update v -> Entry.Entry v blob
+    updateToEntry :: Update v -> Entry.Entry v b
     updateToEntry = \case
         Insert v  -> Entry.Insert v
         Mupsert v -> Entry.Mupdate v

--- a/test/Database/LSMTree/Class/Common.hs
+++ b/test/Database/LSMTree/Class/Common.hs
@@ -21,7 +21,7 @@ import           System.FS.API (FsPath, HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
 
 -- | Model-specific constraints
-type C k v blob = (C_ k, C_ v, C_ blob)
+type C k v b = (C_ k, C_ v, C_ b)
 type C_ a = (Show a, Eq a, Typeable a)
 
 -- | Class abstracting over session operations.

--- a/test/Database/LSMTree/Class/Normal.hs
+++ b/test/Database/LSMTree/Class/Normal.hs
@@ -32,107 +32,107 @@ class (IsSession (Session h)) => IsTable h where
 
     new ::
            ( IOLike m
-           , C k v blob
+           , C k v b
            )
         => Session h m
         -> TableConfig h
-        -> m (h m k v blob)
+        -> m (h m k v b)
 
     close ::
            ( IOLike m
-           , C k v blob
+           , C k v b
            )
-        => h m k v blob
+        => h m k v b
         -> m ()
 
     lookups ::
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , C k v blob
+           , C k v b
            )
-        => h m k v blob
+        => h m k v b
         -> V.Vector k
-        -> m (V.Vector (LookupResult v (BlobRef h m blob)))
+        -> m (V.Vector (LookupResult v (BlobRef h m b)))
 
     rangeLookup ::
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , C k v blob
+           , C k v b
            )
-        => h m k v blob
+        => h m k v b
         -> Range k
-        -> m (V.Vector (QueryResult k v (BlobRef h m blob)))
+        -> m (V.Vector (QueryResult k v (BlobRef h m b)))
 
     newCursor ::
            ( IOLike m
            , SerialiseKey k
-           , C k v blob
+           , C k v b
            )
         => Maybe k
-        -> h m k v blob
-        -> m (Cursor h m k v blob)
+        -> h m k v b
+        -> m (Cursor h m k v b)
 
     closeCursor ::
            ( IOLike m
-           , C k v blob
+           , C k v b
            )
         => proxy h
-        -> Cursor h m k v blob
+        -> Cursor h m k v b
         -> m ()
 
     readCursor ::
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , C k v blob
+           , C k v b
            )
         => proxy h
         -> Int
-        -> Cursor h m k v blob
-        -> m (V.Vector (QueryResult k v (BlobRef h m blob)))
+        -> Cursor h m k v b
+        -> m (V.Vector (QueryResult k v (BlobRef h m b)))
 
     retrieveBlobs ::
            ( IOLike m
-           , SerialiseValue blob
-           , C_ blob
+           , SerialiseValue b
+           , C_ b
            )
         => proxy h
         -> Session h m
-        -> V.Vector (BlobRef h m blob)
-        -> m (V.Vector blob)
+        -> V.Vector (BlobRef h m b)
+        -> m (V.Vector b)
 
     updates ::
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , SerialiseValue blob
-           , C k v blob
+           , SerialiseValue b
+           , C k v b
            )
-        => h m k v blob
-        -> V.Vector (k, Update v blob)
+        => h m k v b
+        -> V.Vector (k, Update v b)
         -> m ()
 
     inserts ::
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , SerialiseValue blob
-           , C k v blob
+           , SerialiseValue b
+           , C k v b
            )
-        => h m k v blob
-        -> V.Vector (k, v, Maybe blob)
+        => h m k v b
+        -> V.Vector (k, v, Maybe b)
         -> m ()
 
     deletes ::
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , SerialiseValue blob
-           , C k v blob
+           , SerialiseValue b
+           , C k v b
            )
-        => h m k v blob
+        => h m k v b
         -> V.Vector k
         -> m ()
 
@@ -140,84 +140,84 @@ class (IsSession (Session h)) => IsTable h where
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , SerialiseValue blob
-           , C k v blob
+           , SerialiseValue b
+           , C k v b
            )
         => SnapshotLabel
         -> SnapshotName
-        -> h m k v blob
+        -> h m k v b
         -> m ()
 
     openSnapshot ::
            ( IOLike m
            , SerialiseKey k
            , SerialiseValue v
-           , SerialiseValue blob
-           , C k v blob
+           , SerialiseValue b
+           , C k v b
            )
         => Session h m
         -> SnapshotLabel
         -> SnapshotName
-        -> m (h m k v blob)
+        -> m (h m k v b)
 
     duplicate ::
            ( IOLike m
-           , C k v blob
+           , C k v b
            )
-        => h m k v blob
-        -> m (h m k v blob)
+        => h m k v b
+        -> m (h m k v b)
 
     union ::
            ( IOLike m
            , SerialiseValue v
-           , C k v blob
+           , C k v b
            )
-        => h m k v blob
-        -> h m k v blob
-        -> m (h m k v blob)
+        => h m k v b
+        -> h m k v b
+        -> m (h m k v b)
 
-withTableNew :: forall h m k v blob a.
+withTableNew :: forall h m k v b a.
     ( IOLike m
     , IsTable h
-    , C k v blob
+    , C k v b
     )
   => Session h m
   -> TableConfig h
-  -> (h m k v blob -> m a)
+  -> (h m k v b -> m a)
   -> m a
 withTableNew sesh conf = bracket (new sesh conf) close
 
-withTableFromSnapshot :: forall h m k v blob a.
+withTableFromSnapshot :: forall h m k v b a.
      ( IOLike m, IsTable h
-     , SerialiseKey k, SerialiseValue v, SerialiseValue blob
-     , C k v blob
+     , SerialiseKey k, SerialiseValue v, SerialiseValue b
+     , C k v b
      )
   => Session h m
   -> SnapshotLabel
   -> SnapshotName
-  -> (h m k v blob -> m a)
+  -> (h m k v b -> m a)
   -> m a
 withTableFromSnapshot sesh label snap = bracket (openSnapshot sesh label snap) close
 
-withTableDuplicate :: forall h m k v blob a.
+withTableDuplicate :: forall h m k v b a.
      ( IOLike m
      , IsTable h
-     , C k v blob
+     , C k v b
      )
-  => h m k v blob
-  -> (h m k v blob -> m a)
+  => h m k v b
+  -> (h m k v b -> m a)
   -> m a
 withTableDuplicate table = bracket (duplicate table) close
 
-withCursor :: forall h m k v blob a.
+withCursor :: forall h m k v b a.
      ( IOLike m
      , IsTable h
      , SerialiseKey k
-     , C k v blob
+     , C k v b
      )
   => Maybe k
-  -> h m k v blob
-  -> (Cursor h m k v blob -> m a)
+  -> h m k v b
+  -> (Cursor h m k v b -> m a)
   -> m a
 withCursor offset hdl = bracket (newCursor offset hdl) (closeCursor (Proxy @h))
 

--- a/test/Database/LSMTree/Model/IO/Normal.hs
+++ b/test/Database/LSMTree/Model/IO/Normal.hs
@@ -27,19 +27,19 @@ import qualified Database.LSMTree.Model.Session as Model
 
 newtype Session m = Session (StrictTVar m (Maybe Model.Model))
 
-data Table m k v blob = Table {
+data Table m k v b = Table {
     _thSession :: !(Session m)
-  , _thTable   :: !(Model.Table k v blob)
+  , _thTable   :: !(Model.Table k v b)
   }
 
-data BlobRef m blob = BlobRef {
+data BlobRef m b = BlobRef {
     _brSession :: !(Session m)
-  , _brBlobRef :: !(Model.BlobRef blob)
+  , _brBlobRef :: !(Model.BlobRef b)
   }
 
-data Cursor m k v blob = Cursor {
+data Cursor m k v b = Cursor {
     _cSession :: !(Session m)
-  , _cCursor  :: !(Model.Cursor k v blob)
+  , _cCursor  :: !(Model.Cursor k v b)
   }
 
 newtype Err = Err (Model.Err)

--- a/test/Database/LSMTree/Model/Table.hs
+++ b/test/Database/LSMTree/Model/Table.hs
@@ -123,7 +123,7 @@ type role Table nominal nominal nominal
 empty :: Table k v b
 empty = Table Map.empty
 
-size :: Table k v blob -> Int
+size :: Table k v b -> Int
 size (Table m) = Map.size m
 
 -- | This instance is for testing and debugging only.
@@ -249,31 +249,31 @@ mupserts r = updates r . fmap (second Mupsert)
 -------------------------------------------------------------------------------}
 
 retrieveBlobs ::
-     SerialiseValue blob
-  => V.Vector (BlobRef blob)
-  -> V.Vector blob
+     SerialiseValue b
+  => V.Vector (BlobRef b)
+  -> V.Vector b
 retrieveBlobs refs = V.map getBlobFromRef refs
 
-data BlobRef blob = BlobRef
+data BlobRef b = BlobRef
     !BS.ByteString  -- ^ digest
     !RawBytes       -- ^ actual contents
   deriving stock (Show)
 
 type role BlobRef nominal
 
-mkBlobRef :: SerialiseValue blob => blob -> BlobRef blob
+mkBlobRef :: SerialiseValue b => b -> BlobRef b
 mkBlobRef blob =  BlobRef (SHA256.hash bs) rb
   where
     !rb = serialiseValue blob
     !bs = deserialiseValue rb :: BS.ByteString
 
-coerceBlobRef :: BlobRef blob -> BlobRef blob'
+coerceBlobRef :: BlobRef b -> BlobRef b'
 coerceBlobRef (BlobRef d b) = BlobRef d b
 
-getBlobFromRef :: SerialiseValue blob => BlobRef blob -> blob
+getBlobFromRef :: SerialiseValue b => BlobRef b -> b
 getBlobFromRef (BlobRef _ rb) = deserialiseValue rb
 
-instance Eq (BlobRef blob) where
+instance Eq (BlobRef b) where
     BlobRef x _ == BlobRef y _ = x == y
 
 {-------------------------------------------------------------------------------

--- a/test/Test/Database/LSMTree/Internal/Entry.hs
+++ b/test/Test/Database/LSMTree/Internal/Entry.hs
@@ -43,8 +43,8 @@ tests = adjustOption (\_ -> QuickCheckTests 10000) $
 
 -- | @resolve == fromEntry . resolve . toEntry@
 prop_resolveEntriesNormalSemantics ::
-     (Show v, Show blob, Eq v, Eq blob, Semigroup v)
-  => NonEmpty (Normal.Update v blob)
+     (Show v, Show b, Eq v, Eq b, Semigroup v)
+  => NonEmpty (Normal.Update v b)
   -> Property
 prop_resolveEntriesNormalSemantics es = expected === real
   where expected = Just . unNormalUpdateSG . sconcat . fmap NormalUpdateSG $ es
@@ -72,10 +72,10 @@ instance Semigroup (Unlawful a) where
   _ <> _ = error "unlawful"
 
 -- | Semigroup wrapper for 'Normal.Update'
-newtype NormalUpdateSG v blob = NormalUpdateSG (Normal.Update v blob)
+newtype NormalUpdateSG v b = NormalUpdateSG (Normal.Update v b)
   deriving stock (Show, Eq)
   deriving newtype (Arbitrary)
-  deriving Semigroup via First (Normal.Update v blob)
+  deriving Semigroup via First (Normal.Update v b)
 
 unNormalUpdateSG :: NormalUpdateSG v b -> Normal.Update v b
 unNormalUpdateSG (NormalUpdateSG x) = x
@@ -96,11 +96,11 @@ instance Semigroup v => Semigroup (MonoidalUpdateSG v) where
       (Monoidal.Mupsert v1 , Monoidal.Insert  v2) -> Monoidal.Insert (v1 <> v2)
       (Monoidal.Mupsert v1 , Monoidal.Mupsert v2) -> Monoidal.Mupsert (v1 <> v2)
 
-newtype EntrySG v blob = EntrySG (Entry v blob)
+newtype EntrySG v b = EntrySG (Entry v b)
   deriving stock (Show, Eq)
   deriving newtype Semigroup
 
-instance (Arbitrary v, Arbitrary blob) => Arbitrary (EntrySG v blob) where
+instance (Arbitrary v, Arbitrary b) => Arbitrary (EntrySG v b) where
   arbitrary = arbitrary2
   shrink = shrink2
 
@@ -134,26 +134,26 @@ instance Arbitrary BlobSpanSG where
   Injections/projections
 -------------------------------------------------------------------------------}
 
-updateToEntryNormal :: Normal.Update v blob -> Entry v blob
+updateToEntryNormal :: Normal.Update v b -> Entry v b
 updateToEntryNormal = \case
     Normal.Insert v Nothing  -> Insert v
     Normal.Insert v (Just b) -> InsertWithBlob v b
     Normal.Delete            -> Delete
 
-entryToUpdateNormal :: Entry v blob -> Maybe (Normal.Update v blob)
+entryToUpdateNormal :: Entry v b -> Maybe (Normal.Update v b)
 entryToUpdateNormal = \case
     Insert v           -> Just (Normal.Insert v Nothing)
     InsertWithBlob v b -> Just (Normal.Insert v (Just b))
     Mupdate _          -> Nothing
     Delete             -> Just Normal.Delete
 
-updateToEntryMonoidal :: Monoidal.Update v -> Entry v blob
+updateToEntryMonoidal :: Monoidal.Update v -> Entry v b
 updateToEntryMonoidal = \case
     Monoidal.Insert v  -> Insert v
     Monoidal.Mupsert v -> Mupdate v
     Monoidal.Delete    -> Delete
 
-entryToUpdateMonoidal :: Entry v blob -> Maybe (Monoidal.Update v)
+entryToUpdateMonoidal :: Entry v b -> Maybe (Monoidal.Update v)
 entryToUpdateMonoidal = \case
     Insert v           -> Just (Monoidal.Insert v)
     InsertWithBlob _ _ -> Nothing

--- a/test/Test/Database/LSMTree/StateMachine/Op.hs
+++ b/test/Test/Database/LSMTree/StateMachine/Op.hs
@@ -40,8 +40,8 @@ data Op a b where
   OpFromLeft           :: Op (Either a b) a
   OpFromRight          :: Op (Either a b) b
   OpComp               :: Op b c -> Op a b -> Op a c
-  OpLookupResults      :: Op (V.Vector (Class.LookupResult v (WrapBlobRef h IO blobref))) (V.Vector (WrapBlobRef h IO blobref))
-  OpQueryResults       :: Op (V.Vector (Class.QueryResult k v (WrapBlobRef h IO blobref))) (V.Vector (WrapBlobRef h IO blobref))
+  OpLookupResults      :: Op (V.Vector (Class.LookupResult v (WrapBlobRef h IO b))) (V.Vector (WrapBlobRef h IO b))
+  OpQueryResults       :: Op (V.Vector (Class.QueryResult k v (WrapBlobRef h IO b))) (V.Vector (WrapBlobRef h IO b))
 
 intOpId :: Op a b -> a -> Maybe b
 intOpId OpId            = Just
@@ -155,7 +155,7 @@ instance Show (Op a b) where
 -------------------------------------------------------------------------------}
 
 class HasBlobRef f where
-  getBlobRef :: f blobref  -> Maybe blobref
+  getBlobRef :: f b  -> Maybe b
 
 instance HasBlobRef (Class.LookupResult v) where
   getBlobRef Class.NotFound{}                = Nothing

--- a/test/Test/Util/Orphans.hs
+++ b/test/Test/Util/Orphans.hs
@@ -45,16 +45,16 @@ type family RealizeIOSim s a where
   RealizeIOSim s (Real.TMVar a) = TMVar (IOSim s) a
   RealizeIOSim s (Real.MVar a)  = MVar (IOSim s) a
   -- lsm-tree
-  RealizeIOSim s (Table IO k v blob)       = Table (IOSim s) k v blob
-  RealizeIOSim s (LookupResult v blobref)        = LookupResult v (RealizeIOSim s blobref)
-  RealizeIOSim s (QueryResult k v blobref)       = QueryResult k v (RealizeIOSim s blobref)
-  RealizeIOSim s (Cursor IO k v blob)            = Table (IOSim s) k v blob
-  RealizeIOSim s (BlobRef IO blob)               = BlobRef (IOSim s) blob
+  RealizeIOSim s (Table IO k v b)    = Table (IOSim s) k v b
+  RealizeIOSim s (LookupResult v b)  = LookupResult v (RealizeIOSim s b)
+  RealizeIOSim s (QueryResult k v b) = QueryResult k v (RealizeIOSim s b)
+  RealizeIOSim s (Cursor IO k v b)   = Table (IOSim s) k v b
+  RealizeIOSim s (BlobRef IO b)      = BlobRef (IOSim s) b
   -- Type family wrappers
-  RealizeIOSim s (WrapTable h IO k v blob) = WrapTable h (IOSim s) k v blob
-  RealizeIOSim s (WrapCursor h IO k v blob)      = WrapCursor h (IOSim s) k v blob
-  RealizeIOSim s (WrapBlobRef h IO blob)         = WrapBlobRef h (IOSim s) blob
-  RealizeIOSim s (WrapBlob blob)                 = WrapBlob blob
+  RealizeIOSim s (WrapTable h IO k v b)  = WrapTable h (IOSim s) k v b
+  RealizeIOSim s (WrapCursor h IO k v b) = WrapCursor h (IOSim s) k v b
+  RealizeIOSim s (WrapBlobRef h IO b)    = WrapBlobRef h (IOSim s) b
+  RealizeIOSim s (WrapBlob b)            = WrapBlob b
   -- Congruence
   RealizeIOSim s (f a b) = f (RealizeIOSim s a) (RealizeIOSim s b)
   RealizeIOSim s (f a)   = f (RealizeIOSim s a)

--- a/test/Test/Util/TypeFamilyWrappers.hs
+++ b/test/Test/Util/TypeFamilyWrappers.hs
@@ -33,30 +33,30 @@ newtype WrapSession h m = WrapSession {
 type WrapTable ::
      ((Type -> Type) -> Type -> Type -> Type -> Type)
   -> (Type -> Type) -> Type -> Type -> Type -> Type
-newtype WrapTable h m k v blob = WrapTable {
-    unwrapTable :: h m k v blob
+newtype WrapTable h m k v b = WrapTable {
+    unwrapTable :: h m k v b
   }
   deriving stock (Show, Eq)
 
 type WrapCursor ::
      ((Type -> Type) -> Type -> Type -> Type -> Type)
   -> (Type -> Type) -> Type -> Type -> Type -> Type
-newtype WrapCursor h m k v blob = WrapCursor {
-    unwrapCursor :: SUT.Class.Cursor h m k v blob
+newtype WrapCursor h m k v b = WrapCursor {
+    unwrapCursor :: SUT.Class.Cursor h m k v b
   }
 
 type WrapBlobRef ::
      ((Type -> Type) -> Type -> Type -> Type -> Type)
   -> (Type -> Type) -> Type -> Type
-newtype WrapBlobRef h m blob = WrapBlobRef {
-    unwrapBlobRef :: SUT.Class.BlobRef h m blob
+newtype WrapBlobRef h m b = WrapBlobRef {
+    unwrapBlobRef :: SUT.Class.BlobRef h m b
   }
 
-deriving stock instance Show (SUT.Class.BlobRef h m blob) => Show (WrapBlobRef h m blob)
-deriving stock instance Eq (SUT.Class.BlobRef h m blob) => Eq (WrapBlobRef h m blob)
+deriving stock instance Show (SUT.Class.BlobRef h m b) => Show (WrapBlobRef h m b)
+deriving stock instance Eq (SUT.Class.BlobRef h m b) => Eq (WrapBlobRef h m b)
 
 type WrapBlob :: Type -> Type
-newtype WrapBlob blob = WrapBlob {
-    unwrapBlob :: blob
+newtype WrapBlob b = WrapBlob {
+    unwrapBlob :: b
   }
   deriving stock (Show, Eq)


### PR DESCRIPTION
Follow-up to #469. It's a rather pervasive change, so I'm keeping this PR in draft mode until more important PRs have landed on `main`