### PR TITLE
Boilerplate for the implementation of n-way unions

### DIFF
--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -125,15 +125,16 @@ deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h, Typeable (
 deriving stock instance Generic (Internal.Table m h)
 -- | Does not check 'NoThunks' for the 'Internal.Session' that this
 -- 'Internal.Table' belongs to.
-deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h, Typeable (PrimState m))
-                        => NoThunks (Internal.Table m h)
+deriving via AllowThunksIn '["tableSession"] (Table m h)
+    instance (NoThunksIOLike m, Typeable m, Typeable h, Typeable (PrimState m))
+          => NoThunks (Internal.Table m h)
 
 deriving stock instance Generic (TableState m h)
 deriving anyclass instance (NoThunksIOLike m, Typeable m, Typeable h, Typeable (PrimState m))
                         => NoThunks (TableState m h)
 
 deriving stock instance Generic (TableEnv m h)
-deriving via AllowThunksIn ["tableSession", "tableSessionEnv"] (TableEnv m h)
+deriving via AllowThunksIn '["tableSessionEnv"] (TableEnv m h)
     instance (NoThunksIOLike m, Typeable m, Typeable h, Typeable (PrimState m))
           => NoThunks (TableEnv m h)
 

--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -107,6 +107,7 @@ import           Control.Monad.Class.MonadThrow
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Coerce (coerce)
 import           Data.Kind (Type)
+import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Typeable (Proxy (..), Typeable, eqT, type (:~:) (Refl))
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (BlobRef (BlobRef), IOLike, Range (..),
@@ -529,21 +530,20 @@ union :: forall m k v b.
   => Table m k v b
   -> Table m k v b
   -> m (Table m k v b)
-union t1 t2 = unions $ V.fromList [t1, t2]
+union t1 t2 = unions $ t1 :| [t2]
 
 {-# SPECIALISE unions ::
-     V.Vector (Table IO k v b)
+     NonEmpty (Table IO k v b)
   -> IO (Table IO k v b) #-}
 unions :: forall m k v b.
      IOLike m
-  => V.Vector (Table m k v b)
+  => NonEmpty (Table m k v b)
   -> m (Table m k v b)
-unions ts0
-  | Just (Internal.Table' (t' :: Internal.Table m h), ts)
-      <- V.uncons ts0
-  = do ts' <- V.imapM (checkTableType (proxy# @h)) ts
-       Internal.Table' <$> Internal.unions (t' `V.cons` ts')
-  | otherwise = throwIO Internal.ErrUnionsZeroTables
+unions (t :| ts) =
+    case t of
+      Internal.Table' (t' :: Internal.Table m h) -> do
+        ts' <- zipWithM (checkTableType (proxy# @h)) [1..] ts
+        Internal.Table' <$> Internal.unions (t' :| ts')
   where
     checkTableType ::
          forall h. Typeable h
@@ -551,8 +551,8 @@ unions ts0
       -> Int
       -> Table m k v b
       -> m (Internal.Table m h)
-    checkTableType _ i (Internal.Table' (t :: Internal.Table m h'))
-      | Just Refl <- eqT @h @h' = pure t
+    checkTableType _ i (Internal.Table' (t' :: Internal.Table m h'))
+      | Just Refl <- eqT @h @h' = pure t'
       | otherwise = throwIO (Internal.ErrUnionsTableTypeMismatch 0 i)
 
 {-------------------------------------------------------------------------------

--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -518,28 +518,24 @@ duplicate (Internal.Table' t) = Internal.Table' <$!> Internal.duplicate t
 -------------------------------------------------------------------------------}
 
 {-# SPECIALISE union ::
-     ResolveValue v
-  => Table IO k v b
+     Table IO k v b
   -> Table IO k v b
   -> IO (Table IO k v b) #-}
 union :: forall m k v b.
-     ( IOLike m
-     , ResolveValue v
-     )
+     IOLike m
   => Table m k v b
   -> Table m k v b
   -> m (Table m k v b)
-union = error "union: not yet implemented" $ union @m @k @v @b
+union = error "union: not yet implemented" $ Internal.union @m
 
 {-# SPECIALISE unions ::
-     ResolveValue v
-  => V.Vector (Table IO k v b)
+     V.Vector (Table IO k v b)
   -> IO (Table IO k v b) #-}
 unions :: forall m k v b.
-     (IOLike m, ResolveValue v)
+     IOLike m
   => V.Vector (Table m k v b)
   -> m (Table m k v b)
-unions = error "unions: not yet implemented" $ unions @m @k @v
+unions = error "unions: not yet implemented" $ Internal.unions @m
 
 {-------------------------------------------------------------------------------
   Monoidal value resolution

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -223,6 +223,10 @@ data LSMTreeError =
   | ErrBlobRefInvalid Int
     -- | 'unions' was called on zero tables. Use 'new' instead.
   | ErrUnionsZeroTables
+    -- | 'unions' was called on tables that are not of the same type.
+  | ErrUnionsTableTypeMismatch
+      Int -- ^ Vector index of table @t1@ involved in the mismatch
+      Int -- ^ Vector index of table @t2@ involved in the mismatch
     -- | 'unions' was called on tables that are not in the same session.
   | ErrUnionsSessionMismatch
       Int -- ^ Vector index of table @t1@ involved in the mismatch

--- a/src/Database/LSMTree/Internal/Paths.hs
+++ b/src/Database/LSMTree/Internal/Paths.hs
@@ -59,6 +59,7 @@ import           System.FS.API
 
 
 newtype SessionRoot = SessionRoot { getSessionRoot :: FsPath }
+  deriving stock Eq
 
 lockFile :: SessionRoot -> FsPath
 lockFile (SessionRoot dir) = dir </> mkFsPath ["lock"]

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -649,8 +649,7 @@ duplicate (Internal.MonoidalTable t) = Internal.MonoidalTable <$> Internal.dupli
 -------------------------------------------------------------------------------}
 
 {-# SPECIALISE union ::
-     ResolveValue v
-  => Table IO k v
+     Table IO k v
   -> Table IO k v
   -> IO (Table IO k v) #-}
 -- | Union two full tables, creating a new table.
@@ -665,17 +664,14 @@ duplicate (Internal.MonoidalTable t) = Internal.MonoidalTable <$> Internal.dupli
 -- NOTE: unioning tables creates a new table, but does not close the tables that
 -- were used as inputs.
 union :: forall m k v.
-     ( IOLike m
-     , ResolveValue v
-     )
+     IOLike m
   => Table m k v
   -> Table m k v
   -> m (Table m k v)
-union = error "union: not yet implemented" $ union @m @k @v
+union = error "union: not yet implemented" $ Internal.union @m
 
 {-# SPECIALISE unions ::
-     ResolveValue v
-  => V.Vector (Table IO k v)
+     V.Vector (Table IO k v)
   -> IO (Table IO k v) #-}
 -- | Like 'union', but for @n@ tables.
 --
@@ -686,10 +682,10 @@ union = error "union: not yet implemented" $ union @m @k @v
 --
 -- * Unioning 0 tables is an exception.
 unions :: forall m k v.
-     (IOLike m, ResolveValue v)
+     IOLike m
   => V.Vector (Table m k v)
   -> m (Table m k v)
-unions = error "unions: not yet implemented" $ unions @m @k @v
+unions = error "unions: not yet implemented" $ Internal.unions @m
 
 {-------------------------------------------------------------------------------
   Monoidal value resolution

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -787,7 +787,7 @@ union :: forall m k v b.
   => Table m k v b
   -> Table m k v b
   -> m (Table m k v b)
-union = error "union: not yet implemented" $ union @m @k @v
+union = error "union: not yet implemented" $ Internal.union @m
 
 {-# SPECIALISE unions :: V.Vector (Table IO k v b) -> IO (Table IO k v b) #-}
 -- | Like 'union', but for @n@ tables.
@@ -802,4 +802,4 @@ unions :: forall m k v b.
      IOLike m
   => V.Vector (Table m k v b)
   -> m (Table m k v b)
-unions = error "union: not yet implemented" $ union @m @k @v
+unions = error "unions: not yet implemented" $ Internal.unions @m

--- a/test/Database/LSMTree/Class.hs
+++ b/test/Database/LSMTree/Class.hs
@@ -16,6 +16,7 @@ module Database.LSMTree.Class (
 
 import           Control.Monad.Class.MonadThrow (MonadThrow (..))
 import           Data.Kind (Constraint, Type)
+import           Data.List.NonEmpty (NonEmpty)
 import           Data.Typeable (Proxy (..))
 import qualified Data.Vector as V
 import           Database.LSMTree as Types (LookupResult (..), QueryResult (..),
@@ -167,7 +168,7 @@ class (IsSession (Session h)) => IsTable h where
            ( IOLike m
            , C k v b
            )
-        => V.Vector (h m k v b)
+        => NonEmpty (h m k v b)
         -> m (h m k v b)
 
 withTableNew :: forall h m k v b a.
@@ -204,7 +205,7 @@ withTableUnion table1 table2 = bracket (table1 `union` table2) close
 
 withTableUnions :: forall h m k v b a.
      (IOLike m, IsTable h, C k v b)
-  => V.Vector (h m k v b)
+  => NonEmpty (h m k v b)
   -> (h m k v b -> m a)
   -> m a
 withTableUnions tables = bracket (unions tables) close

--- a/test/Database/LSMTree/Model/IO.hs
+++ b/test/Database/LSMTree/Model/IO.hs
@@ -17,7 +17,7 @@ module Database.LSMTree.Model.IO (
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Exception (Exception)
 import           Control.Monad.Class.MonadThrow (MonadThrow (..))
-import qualified Data.Vector as V
+import qualified Data.List.NonEmpty as NE
 import qualified Database.LSMTree.Class as Class
 import           Database.LSMTree.Model.Session (TableConfig (..))
 import qualified Database.LSMTree.Model.Session as Model
@@ -93,6 +93,6 @@ instance Class.IsTable Table where
       Table s1 <$> runInOpenSession s1 (Model.union Model.getResolve t1 t2)
 
     unions ts =
-        Table s <$> runInOpenSession s (Model.unions Model.getResolve (V.map thTable ts))
+        Table s <$> runInOpenSession s (Model.unions Model.getResolve (fmap thTable ts))
       where
-        Table s _ = V.head ts
+        Table s _ = NE.head ts

--- a/test/Database/LSMTree/Model/Session.hs
+++ b/test/Database/LSMTree/Model/Session.hs
@@ -76,7 +76,7 @@ module Database.LSMTree.Model.Session (
   , unions
   ) where
 
-import           Control.Monad (when)
+import           Control.Monad (forM, when)
 import           Control.Monad.Except (ExceptT (..), MonadError (..),
                      runExceptT)
 import           Control.Monad.Identity (Identity (runIdentity))
@@ -84,6 +84,7 @@ import           Control.Monad.State.Strict (MonadState (..), StateT (..), gets,
                      modify)
 import           Data.Data
 import           Data.Dynamic
+import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromJust)
@@ -638,14 +639,10 @@ unions ::
      , C k v b
      )
   => ResolveSerialisedValue v
-  -> V.Vector (Table k v b)
+  -> NonEmpty (Table k v b)
   -> m (Table k v b)
-unions r tables
-  | n == 0 = throwError ErrUnionsZeroTables
-  | otherwise = do
-      tables' <- V.forM tables $ \table -> do
-        (_, table') <- guardTableIsOpen table
-        pure table'
-      newTableWith TableConfig $ Model.unions r tables'
-  where
-    n = V.length tables
+unions r tables = do
+    tables' <- forM tables $ \table -> do
+      (_, table') <- guardTableIsOpen table
+      pure table'
+    newTableWith TableConfig $ Model.unions r tables'

--- a/test/Database/LSMTree/Model/Table.hs
+++ b/test/Database/LSMTree/Model/Table.hs
@@ -47,6 +47,7 @@ import qualified Crypto.Hash.SHA256 as SHA256
 import           Data.Bifunctor
 import qualified Data.ByteString as BS
 import           Data.Kind (Type)
+import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Map (Map)
 import qualified Data.Map.Range as Map.R
 import qualified Data.Map.Strict as Map
@@ -317,7 +318,7 @@ union r (Table xs) (Table ys) =
 -- | Like 'union', but for @n@ tables.
 unions ::
      ResolveSerialisedValue v
-  -> V.Vector (Table k v b)
+  -> NonEmpty (Table k v b)
   -> Table k v b
 unions r tables =
-    Table (Map.unionsWith (resolveValueAndBlob r) (V.map values tables))
+    Table (Map.unionsWith (resolveValueAndBlob r) (fmap values tables))

--- a/test/Test/Database/LSMTree/UnitTests.hs
+++ b/test/Test/Database/LSMTree/UnitTests.hs
@@ -36,9 +36,7 @@ tests =
 
         -- Properties
 
-      , testProperty "prop_unions_0" $
-          -- TODO: enable once unions are implemented
-          QC.expectFailure prop_unions_0
+      , testProperty "prop_unions_0" $ prop_unions_0
       , testProperty "prop_unions_1" $
           -- TODO: enable once unions are implemented
           QC.expectFailure prop_unions_1
@@ -161,12 +159,8 @@ unit_snapshots =
 prop_unions_0 :: Property
 prop_unions_0 =
     QC.once $ QC.ioProperty $
-    assertException err $
+    assertException ErrUnionsZeroTables $
       void $ unions @_ @Key1 @Value1 @Blob1 V.empty
-  where
-    -- TODO: fill in once unions has an implementation
-    err :: LSMTreeError
-    err = error "unit_unions_0: unions has no implementation yet"
 
 -- | Unions of 1 table are equivalent to duplicate
 prop_unions_1 :: Property


### PR DESCRIPTION
We add a new `unions` function to the `Internal` module, which should eventually contain the full implementation of unions. For now, the function contains boilerplate for:

* Checking that all input tables have the same configuration, and
* Checking that all input tables are in the same session, and
* Duplicating references to the table contents for each of the tables
* Creating a new table with unioned table contents

The unioning of table contents is not yet implemented and will follow in some later set of PRs.
