### PR TITLE
Make `headerLBS` and `finalLBS` index-type-polymorphic

### DIFF
--- a/src/Database/LSMTree/Internal/ChecksumHandle.hs
+++ b/src/Database/LSMTree/Internal/ChecksumHandle.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MagicHash #-}
+
 module Database.LSMTree.Internal.ChecksumHandle
   (
     -- * Checksum handles
@@ -44,6 +46,7 @@ import qualified Database.LSMTree.Internal.RawOverflowPage as RawOverflowPage
 import           Database.LSMTree.Internal.RawPage (RawPage)
 import qualified Database.LSMTree.Internal.RawPage as RawPage
 import           Database.LSMTree.Internal.Serialise
+import           GHC.Exts (Proxy#)
 import qualified System.FS.API as FS
 import           System.FS.API
 import qualified System.FS.BlockIO.API as FS
@@ -204,15 +207,17 @@ writeFilter hfs filterHandle bf =
 {-# SPECIALISE writeIndexHeader ::
      HasFS IO h
   -> ForIndex (ChecksumHandle RealWorld h)
+  -> Proxy# IndexCompact
   -> IO () #-}
 writeIndexHeader ::
      (MonadSTM m, PrimMonad m)
   => HasFS m h
   -> ForIndex (ChecksumHandle (PrimState m) h)
+  -> Proxy# IndexCompact
   -> m ()
-writeIndexHeader hfs indexHandle =
+writeIndexHeader hfs indexHandle indexTypeProxy =
     writeToHandle hfs (unForIndex indexHandle) $
-      Index.headerLBS
+      Index.headerLBS indexTypeProxy
 
 {-# SPECIALISE writeIndexChunk ::
      HasFS IO h

--- a/src/Database/LSMTree/Internal/RunBuilder.hs
+++ b/src/Database/LSMTree/Internal/RunBuilder.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MagicHash #-}
+
 -- | A mutable run ('RunBuilder') that is under construction.
 --
 module Database.LSMTree.Internal.RunBuilder (
@@ -30,6 +32,7 @@ import           Database.LSMTree.Internal.RawPage (RawPage)
 import           Database.LSMTree.Internal.RunAcc (RunAcc, RunBloomFilterAlloc)
 import qualified Database.LSMTree.Internal.RunAcc as RunAcc
 import           Database.LSMTree.Internal.Serialise
+import           GHC.Exts (proxy#)
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS)
 import qualified System.FS.BlockIO.API as FS
@@ -90,7 +93,7 @@ new hfs hbio runBuilderFsPaths numEntries alloc = do
     runBuilderHandles <- traverse (makeHandle hfs) (pathsForRunFiles runBuilderFsPaths)
 
     let builder = RunBuilder { runBuilderHasFS = hfs, runBuilderHasBlockIO = hbio, .. }
-    writeIndexHeader hfs (forRunIndex runBuilderHandles)
+    writeIndexHeader hfs (forRunIndex runBuilderHandles) (proxy# @IndexCompact)
     return builder
 
 {-# SPECIALISE addKeyOp ::


### PR DESCRIPTION
Generation of headers and footers of serialized indexes has so far been working only for compact indexes. This pull request introduces an implementation of this functionality for ordinary indexes and extends the `Index` type class such that header and footer generation can be accessed independently of the concrete index type.

As a side change, this pull request also corrects the naming of `postVersionBytes`, an entity local to the `fromSBS` definition for `IndexOrdinary`, to `postTypeAndVersionBytes`.