### PR TITLE
Include debug call stacks in `ActionRegistry` errors 

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -862,6 +862,7 @@ test-suite control-test
   hs-source-dirs: test-control
   main-is:        Main.hs
   other-modules:
+    Test.Control.ActionRegistry
     Test.Control.Concurrent.Class.MonadSTM.RWVar
     Test.Control.RefCount
 

--- a/src-control/Control/ActionRegistry.hs
+++ b/src-control/Control/ActionRegistry.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Registry of monadic actions supporting rollback actions and delayed actions
 -- in the presence of (a-)synchronous exceptions.
 --
@@ -14,6 +16,7 @@ module Control.ActionRegistry (
     -- * Action registry  #actionRegistry#
     -- $action-registry
   , ActionRegistry
+  , ActionError
     -- * Runners
   , withActionRegistry
   , unsafeNewActionRegistry
@@ -30,9 +33,14 @@ module Control.ActionRegistry (
 
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive
+import           Data.Kind
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import           Data.Primitive.MutVar
+
+#ifdef NO_IGNORE_ASSERTS
+import           GHC.Stack
+#endif
 
 -- TODO: add tests using fs-sim/io-sim to make sure exception safety is
 -- guaranteed.
@@ -40,11 +48,15 @@ import           Data.Primitive.MutVar
 -- TODO: add assertions that allocated resources end up in the final state, and
 -- that temporarily freed resources are removed from the final state.
 
--- TODO: add callstacks in debug mode, for example to see where an action was
--- registered.
-
 -- TODO: could we statically disallow using a resource after it is freed using
 -- @delayedCommit@, for example through data abstraction?
+
+-- Call stack instrumentation is enabled if assertions are enabled.
+#ifdef NO_IGNORE_ASSERTS
+#define HasCallStackIfDebug HasCallStack
+#else
+#define HasCallStackIfDebug ()
+#endif
 
 {-------------------------------------------------------------------------------
   Modify mutable state
@@ -185,9 +197,40 @@ consAction !a var = modifyMutVar' var $ \as -> a `consStrict` as
   where consStrict !x xs = x : xs
 
 -- | Monadic computations that (may) produce side effects
+type Action :: (Type -> Type) -> Type
+
+-- | An action failed with an exception
+type ActionError :: Type
+
+mkAction :: HasCallStackIfDebug => m () -> Action m
+mkActionError :: SomeException -> Action m -> ActionError
+
+#ifdef NO_IGNORE_ASSERTS
+data Action m = Action {
+    runAction       :: !(m ())
+  , actionCallStack :: !CallStack
+  }
+
+data ActionError = ActionError SomeException CallStack
+  deriving stock Show
+  deriving anyclass Exception
+
+mkAction a = Action a callStack
+
+mkActionError e a = ActionError e (actionCallStack a)
+#else
 newtype Action m = Action {
     runAction :: m ()
   }
+
+newtype ActionError = ActionError SomeException
+  deriving stock Show
+  deriving anyclass Exception
+
+mkAction a = Action a
+
+mkActionError e _ = ActionError e
+#endif
 
 {-------------------------------------------------------------------------------
   Runners
@@ -256,7 +299,7 @@ unsafeCommitActionRegistry reg = do
       Nothing         -> pure ()
       Just exceptions -> throwIO (CommitActionRegistryError exceptions)
 
-data CommitActionRegistryError = CommitActionRegistryError (NonEmpty SomeException)
+data CommitActionRegistryError = CommitActionRegistryError (NonEmpty ActionError)
   deriving stock Show
   deriving anyclass Exception
 
@@ -271,20 +314,20 @@ unsafeAbortActionRegistry reg = do
       Nothing         -> pure ()
       Just exceptions -> throwIO (AbortActionRegistryError exceptions)
 
-data AbortActionRegistryError = AbortActionRegistryError (NonEmpty SomeException)
+data AbortActionRegistryError = AbortActionRegistryError (NonEmpty ActionError)
   deriving stock Show
   deriving anyclass Exception
 
-{-# SPECIALISE runActions :: [Action IO] -> IO [SomeException] #-}
+{-# SPECIALISE runActions :: [Action IO] -> IO [ActionError] #-}
 -- | Run all actions even if previous actions threw exceptions.
-runActions :: MonadCatch m => [Action m] -> m [SomeException]
+runActions :: MonadCatch m => [Action m] -> m [ActionError]
 runActions = go []
   where
     go es [] = pure (reverse es)
     go es (a:as) = do
       eith <- try @_ @SomeException (runAction a)
       case eith of
-        Left e  -> go (e:es) as
+        Left e  -> go (mkActionError e a : es) as
         Right _ -> go es as
 
 {-------------------------------------------------------------------------------
@@ -321,7 +364,12 @@ runActions = go []
   This means all the usual masking caveats apply for the registered actions.
 -}
 
-{-# SPECIALISE withRollback :: ActionRegistry IO -> IO a -> (a -> IO ()) -> IO a #-}
+{-# SPECIALISE withRollback ::
+     HasCallStackIfDebug
+  => ActionRegistry IO
+  -> IO a
+  -> (a -> IO ())
+  -> IO a #-}
 -- | Perform an immediate action and register a rollback action.
 --
 -- See [Registering actions](#g:registeringActions) for more information about
@@ -342,6 +390,7 @@ runActions = go []
 -- @
 withRollback ::
      (PrimMonad m, MonadMask m)
+  => HasCallStackIfDebug
   => ActionRegistry m
   -> m a
   -> (a -> m ())
@@ -349,12 +398,18 @@ withRollback ::
 withRollback reg acquire release =
     withRollbackFun reg Just acquire release
 
-{-# SPECIALISE withRollback_ :: ActionRegistry IO -> IO a -> IO () -> IO a #-}
+{-# SPECIALISE withRollback_ ::
+     HasCallStackIfDebug
+  => ActionRegistry IO
+  -> IO a
+  -> IO ()
+  -> IO a #-}
 -- | Like 'withRollback', but the rollback action does not get access to the
 -- result of the immediate action.
 --
 withRollback_ ::
      (PrimMonad m, MonadMask m)
+  => HasCallStackIfDebug
   => ActionRegistry m
   -> m a
   -> m ()
@@ -363,7 +418,8 @@ withRollback_ reg acquire release =
     withRollbackFun reg Just acquire (\_ -> release)
 
 {-# SPECIALISE withRollbackMaybe ::
-     ActionRegistry IO
+     HasCallStackIfDebug
+  => ActionRegistry IO
   -> IO (Maybe a)
   -> (a -> IO ())
   -> IO (Maybe a)
@@ -373,6 +429,7 @@ withRollback_ reg acquire release =
 --
 withRollbackMaybe ::
      (PrimMonad m, MonadMask m)
+  => HasCallStackIfDebug
   => ActionRegistry m
   -> m (Maybe a)
   -> (a -> m ())
@@ -381,7 +438,8 @@ withRollbackMaybe reg acquire release =
     withRollbackFun reg id acquire release
 
 {-# SPECIALISE withRollbackEither ::
-     ActionRegistry IO
+     HasCallStackIfDebug
+  => ActionRegistry IO
   -> IO (Either e a)
   -> (a -> IO ())
   -> IO (Either e a)
@@ -391,6 +449,7 @@ withRollbackMaybe reg acquire release =
 --
 withRollbackEither ::
      (PrimMonad m, MonadMask m)
+  => HasCallStackIfDebug
   => ActionRegistry m
   -> m (Either e a)
   -> (a -> m ())
@@ -403,7 +462,8 @@ withRollbackEither reg acquire release =
     fromEither (Right x) = Just x
 
 {-# SPECIALISE withRollbackFun ::
-     ActionRegistry IO
+     HasCallStackIfDebug
+  => ActionRegistry IO
   -> (a -> Maybe b)
   -> IO a
   -> (b -> IO ())
@@ -419,6 +479,7 @@ withRollbackEither reg acquire release =
 --
 withRollbackFun ::
      (PrimMonad m, MonadMask m)
+  => HasCallStackIfDebug
   => ActionRegistry m
   -> (a -> Maybe b)
   -> m a
@@ -430,10 +491,14 @@ withRollbackFun reg extract acquire release = do
       case extract x of
         Nothing -> pure x
         Just y -> do
-          consAction (Action (release y)) (registryRollback reg)
+          consAction (mkAction (release y)) (registryRollback reg)
           pure x
 
-{-# SPECIALISE delayedCommit :: ActionRegistry IO -> IO () -> IO () #-}
+{-# SPECIALISE delayedCommit ::
+     HasCallStackIfDebug
+  => ActionRegistry IO
+  -> IO ()
+  -> IO () #-}
 -- | Register a delayed action.
 --
 -- See [Registering actions](#g:registeringActions) for more information about
@@ -449,5 +514,10 @@ withRollbackFun reg extract acquire release = do
 -- For example, incrementing a thread-safe mutable variable can easily be rolled
 -- back by decrementing the same variable again.
 --
-delayedCommit :: PrimMonad m => ActionRegistry m -> m () -> m ()
-delayedCommit reg action = consAction (Action action) (registryDelay reg)
+delayedCommit ::
+     PrimMonad m
+  => HasCallStackIfDebug
+  => ActionRegistry m
+  -> m ()
+  -> m ()
+delayedCommit reg action = consAction (mkAction action) (registryDelay reg)

--- a/test-control/Main.hs
+++ b/test-control/Main.hs
@@ -1,11 +1,13 @@
 module Main (main) where
 
+import qualified Test.Control.ActionRegistry
 import qualified Test.Control.Concurrent.Class.MonadSTM.RWVar
 import qualified Test.Control.RefCount
 import           Test.Tasty
 
 main :: IO ()
 main = defaultMain $ testGroup "control"
-    [ Test.Control.Concurrent.Class.MonadSTM.RWVar.tests
+    [ Test.Control.ActionRegistry.tests
+    , Test.Control.Concurrent.Class.MonadSTM.RWVar.tests
     , Test.Control.RefCount.tests
     ]

--- a/test-control/Test/Control/ActionRegistry.hs
+++ b/test-control/Test/Control/ActionRegistry.hs
@@ -1,0 +1,40 @@
+module Test.Control.ActionRegistry (tests) where
+
+import           Control.ActionRegistry
+import           Control.Monad.Class.MonadThrow
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.Control.ActionRegistry" [
+      testProperty "prop_commitActionRegistryError" prop_commitActionRegistryError
+    , testProperty "prop_abortActionRegistryError" prop_abortActionRegistryError
+    ]
+
+-- | An example where an exception happens while an action registry is being
+-- committed.
+prop_commitActionRegistryError :: Property
+prop_commitActionRegistryError = once $ ioProperty $ do
+    eith <-
+      try @_ @CommitActionRegistryError $
+        withActionRegistry $ \reg -> do
+          delayedCommit reg
+            (throwIO (userError "delayed action failed"))
+    pure $ case eith of
+      Left e   -> tabulate "Printed error" [show e] $ property True
+      Right () -> property False
+
+-- | An example where an exception happens while an action registry is being
+-- aborted.
+prop_abortActionRegistryError :: Property
+prop_abortActionRegistryError = once $ ioProperty $ do
+    eith <-
+      try @_ @AbortActionRegistryError $
+        withActionRegistry $ \reg -> do
+          withRollback reg
+            (pure ())
+            (\_ -> throwIO (userError "rollback action failed"))
+          throwIO (userError "error in withActionRegistry scope")
+    pure $ case eith of
+      Left e   -> tabulate "Printed error" [show e] $ property True
+      Right () -> property False

--- a/test-control/Test/Control/RefCount.hs
+++ b/test-control/Test/Control/RefCount.hs
@@ -16,7 +16,7 @@ import           Data.IORef
 #endif
 
 tests :: TestTree
-tests = testGroup "Control.RefCount" [
+tests = testGroup "Test.Control.RefCount" [
       testProperty "prop_RefCounter"          prop_RefCounter
 #ifdef NO_IGNORE_ASSERTS
       -- All of these tests below are checking that the debug implementation of


### PR DESCRIPTION
This is useful for debugging purposes. See the commit messages.
