### PR TITLE
Split out module MergingRun

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -139,6 +139,7 @@ library
     Database.LSMTree.Internal.Lookup
     Database.LSMTree.Internal.Merge
     Database.LSMTree.Internal.MergeSchedule
+    Database.LSMTree.Internal.MergingRun
     Database.LSMTree.Internal.Page
     Database.LSMTree.Internal.PageAcc
     Database.LSMTree.Internal.PageAcc1

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -45,6 +45,7 @@ import           Database.LSMTree.Internal.Index.CompactAcc
 import           Database.LSMTree.Internal.Merge hiding (Level)
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule
+import           Database.LSMTree.Internal.MergingRun
 import           Database.LSMTree.Internal.Page
 import           Database.LSMTree.Internal.PageAcc
 import           Database.LSMTree.Internal.Paths

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1198,6 +1198,7 @@ openSnapshot sesh label tableType override snap resolve = do
         snapLevels' <- openRuns reg hfs hbio conf (sessionUniqCounter seshEnv) snapDir actDir snapLevels
         -- Convert from the snapshot format, restoring merge progress in the process
         tableLevels <- fromSnapLevels reg hfs hbio conf (sessionUniqCounter seshEnv) resolve actDir snapLevels'
+        releaseRuns reg snapLevels'
 
         tableCache <- mkLevelsCache reg tableLevels
         newWith reg sesh seshEnv conf' am $! TableContent {

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1112,7 +1112,9 @@ createSnapshot resolve snap label tableType t = do
           -- credits as if the buffer was full, and then flush the (possibly)
           -- underfull buffer. However, note that this bit of code
           -- here is probably going to change anyway because of #392
-          supplyCredits conf (Credit $ unNumEntries $ case confWriteBufferAlloc conf of AllocNumEntries x -> x) (tableLevels content)
+          let credits = case confWriteBufferAlloc conf of
+                AllocNumEntries n -> Credits (unNumEntries n)
+          supplyCredits conf credits (tableLevels content)
           content' <- flushWriteBuffer
                 (TraceMerge `contramap` tableTracer t)
                 conf

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP          #-}
-{-# LANGUAGE DataKinds    #-}
-{-# LANGUAGE TypeFamilies #-}
-
-{- HLINT ignore "Use when" -}
-
 -- TODO: establish that this implementation matches up with the ScheduledMerges
 -- prototype. See lsm-tree#445.
 module Database.LSMTree.Internal.MergeSchedule (
@@ -45,19 +39,16 @@ module Database.LSMTree.Internal.MergeSchedule (
   ) where
 
 import           Control.Concurrent.Class.MonadMVar.Strict
-import           Control.DeepSeq (NFData (..))
-import           Control.Monad (void, when, (<$!>))
+import           Control.Monad ((<$!>))
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
-import           Control.Monad.Class.MonadThrow (MonadCatch (bracketOnError),
-                     MonadMask, MonadThrow (..))
+import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow (..))
 import           Control.Monad.Primitive
 import           Control.RefCount
 import           Control.TempRegistry
 import           Control.Tracer
 import           Data.BloomFilter (Bloom)
 import           Data.Foldable (fold)
-import           Data.Primitive.MutVar
 import           Data.Primitive.PrimVar
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.Assertions (assert)
@@ -66,8 +57,8 @@ import           Database.LSMTree.Internal.Entry (Entry, NumEntries (..),
                      unNumEntries)
 import           Database.LSMTree.Internal.Index.Compact (IndexCompact)
 import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
-import           Database.LSMTree.Internal.Merge (Merge, StepResult (..))
 import qualified Database.LSMTree.Internal.Merge as Merge
+import           Database.LSMTree.Internal.MergingRun
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..),
                      SessionRoot (..))
 import qualified Database.LSMTree.Internal.Paths as Paths
@@ -304,105 +295,6 @@ data IncomingRun m h =
        Single  !(Ref (Run m h))
      | Merging !(Ref (MergingRun m h))
 
--- | A merging of multiple runs.
---
--- TODO: Move to a separate module.
-data MergingRun m h = MergingRun {
-      mergePolicy         :: !MergePolicyForLevel
-    , mergeNumRuns        :: !NumRuns
-      -- | Sum of number of entries in the input runs
-    , mergeNumEntries     :: !NumEntries
-      -- | The number of currently /unspent/ credits
-    , mergeUnspentCredits :: !(UnspentCreditsVar (PrimState m))
-      -- | The total number of performed merging steps.
-    , mergeStepsPerformed :: !(TotalStepsVar (PrimState m))
-      -- | A variable that caches knowledge about whether the merge has been
-      -- completed. If 'MergeKnownCompleted', then we are sure the merge has been
-      -- completed, otherwise if 'MergeMaybeCompleted' we have to check the
-      -- 'MergingRunState'.
-    , mergeKnownCompleted :: !(MutVar (PrimState m) MergeKnownCompleted)
-    , mergeState          :: !(StrictMVar m (MergingRunState m h))
-    , mergeRefCounter     :: !(RefCounter m)
-    }
-
-instance RefCounted m (MergingRun m h) where
-    getRefCounter = mergeRefCounter
-
-{-# SPECIALISE newMergingRun ::
-     MergePolicyForLevel
-  -> NumRuns
-  -> NumEntries
-  -> MergeKnownCompleted
-  -> MergingRunState IO h
-  -> IO (Ref (MergingRun IO h))
-  #-}
--- | This allows constructing ill-formed MergingRuns, but the flexibility is
--- needed for creating a merging run that is already Completed, as well as
--- opening a merging run from a snapshot.
---
--- TODO: instead create a Single run when OneShot merging?
---
--- TODO: do not store MergeKnownCompleted in snapshot? It's redundant.
---
--- TODO: slightly different API for opening from snapshot?
-newMergingRun ::
-     (MonadMVar m, MonadMask m, MonadSTM m, MonadST m)
-  => MergePolicyForLevel
-  -> NumRuns
-  -> NumEntries
-  -> MergeKnownCompleted
-  -> MergingRunState m h
-  -> m (Ref (MergingRun m h))
-newMergingRun mergePolicy mergeNumRuns mergeNumEntries knownCompleted state = do
-    mergeUnspentCredits <- UnspentCreditsVar <$> newPrimVar 0
-    mergeStepsPerformed <- TotalStepsVar <$> newPrimVar 0
-    case state of
-      OngoingMerge{}   -> assert (knownCompleted == MergeMaybeCompleted) (pure ())
-      CompletedMerge{} -> pure ()
-    mergeKnownCompleted <- newMutVar knownCompleted
-    mergeState <- newMVar $! state
-    newRef (finalise mergeState) $ \mergeRefCounter ->
-      MergingRun {
-        mergePolicy
-      , mergeNumRuns
-      , mergeNumEntries
-      , mergeUnspentCredits
-      , mergeStepsPerformed
-      , mergeKnownCompleted
-      , mergeState
-      , mergeRefCounter
-      }
-  where
-    finalise var = withMVar var $ \case
-        CompletedMerge r ->
-          releaseRef r
-        OngoingMerge rs _ m -> do
-          V.forM_ rs releaseRef
-          Merge.abort m
-
--- | Create references to the runs that should be queried for lookups.
--- In particular, if the merge is not complete, these are the input runs.
-duplicateMergingRunRuns ::
-     (PrimMonad m, MonadMVar m, MonadMask m)
-  => TempRegistry m
-  -> Ref (MergingRun m h)
-  -> m (V.Vector (Ref (Run m h)))
-duplicateMergingRunRuns reg (DeRef mr) =
-    -- We take the references while holding the MVar to make sure the MergingRun
-    -- does not get completed concurrently before we are done.
-    withMVar (mergeState mr) $ \case
-      CompletedMerge r    -> V.singleton <$> dupRun r
-      OngoingMerge rs _ _ -> V.mapM dupRun rs
-  where
-    dupRun r = allocateTemp reg (dupRef r) releaseRef
-
-data MergePolicyForLevel = LevelTiering | LevelLevelling
-  deriving stock (Show, Eq)
-
-instance NFData MergePolicyForLevel where
-  rnf LevelTiering   = ()
-  rnf LevelLevelling = ()
-
 mergePolicyForLevel :: MergePolicy -> LevelNo -> Levels m h -> MergePolicyForLevel
 mergePolicyForLevel MergePolicyLazyLevelling (LevelNo n) nextLevels
   | n == 1
@@ -410,34 +302,6 @@ mergePolicyForLevel MergePolicyLazyLevelling (LevelNo n) nextLevels
   = LevelTiering    -- always use tiering on first level
   | V.null nextLevels = LevelLevelling  -- levelling on last level
   | otherwise         = LevelTiering
-
-newtype NumRuns = NumRuns { unNumRuns :: Int }
-  deriving stock (Show, Eq)
-  deriving newtype NFData
-
-newtype UnspentCreditsVar s = UnspentCreditsVar { getUnspentCreditsVar :: PrimVar s Int }
-
-data MergingRunState m h =
-    CompletedMerge
-      !(Ref (Run m h))
-      -- ^ Output run
-  | OngoingMerge
-      !(V.Vector (Ref (Run m h)))
-      -- ^ Input runs
-      !(SpentCreditsVar (PrimState m))
-      -- ^ The total number of spent credits.
-      !(Merge m h)
-
-newtype TotalStepsVar s = TotalStepsVar { getTotalStepsVar ::  PrimVar s Int  }
-
-newtype SpentCreditsVar s = SpentCreditsVar { getSpentCreditsVar :: PrimVar s Int }
-
-data MergeKnownCompleted = MergeKnownCompleted | MergeMaybeCompleted
-  deriving stock (Show, Eq, Read)
-
-instance NFData MergeKnownCompleted where
-  rnf MergeKnownCompleted = ()
-  rnf MergeMaybeCompleted = ()
 
 {-# SPECIALISE duplicateLevels :: TempRegistry IO -> Levels IO h -> IO (Levels IO h) #-}
 duplicateLevels ::
@@ -764,8 +628,8 @@ _levelsInvariant conf levels =
   -> IO (Levels IO h) #-}
 -- | Add a run to the levels, and propagate merges.
 --
--- NOTE: @go@ is based on the @ScheduledMerges.increment@ prototype. See @ScheduledMerges.increment@
--- for documentation about the merge algorithm.
+-- NOTE: @go@ is based on the @ScheduledMerges.increment@ prototype.
+-- See @ScheduledMerges.increment@ for documentation about the merge algorithm.
 addRunToLevels ::
      forall m h.
      (MonadMask m, MonadMVar m, MonadST m, MonadSTM m)
@@ -1000,61 +864,9 @@ mergeRuns resolve hfs hbio caching alloc runPaths mergeLevel runs = do
     allow to achieve a nice balance between spreading out I/O and achieving good
     (concurrent) performance.
 
-  As mentioned, merge work is done in batches based on accumulated, unspent
-  credits and a threshold value. Moreover, merging runs can be shared across
-  tables, which means that multiple threads can contribute to the same merge
-  concurrently. The design to contribute credits to the same merging run is
-  largely lock-free. The design ensures consistency of the unspent credits and
-  the merge state, while allowing threads to progress without waiting on other
-  threads.
-
-  First, scaled credits are added atomically to a PrimVar that holds the current
-  total of unspent credits. If this addition exceeded the threshold, then
-  credits are atomically subtracted from the PrimVar to get it below the
-  threshold. The number of subtracted credits is then the number of merge steps
-  that will be performed. While doing the merging work, a (more expensive) MVar
-  lock is taken to ensure that the merging work itself is performed only
-  sequentially. If at some point, doing the merge work resulted in the merge
-  being done, then the merge is converted into a new run.
-
-  In the presence of async exceptions, we offer a weaker guarantee regarding
-  consistency of the accumulated, unspent credits and the merge state: a merge
-  /may/ progress more than the number of credits that were taken. If an async
-  exception happens at some point during merging work, then we put back all the
-  credits we took beforehand. This makes the implementation simple, and merges
-  will still finish in time. It would be bad if we did not put back credits,
-  because then a merge might not finish in time, which will mess up the shape of
-  the levels tree.
-
-  The implementation also tracks the total of spent credits, and the number of
-  perfomed merge steps. These are the use cases:
-
-  * The total of spent credits + the total of unspent credits is used by the
-    snapshot feature to restore merge work on snapshot load that was lost during
-    snapshot creation.
-
-  * For simplicity, merges are allowed to do more steps than requested. However,
-    it does mean that once we do more steps next time a batch of work is done,
-    then we should account for the surplus of steps performed by the previous
-    batch. The total of spent credits + the number of performed merge steps is
-    used to compute this surplus, and adjust for it.
-
-    TODO: we should reconsider at some later point in time whether this surplus
-    adjustment is necessary. It does not make a difference for correctness, but it
-    does mean we get a slightly better distribution of work over time. For
-    sensible batch sizes and workloads without many duplicate keys, it probably
-    won't make much of a difference. However, without this calculation the surplus
-    can accumulate over time, so if we're really pedantic about work distribution
-    then this is the way to go
-
-  Async exceptions are allowed to mess up the consistency between the the merge
-  state, the merge steps performed variable, and the spent credits variable.
-  There is an important invariant that we maintain, even in the presence of
-  async exceptions: @merge steps actually performed >= recorded merge steps
-  performed >= recorded spent credits@. TODO: and this makes it correct (?).
+  Merging runs can be shared across tables, which means that multiple threads
+  can contribute to the same merge concurrently.
 -}
-
-newtype Credit = Credit Int
 
 {-# SPECIALISE supplyCredits ::
      TableConfig
@@ -1075,10 +887,6 @@ supplyCredits conf c levels =
       let !c' = scaleCreditsForMerge ir c in
       let !creditsThresh = creditThresholdForLevel conf ln in
       supplyMergeCredits c' creditsThresh ir
-
--- | 'Credit's scaled based on the merge requirements for merging runs. See
--- 'scaleCreditsForMerge'.
-newtype ScaledCredits = ScaledCredits Int
 
 -- | Scale a number of credits to a number of merge steps to be performed, based
 -- on the merging run.
@@ -1120,222 +928,15 @@ supplyMergeCredits ::
   -> IncomingRun m h
   -> m ()
 supplyMergeCredits _ _ Single{} = pure ()
-supplyMergeCredits (ScaledCredits c) creditsThresh
-                   (Merging (DeRef MergingRun {..})) = do
-    mergeCompleted <- readMutVar mergeKnownCompleted
-
-    -- The merge is already finished
-    if mergeCompleted == MergeKnownCompleted then
-      pure ()
-    else do
-      -- unspentCredits' is our /estimate/ of what the new total of unspent credits is.
-      Credit unspentCredits' <- addUnspentCredits mergeUnspentCredits (Credit c)
-      totalSteps <- readPrimVar (getTotalStepsVar mergeStepsPerformed)
-
-      -- We can finish the merge immediately
-      if totalSteps + unspentCredits' >= unNumEntries mergeNumEntries then do
-        isMergeDone <-
-          bracketOnError (takeAllUnspentCredits mergeUnspentCredits)
-                         (putBackUnspentCredits mergeUnspentCredits)
-                         (stepMerge mergeState mergeStepsPerformed)
-        when isMergeDone $ completeMerge mergeState mergeKnownCompleted
-      -- We can do some merging work without finishing the merge immediately
-      else if unspentCredits' >= getCreditThreshold creditsThresh then do
-        isMergeDone <-
-          -- Try to take some unspent credits. The number of taken credits is the
-          -- number of merging steps we will try to do.
-          --
-          -- If an error happens during the body, then we put back as many credits
-          -- as we took, even if the merge has progressed. See Note [Credits] why
-          -- this is okay.
-          bracketOnError
-            (tryTakeUnspentCredits mergeUnspentCredits creditsThresh (Credit unspentCredits'))
-            (mapM_ (putBackUnspentCredits mergeUnspentCredits)) $ \case
-              Nothing -> pure False
-              Just c' -> stepMerge mergeState mergeStepsPerformed c'
-
-        -- If we just finished the merge, then we convert the output of the merge
-        -- into a new run. i.e., we complete the merge.
-        --
-        -- If an async exception happens before we get to perform the
-        -- completion, then that is fine. The next supplyMergeCredits will
-        -- complete the merge.
-        when isMergeDone $ completeMerge mergeState mergeKnownCompleted
-      -- Just accumulate unspent credits, because we are not over the threshold yet
-      else
-        pure ()
-
-{-# SPECIALISE addUnspentCredits ::
-     UnspentCreditsVar RealWorld
-  -> Credit
-  -> IO Credit #-}
--- | Add credits to unspent credits. Returns the /estimate/ of what the new
--- total of unspent credits is. The /actual/ total might have been changed again
--- by a different thread.
-addUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> Credit
-  -> m Credit
-addUnspentCredits (UnspentCreditsVar !var) (Credit c) = Credit . (c+) <$> fetchAddInt var c
-
-{-# SPECIALISE tryTakeUnspentCredits ::
-     UnspentCreditsVar RealWorld
-  -> CreditThreshold
-  -> Credit
-  -> IO (Maybe Credit) #-}
--- | In a CAS-loop, subtract credits from the unspent credits to get it below
--- the threshold again. If succesful, return Just that many credits, or Nothing
--- otherwise.
---
--- The number of taken credits is a multiple of creditsThresh, so that the
--- amount of merging work that we do each time is relatively uniform.
---
--- Nothing can be returned if the variable has already gone below the threshold,
--- which may happen if another thread is concurrently doing the same loop on
--- 'mergeUnspentCredits'.
-tryTakeUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> CreditThreshold
-  -> Credit
-  -> m (Maybe Credit)
-tryTakeUnspentCredits
-    unspentCreditsVar@(UnspentCreditsVar !var)
-    thresh@(CreditThreshold !creditsThresh)
-    (Credit !prev)
-  | prev < creditsThresh = pure Nothing
-  | otherwise = do
-      -- numThresholds is guaranteed to be >= 1
-      let !numThresholds = prev `div` creditsThresh
-          !creditsToTake = numThresholds * creditsThresh
-          !new = prev - creditsToTake
-      assert (new < creditsThresh) $ pure ()
-      prev' <- casInt var prev new
-      if prev' == prev then
-        pure (Just (Credit creditsToTake))
-      else
-        tryTakeUnspentCredits unspentCreditsVar thresh (Credit prev')
-
-{-# SPECIALISE putBackUnspentCredits :: UnspentCreditsVar RealWorld -> Credit -> IO () #-}
-putBackUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> Credit
-  -> m ()
-putBackUnspentCredits (UnspentCreditsVar !var) (Credit !x) = void $ fetchAddInt var x
-
-{-# SPECIALISE takeAllUnspentCredits :: UnspentCreditsVar RealWorld -> IO Credit #-}
--- | In a CAS-loop, subtract all unspent credits and return them.
-takeAllUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> m Credit
-takeAllUnspentCredits (UnspentCreditsVar !unspentCreditsVar) = do
-    prev <- readPrimVar unspentCreditsVar
-    casLoop prev
-  where
-    casLoop !prev = do
-      prev' <- casInt unspentCreditsVar prev 0
-      if prev' == prev then
-        pure (Credit prev)
-      else
-        casLoop prev'
-
-{-# SPECIALISE stepMerge :: StrictMVar IO (MergingRunState IO h) -> TotalStepsVar RealWorld -> Credit -> IO Bool #-}
-stepMerge ::
-     (MonadMVar m, MonadMask m, MonadSTM m, MonadST m)
-  => StrictMVar m (MergingRunState m h)
-  -> TotalStepsVar (PrimState m)
-  -> Credit
-  -> m Bool
-stepMerge mergeVar (TotalStepsVar totalStepsVar) (Credit c) =
-    withMVar mergeVar $ \case
-      CompletedMerge{} -> pure False
-      (OngoingMerge
-          _rs
-          (SpentCreditsVar spentCreditsVar)
-          m) -> do
-        totalSteps <- readPrimVar totalStepsVar
-        spentCredits <- readPrimVar spentCreditsVar
-
-        -- If we previously performed too many merge steps, then we
-        -- perform fewer now.
-        let stepsToDo = max 0 (spentCredits + c - totalSteps)
-        -- Merge.steps guarantees that stepsDone >= stepsToDo /unless/
-        -- the merge was just now finished.
-        (stepsDone, stepResult) <- Merge.steps m stepsToDo
-        assert (case stepResult of
-                  MergeInProgress -> stepsDone >= stepsToDo
-                  MergeDone       -> True
-                ) $ pure ()
-
-        -- This should be the only point at which we write to these
-        -- variables.
-        --
-        -- It is guaranteed that totalSteps' >= spentCredits' /unless/
-        -- the merge was just now finished.
-        let totalSteps' = totalSteps + stepsDone
-        let spentCredits' = spentCredits + c
-        -- It is guaranteed that @readPrimVar totalStepsVar >=
-        -- readPrimVar spentCreditsVar@, /unless/ the merge was just now
-        -- finished.
-        writePrimVar totalStepsVar $! totalSteps'
-        writePrimVar spentCreditsVar $! spentCredits'
-        assert (case stepResult of
-                  MergeInProgress -> totalSteps' >= spentCredits'
-                  MergeDone       -> True
-              ) $ pure ()
-
-        pure $ stepResult == MergeDone
-
-{-# SPECIALISE completeMerge ::
-     StrictMVar IO (MergingRunState IO h)
-  -> MutVar RealWorld MergeKnownCompleted
-  -> IO () #-}
--- | Convert an 'OngoingMerge' to a 'CompletedMerge'.
-completeMerge ::
-     (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
-  => StrictMVar m (MergingRunState m h)
-  -> MutVar (PrimState m) MergeKnownCompleted
-  -> m ()
-completeMerge mergeVar mergeKnownCompletedVar = do
-    modifyMVarMasked_ mergeVar $ \case
-      mrs@CompletedMerge{} -> pure $! mrs
-      (OngoingMerge rs _spentCreditsVar m) -> do
-        -- first try to complete the merge before performing other side effects,
-        -- in case the completion fails
-        r <- Merge.complete m
-        V.forM_ rs releaseRef
-        -- Cache the knowledge that we completed the merge
-        writeMutVar mergeKnownCompletedVar MergeKnownCompleted
-        pure $! CompletedMerge r
+supplyMergeCredits credits creditsThresh (Merging mr) =
+    supplyCreditsMergingRun credits creditsThresh mr
 
 {-# SPECIALISE expectCompletedMerge :: TempRegistry IO -> IncomingRun IO h -> IO (Ref (Run IO h)) #-}
 expectCompletedMerge ::
      (MonadMVar m, MonadSTM m, MonadST m, MonadMask m)
   => TempRegistry m -> IncomingRun m h -> m (Ref (Run m h))
-expectCompletedMerge _ (Single r) = pure r
-expectCompletedMerge reg (Merging (mr@(DeRef MergingRun {..}))) = do
-    knownCompleted <- readMutVar mergeKnownCompleted
-    -- The merge is not guaranteed to be complete, so we do the remaining steps
-    when (knownCompleted == MergeMaybeCompleted) $ do
-      totalSteps <- readPrimVar (getTotalStepsVar mergeStepsPerformed)
-      isMergeDone <- stepMerge mergeState mergeStepsPerformed (Credit (unNumEntries mergeNumEntries - totalSteps))
-      when isMergeDone $ completeMerge mergeState mergeKnownCompleted
-      -- TODO: can we think of a check to see if we did not do too much work here?
-    r <- withMVar mergeState $ \case
-      CompletedMerge r -> pure r
-      OngoingMerge{} -> do
-        -- If the algorithm finds an ongoing merge here, then it is a bug in
-        -- our merge sceduling algorithm. As such, we throw a pure error.
-        error "expectCompletedMerge: expected a completed merge, but found an ongoing merge"
-    -- return a fresh reference to the run
-    r' <- allocateTemp reg (dupRef r) releaseRef
-    freeTemp reg (releaseRef mr)
-    pure r'
-
-newtype CreditThreshold = CreditThreshold { getCreditThreshold :: Int }
+expectCompletedMerge _   (Single r)   = pure r
+expectCompletedMerge reg (Merging mr) = expectCompletedMergingRun reg mr
 
 -- TODO: the thresholds for doing merge work should be different for each level,
 -- maybe co-prime?

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -1,0 +1,477 @@
+{-# LANGUAGE TypeFamilies #-}
+
+{- HLINT ignore "Use when" -}
+
+-- | An incremental merge of multiple runs.
+module Database.LSMTree.Internal.MergingRun (
+    MergingRun (..)
+  , newMergingRun
+  , duplicateMergingRunRuns
+  , supplyCreditsMergingRun
+  , expectCompletedMergingRun
+    -- * Useful types
+  , Credit (..)
+  , ScaledCredits (..)
+  , CreditThreshold (..)
+  , NumRuns (..)
+  , MergePolicyForLevel (..)
+    -- * Internal state
+  , UnspentCreditsVar (..)
+  , TotalStepsVar (..)
+  , MergingRunState (..)
+  , SpentCreditsVar (..)
+  , MergeKnownCompleted (..)
+  ) where
+
+import           Control.Concurrent.Class.MonadMVar.Strict
+import           Control.DeepSeq (NFData (..))
+import           Control.Monad (void, when)
+import           Control.Monad.Class.MonadST (MonadST)
+import           Control.Monad.Class.MonadSTM (MonadSTM (..))
+import           Control.Monad.Class.MonadThrow (MonadCatch (bracketOnError),
+                     MonadMask)
+import           Control.Monad.Primitive
+import           Control.RefCount
+import           Control.TempRegistry
+import           Data.Primitive.MutVar
+import           Data.Primitive.PrimVar
+import qualified Data.Vector as V
+import           Database.LSMTree.Internal.Assertions (assert)
+import           Database.LSMTree.Internal.Entry (NumEntries (..), unNumEntries)
+import           Database.LSMTree.Internal.Merge (Merge, StepResult (..))
+import qualified Database.LSMTree.Internal.Merge as Merge
+import           Database.LSMTree.Internal.Run (Run)
+
+data MergingRun m h = MergingRun {
+      mergePolicy         :: !MergePolicyForLevel
+    , mergeNumRuns        :: !NumRuns
+      -- | Sum of number of entries in the input runs
+    , mergeNumEntries     :: !NumEntries
+      -- | The number of currently /unspent/ credits
+    , mergeUnspentCredits :: !(UnspentCreditsVar (PrimState m))
+      -- | The total number of performed merging steps.
+    , mergeStepsPerformed :: !(TotalStepsVar (PrimState m))
+      -- | A variable that caches knowledge about whether the merge has been
+      -- completed. If 'MergeKnownCompleted', then we are sure the merge has
+      -- been completed, otherwise if 'MergeMaybeCompleted' we have to check the
+      -- 'MergingRunState'.
+    , mergeKnownCompleted :: !(MutVar (PrimState m) MergeKnownCompleted)
+    , mergeState          :: !(StrictMVar m (MergingRunState m h))
+    , mergeRefCounter     :: !(RefCounter m)
+    }
+
+instance RefCounted m (MergingRun m h) where
+    getRefCounter = mergeRefCounter
+
+data MergePolicyForLevel = LevelTiering | LevelLevelling
+  deriving stock (Show, Eq)
+
+instance NFData MergePolicyForLevel where
+  rnf LevelTiering   = ()
+  rnf LevelLevelling = ()
+
+newtype NumRuns = NumRuns { unNumRuns :: Int }
+  deriving stock (Show, Eq)
+  deriving newtype NFData
+
+newtype UnspentCreditsVar s = UnspentCreditsVar {
+    getUnspentCreditsVar :: PrimVar s Int
+  }
+
+newtype TotalStepsVar s = TotalStepsVar {
+    getTotalStepsVar ::  PrimVar s Int
+  }
+
+data MergingRunState m h =
+    CompletedMerge
+      !(Ref (Run m h))
+      -- ^ Output run
+  | OngoingMerge
+      !(V.Vector (Ref (Run m h)))
+      -- ^ Input runs
+      !(SpentCreditsVar (PrimState m))
+      -- ^ The total number of spent credits.
+      !(Merge m h)
+
+newtype SpentCreditsVar s = SpentCreditsVar {
+    getSpentCreditsVar :: PrimVar s Int
+  }
+
+data MergeKnownCompleted = MergeKnownCompleted | MergeMaybeCompleted
+  deriving stock (Show, Eq, Read)
+
+instance NFData MergeKnownCompleted where
+  rnf MergeKnownCompleted = ()
+  rnf MergeMaybeCompleted = ()
+
+{-# SPECIALISE newMergingRun ::
+     MergePolicyForLevel
+  -> NumRuns
+  -> NumEntries
+  -> MergeKnownCompleted
+  -> MergingRunState IO h
+  -> IO (Ref (MergingRun IO h)) #-}
+-- | This allows constructing ill-formed MergingRuns, but the flexibility is
+-- needed for creating a merging run that is already Completed, as well as
+-- opening a merging run from a snapshot.
+newMergingRun ::
+     (MonadMVar m, MonadMask m, MonadSTM m, MonadST m)
+  => MergePolicyForLevel
+  -> NumRuns
+  -> NumEntries
+  -> MergeKnownCompleted
+  -> MergingRunState m h
+  -> m (Ref (MergingRun m h))
+newMergingRun mergePolicy mergeNumRuns mergeNumEntries knownCompleted state = do
+    mergeUnspentCredits <- UnspentCreditsVar <$> newPrimVar 0
+    mergeStepsPerformed <- TotalStepsVar <$> newPrimVar 0
+    case state of
+      OngoingMerge{}   -> assert (knownCompleted == MergeMaybeCompleted) (pure ())
+      CompletedMerge{} -> pure ()
+    mergeKnownCompleted <- newMutVar knownCompleted
+    mergeState <- newMVar $! state
+    newRef (finalise mergeState) $ \mergeRefCounter ->
+      MergingRun {
+        mergePolicy
+      , mergeNumRuns
+      , mergeNumEntries
+      , mergeUnspentCredits
+      , mergeStepsPerformed
+      , mergeKnownCompleted
+      , mergeState
+      , mergeRefCounter
+      }
+  where
+    finalise var = withMVar var $ \case
+        CompletedMerge r ->
+          releaseRef r
+        OngoingMerge rs _ m -> do
+          V.forM_ rs releaseRef
+          Merge.abort m
+
+-- | Create references to the runs that should be queried for lookups.
+-- In particular, if the merge is not complete, these are the input runs.
+duplicateMergingRunRuns ::
+     (PrimMonad m, MonadMVar m, MonadMask m)
+  => TempRegistry m
+  -> Ref (MergingRun m h)
+  -> m (V.Vector (Ref (Run m h)))
+duplicateMergingRunRuns reg (DeRef mr) =
+    -- We take the references while holding the MVar to make sure the MergingRun
+    -- does not get completed concurrently before we are done.
+    withMVar (mergeState mr) $ \case
+      CompletedMerge r    -> V.singleton <$> dupRun r
+      OngoingMerge rs _ _ -> V.mapM dupRun rs
+  where
+    dupRun r = allocateTemp reg (dupRef r) releaseRef
+
+{-------------------------------------------------------------------------------
+  Credits
+-------------------------------------------------------------------------------}
+
+{-
+  Note [Merge Batching]
+~~~~~~~~~~~~~~
+
+  Merge work is done in batches based on accumulated, unspent credits and a
+  threshold value. Moreover, merging runs can be shared across tables, which
+  means that multiple threads can contribute to the same merge concurrently.
+  The design to contribute credits to the same merging run is largely lock-free.
+  It ensures consistency of the unspent credits and the merge state, while
+  allowing threads to progress without waiting on other threads.
+
+  First, credits are added atomically to a PrimVar that holds the current total
+  of unspent credits. If this addition exceeded the threshold, then credits are
+  atomically subtracted from the PrimVar to get it below the threshold. The
+  number of subtracted credits is then the number of merge steps that will be
+  performed. While doing the merging work, a (more expensive) MVar lock is taken
+  to ensure that the merging work itself is performed only sequentially. If at
+  some point, doing the merge work resulted in the merge being done, then the
+  merge is converted into a new run.
+
+  In the presence of async exceptions, we offer a weaker guarantee regarding
+  consistency of the accumulated, unspent credits and the merge state: a merge
+  /may/ progress more than the number of credits that were taken. If an async
+  exception happens at some point during merging work, then we put back all the
+  credits we took beforehand. This makes the implementation simple, and merges
+  will still finish in time. It would be bad if we did not put back credits,
+  because then a merge might not finish in time, which will mess up the shape of
+  the levels tree.
+
+  The implementation also tracks the total of spent credits, and the number of
+  perfomed merge steps. These are the use cases:
+
+  * The total of spent credits + the total of unspent credits is used by the
+    snapshot feature to restore merge work on snapshot load that was lost during
+    snapshot creation.
+
+  * For simplicity, merges are allowed to do more steps than requested. However,
+    it does mean that once we do more steps next time a batch of work is done,
+    then we should account for the surplus of steps performed by the previous
+    batch. The total of spent credits + the number of performed merge steps is
+    used to compute this surplus, and adjust for it.
+
+    TODO: we should reconsider at some later point in time whether this surplus
+    adjustment is necessary. It does not make a difference for correctness, but
+    it does mean we get a slightly better distribution of work over time. For
+    sensible batch sizes and workloads without many duplicate keys, it probably
+    won't make much of a difference. However, without this calculation the
+    surplus can accumulate over time, so if we're really pedantic about work
+    distribution then this is the way to go.
+
+  Async exceptions are allowed to mess up the consistency between the the merge
+  state, the merge steps performed variable, and the spent credits variable.
+  There is an important invariant that we maintain, even in the presence of
+  async exceptions: @merge steps actually performed >= recorded merge steps
+  performed >= recorded spent credits@. TODO: and this makes it correct (?).
+-}
+
+newtype Credit = Credit Int
+
+-- | 'Credit's scaled based on the merge requirements for merging runs. See
+-- 'scaleCreditsForMerge'.
+newtype ScaledCredits = ScaledCredits Int
+
+-- | Credits are accumulated until they go over the 'CreditThreshold', after
+-- which a batch of merge work will be performed. Configuring this threshold
+-- should allow to achieve a nice balance between spreading out I/O and
+-- achieving good (concurrent) performance.
+newtype CreditThreshold = CreditThreshold { getCreditThreshold :: Int }
+
+{-# SPECIALISE supplyCreditsMergingRun ::
+     ScaledCredits
+  -> CreditThreshold
+  -> Ref (MergingRun IO h)
+  -> IO () #-}
+-- | Supply the given amount of credits to a merging run. This /may/ cause an
+-- ongoing merge to progress.
+supplyCreditsMergingRun ::
+     forall m h. (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
+  => ScaledCredits
+  -> CreditThreshold
+  -> Ref (MergingRun m h)
+  -> m ()
+supplyCreditsMergingRun (ScaledCredits c) creditsThresh (DeRef MergingRun {..}) = do
+    mergeCompleted <- readMutVar mergeKnownCompleted
+
+    -- The merge is already finished
+    if mergeCompleted == MergeKnownCompleted then
+      pure ()
+    else do
+      -- unspentCredits' is our /estimate/ of what the new total of unspent
+      -- credits is.
+      Credit unspentCredits' <- addUnspentCredits mergeUnspentCredits (Credit c)
+      totalSteps <- readPrimVar (getTotalStepsVar mergeStepsPerformed)
+
+      if totalSteps + unspentCredits' >= unNumEntries mergeNumEntries then do
+        -- We can finish the merge immediately
+        isMergeDone <-
+          bracketOnError (takeAllUnspentCredits mergeUnspentCredits)
+                         (putBackUnspentCredits mergeUnspentCredits)
+                         (stepMerge mergeState mergeStepsPerformed)
+        when isMergeDone $ completeMerge mergeState mergeKnownCompleted
+      else if unspentCredits' >= getCreditThreshold creditsThresh then do
+        -- We can do some merging work without finishing the merge immediately
+        isMergeDone <-
+          -- Try to take some unspent credits. The number of taken credits is
+          -- the number of merging steps we will try to do.
+          --
+          -- If an error happens during the body, then we put back as many
+          -- credits as we took, even if the merge has progressed. See Note
+          -- [Merge Batching] to see why this is okay.
+          bracketOnError
+            (tryTakeUnspentCredits mergeUnspentCredits creditsThresh (Credit unspentCredits'))
+            (mapM_ (putBackUnspentCredits mergeUnspentCredits)) $ \case
+              Nothing -> pure False
+              Just c' -> stepMerge mergeState mergeStepsPerformed c'
+
+        -- If we just finished the merge, then we convert the output of the
+        -- merge into a new run. i.e., we complete the merge.
+        --
+        -- If an async exception happens before we get to perform the
+        -- completion, then that is fine. The next supplyCreditsMergingRun will
+        -- complete the merge.
+        when isMergeDone $ completeMerge mergeState mergeKnownCompleted
+      else
+        -- Just accumulate credits, because we are not over the threshold yet
+        pure ()
+
+{-# SPECIALISE addUnspentCredits ::
+     UnspentCreditsVar RealWorld
+  -> Credit
+  -> IO Credit #-}
+-- | Add credits to unspent credits. Returns the /estimate/ of what the new
+-- total of unspent credits is. The /actual/ total might have been changed again
+-- by a different thread.
+addUnspentCredits ::
+     PrimMonad m
+  => UnspentCreditsVar (PrimState m)
+  -> Credit
+  -> m Credit
+addUnspentCredits (UnspentCreditsVar !var) (Credit c) =
+    Credit . (c+) <$> fetchAddInt var c
+
+{-# SPECIALISE tryTakeUnspentCredits ::
+     UnspentCreditsVar RealWorld
+  -> CreditThreshold
+  -> Credit
+  -> IO (Maybe Credit) #-}
+-- | In a CAS-loop, subtract credits from the unspent credits to get it below
+-- the threshold again. If succesful, return Just that many credits, or Nothing
+-- otherwise.
+--
+-- The number of taken credits is a multiple of creditsThresh, so that the
+-- amount of merging work that we do each time is relatively uniform.
+--
+-- Nothing can be returned if the variable has already gone below the threshold,
+-- which may happen if another thread is concurrently doing the same loop on
+-- 'mergeUnspentCredits'.
+tryTakeUnspentCredits ::
+     PrimMonad m
+  => UnspentCreditsVar (PrimState m)
+  -> CreditThreshold
+  -> Credit
+  -> m (Maybe Credit)
+tryTakeUnspentCredits
+    unspentCreditsVar@(UnspentCreditsVar !var)
+    thresh@(CreditThreshold !creditsThresh)
+    (Credit !prev)
+  | prev < creditsThresh = pure Nothing
+  | otherwise = do
+      -- numThresholds is guaranteed to be >= 1
+      let !numThresholds = prev `div` creditsThresh
+          !creditsToTake = numThresholds * creditsThresh
+          !new = prev - creditsToTake
+      assert (new < creditsThresh) $ pure ()
+      prev' <- casInt var prev new
+      if prev' == prev then
+        pure (Just (Credit creditsToTake))
+      else
+        tryTakeUnspentCredits unspentCreditsVar thresh (Credit prev')
+
+{-# SPECIALISE putBackUnspentCredits ::
+     UnspentCreditsVar RealWorld
+  -> Credit
+  -> IO () #-}
+putBackUnspentCredits ::
+     PrimMonad m
+  => UnspentCreditsVar (PrimState m)
+  -> Credit
+  -> m ()
+putBackUnspentCredits (UnspentCreditsVar !var) (Credit !x) =
+    void $ fetchAddInt var x
+
+{-# SPECIALISE takeAllUnspentCredits ::
+     UnspentCreditsVar RealWorld
+  -> IO Credit #-}
+-- | In a CAS-loop, subtract all unspent credits and return them.
+takeAllUnspentCredits ::
+     PrimMonad m
+  => UnspentCreditsVar (PrimState m)
+  -> m Credit
+takeAllUnspentCredits (UnspentCreditsVar !unspentCreditsVar) = do
+    prev <- readPrimVar unspentCreditsVar
+    casLoop prev
+  where
+    casLoop !prev = do
+      prev' <- casInt unspentCreditsVar prev 0
+      if prev' == prev then
+        pure (Credit prev)
+      else
+        casLoop prev'
+
+{-# SPECIALISE stepMerge ::
+     StrictMVar IO (MergingRunState IO h)
+  -> TotalStepsVar RealWorld
+  -> Credit
+  -> IO Bool #-}
+stepMerge ::
+     (MonadMVar m, MonadMask m, MonadSTM m, MonadST m)
+  => StrictMVar m (MergingRunState m h)
+  -> TotalStepsVar (PrimState m)
+  -> Credit
+  -> m Bool
+stepMerge mergeVar (TotalStepsVar totalStepsVar) (Credit c) =
+    withMVar mergeVar $ \case
+      CompletedMerge{} -> pure False
+      (OngoingMerge _rs (SpentCreditsVar spentCreditsVar) m) -> do
+        totalSteps <- readPrimVar totalStepsVar
+        spentCredits <- readPrimVar spentCreditsVar
+
+        -- If we previously performed too many merge steps, then we perform
+        -- fewer now.
+        let stepsToDo = max 0 (spentCredits + c - totalSteps)
+        -- Merge.steps guarantees that @stepsDone >= stepsToDo@ /unless/ the
+        -- merge was just now finished.
+        (stepsDone, stepResult) <- Merge.steps m stepsToDo
+        assert (case stepResult of
+                  MergeInProgress -> stepsDone >= stepsToDo
+                  MergeDone       -> True
+                ) $ pure ()
+
+        -- This should be the only point at which we write to these variables.
+        --
+        -- It is guaranteed that @totalSteps' >= spentCredits'@ /unless/ the
+        -- merge was just now finished.
+        let totalSteps' = totalSteps + stepsDone
+        let spentCredits' = spentCredits + c
+        -- It is guaranteed that
+        -- @readPrimVar totalStepsVar >= readPrimVar spentCreditsVar@,
+        -- /unless/ the merge was just now finished.
+        writePrimVar totalStepsVar $! totalSteps'
+        writePrimVar spentCreditsVar $! spentCredits'
+        assert (case stepResult of
+                  MergeInProgress -> totalSteps' >= spentCredits'
+                  MergeDone       -> True
+              ) $ pure ()
+
+        pure $ stepResult == MergeDone
+
+{-# SPECIALISE completeMerge ::
+     StrictMVar IO (MergingRunState IO h)
+  -> MutVar RealWorld MergeKnownCompleted
+  -> IO () #-}
+-- | Convert an 'OngoingMerge' to a 'CompletedMerge'.
+completeMerge ::
+     (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
+  => StrictMVar m (MergingRunState m h)
+  -> MutVar (PrimState m) MergeKnownCompleted
+  -> m ()
+completeMerge mergeVar mergeKnownCompletedVar = do
+    modifyMVarMasked_ mergeVar $ \case
+      mrs@CompletedMerge{} -> pure $! mrs
+      (OngoingMerge rs _spentCreditsVar m) -> do
+        -- first try to complete the merge before performing other side effects,
+        -- in case the completion fails
+        r <- Merge.complete m
+        V.forM_ rs releaseRef
+        -- Cache the knowledge that we completed the merge
+        writeMutVar mergeKnownCompletedVar MergeKnownCompleted
+        pure $! CompletedMerge r
+
+{-# SPECIALISE expectCompletedMergingRun ::
+     TempRegistry IO
+  -> Ref (MergingRun IO h)
+  -> IO (Ref (Run IO h)) #-}
+expectCompletedMergingRun ::
+     (MonadMVar m, MonadSTM m, MonadST m, MonadMask m)
+  => TempRegistry m -> Ref (MergingRun m h) -> m (Ref (Run m h))
+expectCompletedMergingRun reg mr@(DeRef MergingRun {..}) = do
+    knownCompleted <- readMutVar mergeKnownCompleted
+    -- The merge is not guaranteed to be complete, so we do the remaining steps
+    when (knownCompleted == MergeMaybeCompleted) $ do
+      totalSteps <- readPrimVar (getTotalStepsVar mergeStepsPerformed)
+      isMergeDone <- stepMerge mergeState mergeStepsPerformed (Credit (unNumEntries mergeNumEntries - totalSteps))
+      when isMergeDone $ completeMerge mergeState mergeKnownCompleted
+      -- TODO: can we think of a check to see if we did not do too much work
+      -- here?
+    r <- withMVar mergeState $ \case
+      CompletedMerge r -> pure r
+      OngoingMerge{} -> do
+        -- If the algorithm finds an ongoing merge here, then it is a bug in
+        -- our merge sceduling algorithm. As such, we throw a pure error.
+        error "expectCompletedMergingRun: expected a completed merge, but found an ongoing merge"
+    -- return a fresh reference to the run
+    r' <- allocateTemp reg (dupRef r) releaseRef
+    freeTemp reg (releaseRef mr)
+    pure r'

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -33,6 +33,8 @@ import qualified Database.LSMTree.Internal.CRC32C as FS
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule
+import           Database.LSMTree.Internal.MergingRun (NumRuns (..))
+import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.Run (ChecksumError (..),
                      FileFormatError (..))
 import           Database.LSMTree.Internal.RunNumber
@@ -510,16 +512,16 @@ instance DecodeVersioned UnspentCredits where
 
 -- MergeKnownCompleted
 
-instance Encode MergeKnownCompleted where
-  encode MergeKnownCompleted = encodeWord 0
-  encode MergeMaybeCompleted = encodeWord 1
+instance Encode MR.MergeKnownCompleted where
+  encode MR.MergeKnownCompleted = encodeWord 0
+  encode MR.MergeMaybeCompleted = encodeWord 1
 
-instance DecodeVersioned MergeKnownCompleted where
+instance DecodeVersioned MR.MergeKnownCompleted where
   decodeVersioned V0 = do
       tag <- decodeWord
       case tag of
-        0 -> pure MergeKnownCompleted
-        1 -> pure MergeMaybeCompleted
+        0 -> pure MR.MergeKnownCompleted
+        1 -> pure MR.MergeMaybeCompleted
         _ -> fail ("[MergeKnownCompleted] Unexpected tag: " <> show tag)
 
 -- SnapMergingRunState

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -18,6 +18,7 @@ import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule
+import           Database.LSMTree.Internal.MergingRun
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.Snapshot.Codec

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -173,7 +173,6 @@ testAll test = [
     , test (Proxy @NumRuns)
     , test (Proxy @MergePolicyForLevel)
     , test (Proxy @UnspentCredits)
-    , test (Proxy @MergeKnownCompleted)
     , test (Proxy @(SnapMergingRunState RunNumber))
     , test (Proxy @SpentCredits)
     , test (Proxy @Merge.Level)
@@ -287,12 +286,12 @@ deriving newtype instance Arbitrary RunNumber
 instance Arbitrary (SnapIncomingRun RunNumber) where
   arbitrary = oneof [
         SnapMergingRun <$> arbitrary <*> arbitrary <*> arbitrary
-                       <*> arbitrary <*> arbitrary <*> arbitrary
+                       <*> arbitrary <*> arbitrary
       , SnapSingleRun <$> arbitrary
       ]
-  shrink (SnapMergingRun a b c d e f) =
-      [ SnapMergingRun a' b' c' d' e' f'
-      | (a', b', c', d', e', f') <- shrink (a, b, c, d, e, f) ]
+  shrink (SnapMergingRun a b c d e) =
+      [ SnapMergingRun a' b' c' d' e'
+      | (a', b', c', d', e') <- shrink (a, b, c, d, e) ]
   shrink (SnapSingleRun a)  = SnapSingleRun <$> shrink a
 
 deriving newtype instance Arbitrary NumRuns
@@ -302,10 +301,6 @@ instance Arbitrary MergePolicyForLevel where
   shrink _ = []
 
 deriving newtype instance Arbitrary UnspentCredits
-
-instance Arbitrary MergeKnownCompleted where
-  arbitrary = elements [MergeKnownCompleted, MergeMaybeCompleted]
-  shrink _ = []
 
 instance Arbitrary (SnapMergingRunState RunNumber) where
   arbitrary = oneof [


### PR DESCRIPTION
It is one of the core abstractions of the code base. This will allow us to use MergingRun in other modules without having to depend on the whole `MergeSchedule`.

I also untangled its usage a bit to provide a clean module interface. For some of the later changes, there are many alternative solutions, so I added them as separate commits that can be better viewed and discussed individually.

