### PR TITLE
Release a `RefTracker` even if the corresponding finaliser threw an error

### DIFF
--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -249,8 +249,8 @@ releaseRef ::
   -> m ()
 releaseRef ref@Ref{refobj} = do
     assertNoDoubleRelease ref
-    decrementRefCounter (getRefCounter refobj)
     releaseRefTracker ref
+    decrementRefCounter (getRefCounter refobj)
 
 {-# COMPLETE DeRef #-}
 #if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)

--- a/test-control/Test/Control/RefCount.hs
+++ b/test-control/Test/Control/RefCount.hs
@@ -28,6 +28,7 @@ tests = testGroup "Control.RefCount" [
     , testProperty "prop_ref_never_released0" prop_ref_never_released0
     , testProperty "prop_ref_never_released1" prop_ref_never_released1
     , testProperty "prop_ref_never_released2" prop_ref_never_released2
+    , testProperty "prop_release_ref_exception" prop_release_ref_exception
 #endif
     ]
 
@@ -176,5 +177,13 @@ expectRefNeverReleased :: RefException -> IO Property
 expectRefNeverReleased RefNeverReleased{} = return (property True)
 expectRefNeverReleased e =
     return (counterexample (displayException e) $ property False)
+
+-- | If a finaliser throws an exception, then the 'RefTracker' is still released
+prop_release_ref_exception :: Property
+prop_release_ref_exception = once $ ioProperty $ do
+    finalised <- newIORef False
+    ref  <- newRef (writeIORef finalised True >> error "oops") TestObject
+    _ <- try @SomeException (releaseRef ref)
+    checkForgottenRefs
 #endif
 


### PR DESCRIPTION
In debug mode if the finaliser of a reference counted object throws an error, then the `RefTracker` is never released. `checkForgottenRefs` will then report the reference as forgotten, even though the finaliser ran, though not successfully.  This PR ensures that the `RefTracker` is released even if the finaliser throw an error. This improves the experience of debugging finalisers that fail.
