### PR TITLE
Resolving TODO: Converted FilePointer to Word representation

### DIFF
--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -197,9 +197,10 @@ mkWeakBlobRef (DeRef WriteBufferBlobs {blobFile}) blobspan =
 
 
 -- | A mutable file offset, suitable to share between threads.
+--
+-- This pointer is limited to 31-bit file offsets on 32-bit systems. This should
+-- be a sufficiently large limit that we never reach it in practice.
 newtype FilePointer m = FilePointer (PrimVar (PrimState m) Int)
---TODO: this would be better as Word64
--- this will limit to 31bit file sizes on 32bit arches
 
 instance NFData (FilePointer m) where
   rnf (FilePointer var) = var `seq` ()


### PR DESCRIPTION
# Description

A small refactoring addressing the TODO task of converting the `FilePointer` representation to `Word`, while exposing a `Word64` API.

The implementation in the PR replicates the definition of [`Data.Primitive.PrimVar.fetchAddInt`](https://hackage.haskell.org/package/primitive-0.9.0.0/docs/Data-Primitive-PrimVar.html#v:fetchAddInt), adapted for the unsigned `Word` type.

