### PR TITLE
WIP: Adding in `fsync`-like capabilities to `HasBlockIO` abstractions

### DIFF
--- a/blockio-api/src-linux/System/FS/BlockIO/Async.hs
+++ b/blockio-api/src-linux/System/FS/BlockIO/Async.hs
@@ -110,7 +110,7 @@ ioopConv (IOOpWrite h off buf bufOff c) = handleFd h >>= \fd ->
 --
 -- TODO: if the handle were to have a reader/writer lock, then we could take the
 -- reader lock in 'submitIO'. However, the current implementation of 'Handle'
--- only allows mutally exclusive access to the underlying file descriptor, so it
+-- only allows mutually exclusive access to the underlying file descriptor, so it
 -- would require a change in @fs-api@. See [fs-sim#49].
 handleFd :: Handle HandleIO -> IO Fd
 handleFd h = withOpenHandle "submitIO" (handleRaw h) pure

--- a/blockio-api/src-linux/System/FS/BlockIO/Async.hs
+++ b/blockio-api/src-linux/System/FS/BlockIO/Async.hs
@@ -35,7 +35,7 @@ asyncHasBlockIO ::
   -> HasFS IO HandleIO
   -> API.IOCtxParams
   -> IO (API.HasBlockIO IO HandleIO)
-asyncHasBlockIO hSetNoCache hAdvise hAllocate tryLockFile hasFS ctxParams = do
+asyncHasBlockIO hSetNoCache hAdvise hAllocate hSynchronize tryLockFile hasFS ctxParams = do
   ctx <- I.initIOCtx (ctxParamsConv ctxParams)
   pure $ API.HasBlockIO {
       API.close = I.closeIOCtx ctx
@@ -43,6 +43,7 @@ asyncHasBlockIO hSetNoCache hAdvise hAllocate tryLockFile hasFS ctxParams = do
     , API.hSetNoCache
     , API.hAdvise
     , API.hAllocate
+    , API.hSynchronize
     , API.tryLockFile
     }
 

--- a/blockio-api/src/System/FS/BlockIO/Serial.hs
+++ b/blockio-api/src/System/FS/BlockIO/Serial.hs
@@ -23,10 +23,11 @@ serialHasBlockIO ::
   => (Handle h -> Bool -> m ())
   -> (Handle h -> API.FileOffset -> API.FileOffset -> API.Advice -> m ())
   -> (Handle h -> API.FileOffset -> API.FileOffset -> m ())
+  -> (Handle h -> m ())
   -> (FsPath -> LockMode -> m (Maybe (API.LockFileHandle m)))
   -> HasFS m h
   -> m (API.HasBlockIO m h)
-serialHasBlockIO hSetNoCache hAdvise hAllocate tryLockFile hfs = do
+serialHasBlockIO hSetNoCache hAdvise hAllocate hSynchronize tryLockFile hfs = do
   ctx <- initIOCtx (SomeHasFS hfs)
   pure $ API.HasBlockIO {
       API.close = close ctx
@@ -34,6 +35,7 @@ serialHasBlockIO hSetNoCache hAdvise hAllocate tryLockFile hfs = do
     , API.hSetNoCache
     , API.hAdvise
     , API.hAllocate
+    , API.hSynchronize
     , API.tryLockFile
     }
 

--- a/blockio-sim/src/System/FS/BlockIO/Sim.hs
+++ b/blockio-sim/src/System/FS/BlockIO/Sim.hs
@@ -27,7 +27,7 @@ fromHasFS ::
   => HasFS m HandleMock
   -> m (HasBlockIO m HandleMock)
 fromHasFS hfs =
-    serialHasBlockIO hSetNoCache hAdvise hAllocate (simTryLockFile hfs) hfs
+    serialHasBlockIO hSetNoCache hAdvise hAllocate hSynchronize (simTryLockFile hfs) hfs
   where
     -- TODO: It should be possible for the implementations and simulation to
     -- throw an FsError when doing file I/O with misaligned byte arrays after
@@ -36,6 +36,7 @@ fromHasFS hfs =
     hSetNoCache _h _b = pure ()
     hAdvise _ _ _ _ = pure ()
     hAllocate _ _ _ = pure ()
+    hSynchronize _ = pure ()
 
 -- | Lock files are reader\/writer locks.
 --

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -761,11 +761,15 @@ library blockio-api
 
   elif os(osx)
     hs-source-dirs: blockio-api/src-macos
-    build-depends:  lsm-tree:fcntl-nocache
+    build-depends:
+      , lsm-tree:fcntl-nocache
+      , unix                    ^>=2.8
+
     other-modules:  System.FS.BlockIO.Internal
 
   elif os(windows)
     hs-source-dirs: blockio-api/src-windows
+    build-depends:  Win32 >=2.13 && <3.0
     other-modules:  System.FS.BlockIO.Internal
 
   if flag(serialblockio)


### PR DESCRIPTION
# Description

Adds "file synchronization" capabilities to the `blockio-api` and `blockio-sim` packages. This includes `fsync` and `fdatasync` on POSIX systems (includes MacOS). 

The new function added to the `HasBlockIO` type-class for "flushing" buffered data to the storage medium is `hSynchronize`.

I'm handing this PR off to @jorisdral.

Next steps:

   - [ ] Bikshedding whether to use American or British English, potentially renaming to `hSynchronise`.
   - [ ] Ensure that `hSynchronise` works on Linux.
   - [X] Ensure that `hSynchronise` works on MacOSs.
   - [ ] Ensure that `hSynchronise` works on Windows.
   - [ ] Ensure that there is no other missing call sites/hooks that need to be added.