### PR TITLE
Use functional dependencies rather than type families to enable SPECIALISE

### DIFF
--- a/src/Database/LSMTree/Internal/BlobFile.hs
+++ b/src/Database/LSMTree/Internal/BlobFile.hs
@@ -32,8 +32,7 @@ data BlobFile m h = BlobFile {
      }
   deriving stock (Show)
 
-instance RefCounted (BlobFile m h) where
-    type FinaliserM (BlobFile m h) = m
+instance RefCounted m (BlobFile m h) where
     getRefCounter = blobFileRefCounter
 
 instance NFData h => NFData (BlobFile m h) where

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -325,8 +325,7 @@ data MergingRun m h = MergingRun {
     , mergeRefCounter     :: !(RefCounter m)
     }
 
-instance RefCounted (MergingRun m h) where
-    type FinaliserM (MergingRun m h) = m
+instance RefCounted m (MergingRun m h) where
     getRefCounter = mergeRefCounter
 
 {-# SPECIALISE newMergingRun ::

--- a/src/Database/LSMTree/Internal/Run.hs
+++ b/src/Database/LSMTree/Internal/Run.hs
@@ -101,8 +101,7 @@ instance NFData h => NFData (Run m h) where
       rnf a `seq` rwhnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq`
       rnf f `seq` rnf g `seq` rnf h `seq` rwhnf i `seq` rwhnf j
 
-instance RefCounted (Run m h) where
-    type FinaliserM (Run m h) = m
+instance RefCounted m (Run m h) where
     getRefCounter = runRefCounter
 
 size :: Ref (Run m h) -> NumEntries

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -112,8 +112,7 @@ data WriteBufferBlobs m h =
 instance NFData h => NFData (WriteBufferBlobs m h) where
   rnf (WriteBufferBlobs a b c) = rnf a `seq` rnf b `seq` rnf c
 
-instance RefCounted (WriteBufferBlobs m h) where
-  type FinaliserM (WriteBufferBlobs m h) = m
+instance RefCounted m (WriteBufferBlobs m h) where
   getRefCounter = writeBufRefCounter
 
 {-# SPECIALISE new :: HasFS IO h -> FS.FsPath -> IO (Ref (WriteBufferBlobs IO h)) #-}

--- a/test-control/Test/Control/RefCount.hs
+++ b/test-control/Test/Control/RefCount.hs
@@ -108,14 +108,12 @@ readRefCount (RefCounter countVar _) = readPrimVar countVar
 #ifdef NO_IGNORE_ASSERTS
 data TestObject = TestObject !(RefCounter IO)
 
-instance RefCounted TestObject where
-    type FinaliserM TestObject = IO
+instance RefCounted IO TestObject where
     getRefCounter (TestObject rc) = rc
 
 data TestObject2 = TestObject2 (Ref TestObject)
 
-instance RefCounted TestObject2 where
-    type FinaliserM TestObject2 = IO
+instance RefCounted IO TestObject2 where
     getRefCounter (TestObject2 (DeRef to1)) = getRefCounter to1
 
 prop_ref_double_free :: Property


### PR DESCRIPTION
@dcoutts As per my message, this enables SPECIALISE for the reference counting functions, since it eliminates the need for a `FinaliserM obj ~ m` constraint.