### PR TITLE
Resolving TODO: Converted NumEntries to Word64 representation

### DIFF
--- a/src/Database/LSMTree/Internal/Entry.hs
+++ b/src/Database/LSMTree/Internal/Entry.hs
@@ -67,8 +67,13 @@ instance Bifoldable Entry where
       Mupdate v           -> f v
       Delete              -> mempty
 
--- | TODO: we should change this to be a Word64, so that it is in line with the
--- disk format.
+-- | A count of entries, for example the number of entries in a run.
+--
+-- This number is limited by the machine's word size. On 32-bit systems, the
+-- maximum number we can represent is @2^31@ which is roughly 2 billion. This
+-- should be a sufficiently large limit that we never reach it in practice. By
+-- extension for 64-bit and higher-bit systems this limit is also sufficiently
+-- large.
 newtype NumEntries = NumEntries Int
   deriving stock (Eq, Ord, Show)
   deriving newtype NFData


### PR DESCRIPTION
# Description

A small refactoring addressing the TODO task of converting the `NumEntries` representation to `Word64`. 

This had some implications for serialization of both `Index` types. The round-trip test cases are passing so delicate part of the conversion ought to be correctly handled by the PR.