### PR TITLE
Test generators and shrinkers for snapshot metadata

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -384,6 +384,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.StateMachine.Op
     Test.Database.LSMTree.UnitTests
     Test.System.Posix.Fcntl.NoCache
+    Test.Util.Arbitrary
     Test.Util.FS
     Test.Util.Orphans
     Test.Util.PrettyProxy

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -15,6 +15,7 @@ module Database.LSMTree.Internal.Merge (
   , steps
   ) where
 
+import           Control.DeepSeq (NFData (..))
 import           Control.Exception (assert)
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadST (MonadST)
@@ -73,6 +74,10 @@ data MergeState =
 
 data Level = MidLevel | LastLevel
   deriving stock (Eq, Show)
+
+instance NFData Level where
+  rnf MidLevel  = ()
+  rnf LastLevel = ()
 
 type Mappend = SerialisedValue -> SerialisedValue -> SerialisedValue
 

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -45,6 +45,7 @@ module Database.LSMTree.Internal.MergeSchedule (
   ) where
 
 import           Control.Concurrent.Class.MonadMVar.Strict
+import           Control.DeepSeq (NFData (..))
 import           Control.Monad (void, when, (<$!>))
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
@@ -399,6 +400,10 @@ duplicateMergingRunRuns reg (DeRef mr) =
 data MergePolicyForLevel = LevelTiering | LevelLevelling
   deriving stock (Show, Eq)
 
+instance NFData MergePolicyForLevel where
+  rnf LevelTiering   = ()
+  rnf LevelLevelling = ()
+
 mergePolicyForLevel :: MergePolicy -> LevelNo -> Levels m h -> MergePolicyForLevel
 mergePolicyForLevel MergePolicyLazyLevelling (LevelNo n) nextLevels
   | n == 1
@@ -409,6 +414,7 @@ mergePolicyForLevel MergePolicyLazyLevelling (LevelNo n) nextLevels
 
 newtype NumRuns = NumRuns { unNumRuns :: Int }
   deriving stock (Show, Eq)
+  deriving newtype NFData
 
 newtype UnspentCreditsVar s = UnspentCreditsVar { getUnspentCreditsVar :: PrimVar s Int }
 
@@ -429,6 +435,10 @@ newtype SpentCreditsVar s = SpentCreditsVar { getSpentCreditsVar :: PrimVar s In
 
 data MergeKnownCompleted = MergeKnownCompleted | MergeMaybeCompleted
   deriving stock (Show, Eq, Read)
+
+instance NFData MergeKnownCompleted where
+  rnf MergeKnownCompleted = ()
+  rnf MergeMaybeCompleted = ()
 
 {-# SPECIALISE duplicateLevels :: TempRegistry IO -> Levels IO h -> IO (Levels IO h) #-}
 duplicateLevels ::

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -66,12 +66,12 @@ import qualified System.FS.API as FS
 import           System.FS.API (Handle (..), mkFsPath)
 import qualified System.FS.BlockIO.API as FS
 import           System.FS.BlockIO.API
-import           Test.Database.LSMTree.Generators (deepseqInvariant,
-                     prop_arbitraryAndShrinkPreserveInvariant,
-                     prop_forAllArbitraryAndShrinkPreserveInvariant)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
+import           Test.Util.Arbitrary (deepseqInvariant,
+                     prop_arbitraryAndShrinkPreserveInvariant,
+                     prop_forAllArbitraryAndShrinkPreserveInvariant)
 import           Test.Util.FS (withTempIOHasBlockIO)
 
 tests :: TestTree

--- a/test/Test/Util/Arbitrary.hs
+++ b/test/Test/Util/Arbitrary.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Util.Arbitrary (
+    prop_arbitraryAndShrinkPreserveInvariant
+  , prop_forAllArbitraryAndShrinkPreserveInvariant
+  , deepseqInvariant
+  ) where
+
+import           Control.DeepSeq (NFData, deepseq)
+import           Test.QuickCheck
+import           Test.Tasty (TestTree)
+import           Test.Tasty.QuickCheck (testProperty)
+
+prop_arbitraryAndShrinkPreserveInvariant ::
+    forall a. (Arbitrary a, Show a) => (a -> Bool) -> [TestTree]
+prop_arbitraryAndShrinkPreserveInvariant =
+    prop_forAllArbitraryAndShrinkPreserveInvariant arbitrary shrink
+
+prop_forAllArbitraryAndShrinkPreserveInvariant ::
+    forall a. Show a => Gen a -> (a -> [a]) -> (a -> Bool) -> [TestTree]
+prop_forAllArbitraryAndShrinkPreserveInvariant gen shr inv =
+    [ testProperty "Arbitrary satisfies invariant" $
+            property $ forAllShrink gen shr inv
+    , testProperty "Shrinking satisfies invariant" $
+            property $ forAll gen $ \x ->
+                         case shr x of
+                           [] -> label "no shrinks" $ property True
+                           xs -> forAll (growingElements xs) inv
+    ]
+
+-- | Trivial invariant, but checks that the value is finite
+deepseqInvariant :: NFData a => a -> Bool
+deepseqInvariant x = x `deepseq` True


### PR DESCRIPTION
I wrote these commits when I was debugging a looping shrinker, but it turned out it was not the shrinkers for metadata that was looping. It was the shrinker for the  `Errors` type instead (see [fs-sim#84](https://github.com/input-output-hk/fs-sim/pull/84)). So even though the new tests in this PR did not find any bugs, we might as well include the tests on `main`
