### PR TITLE
Add fault testing to the `StateMachine` tests

### DIFF
--- a/cabal.project.release
+++ b/cabal.project.release
@@ -30,3 +30,11 @@ if impl(ghc >=9.12)
 if (impl(ghc < 9.0) && os(windows))
   package text
     flags: -simdutf
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/fs-sim
+  tag: 22ca7c9972c2a9ee9633d2c05dddd010d2938094
+  subdir:
+    fs-api
+    fs-sim

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -386,6 +386,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.StateMachine.DL
     Test.Database.LSMTree.StateMachine.Op
     Test.Database.LSMTree.UnitTests
+    Test.FS
     Test.System.Posix.Fcntl.NoCache
     Test.Util.Arbitrary
     Test.Util.FS

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -37,13 +37,15 @@ import qualified Test.Database.LSMTree.Monoidal
 import qualified Test.Database.LSMTree.StateMachine
 import qualified Test.Database.LSMTree.StateMachine.DL
 import qualified Test.Database.LSMTree.UnitTests
+import qualified Test.FS
 import qualified Test.System.Posix.Fcntl.NoCache
 import           Test.Tasty
 
 main :: IO ()
 main = do
   defaultMain $ testGroup "lsm-tree"
-    [ Test.Database.LSMTree.Class.tests
+    [ Test.Data.Arena.tests
+    , Test.Database.LSMTree.Class.tests
     , Test.Database.LSMTree.Generators.tests
     , Test.Database.LSMTree.Internal.tests
     , Test.Database.LSMTree.Internal.BloomFilter.tests
@@ -75,8 +77,8 @@ main = do
     , Test.Database.LSMTree.UnitTests.tests
     , Test.Database.LSMTree.StateMachine.tests
     , Test.Database.LSMTree.StateMachine.DL.tests
+    , Test.FS.tests
     , Test.System.Posix.Fcntl.NoCache.tests
-    , Test.Data.Arena.tests
     ]
   Control.RefCount.checkForgottenRefs
   -- This use of checkForgottenRefs is a last resort. Refs that are forgotten

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -978,14 +978,16 @@ runModel lookUp = \case
     RetrieveBlobs blobsVar ->
       wrap (MVector . fmap (MBlob . WrapBlob))
       . Model.runModelM (Model.retrieveBlobs (getBlobRefs . lookUp $ blobsVar))
-    -- TODO: use merrs
-    CreateSnapshot _merrs label name tableVar ->
+    CreateSnapshot merrs label name tableVar ->
       wrap MUnit
-      . Model.runModelM (Model.createSnapshot label name (getTable $ lookUp tableVar))
-    -- TODO: use merrs
-    OpenSnapshot _merrs label name ->
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.createSnapshot label name (getTable $ lookUp tableVar))
+          (pure ())
+    OpenSnapshot merrs label name ->
       wrap MTable
-      . Model.runModelM (Model.openSnapshot label name)
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.openSnapshot label name)
+          (pure ())
     DeleteSnapshot name ->
       wrap MUnit
       . Model.runModelM (Model.deleteSnapshot name)

--- a/test/Test/FS.hs
+++ b/test/Test/FS.hs
@@ -1,0 +1,68 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- TODO: upstream to fs-sim
+module Test.FS (tests) where
+
+import           GHC.Generics (Generic)
+import           System.FS.API
+import           System.FS.Sim.Error
+import qualified System.FS.Sim.Stream as S
+import           System.FS.Sim.Stream (InternalInfo (..), Stream (..))
+import           Test.QuickCheck
+import           Test.QuickCheck.Classes (eqLaws)
+import           Test.QuickCheck.Instances ()
+import           Test.Tasty
+import           Test.Util.FS
+import           Test.Util.QC
+
+tests :: TestTree
+tests = testGroup "Test.FS" [
+      testClassLaws "Stream" $
+        eqLaws (Proxy @(Stream Int))
+    , testClassLaws "Errors" $
+        eqLaws (Proxy @Errors)
+    ]
+
+-- | This is not a fully lawful instance, because it uses 'approximateEqStream'.
+instance Eq a => Eq (Stream a) where
+  (==) = approximateEqStream
+
+instance Arbitrary a => Arbitrary (Stream a) where
+  arbitrary = oneof [
+        S.genFinite arbitrary
+      , S.genInfinite arbitrary
+      ]
+  shrink s = S.liftShrinkStream shrink s
+
+deriving stock instance Generic (Stream a)
+deriving anyclass instance CoArbitrary a => CoArbitrary (Stream a)
+deriving anyclass instance Function a => Function (Stream a)
+
+deriving stock instance Generic InternalInfo
+deriving anyclass instance Function InternalInfo
+deriving anyclass instance CoArbitrary InternalInfo
+
+-- | This is not a fully lawful instance, because it uses 'approximateEqStream'.
+deriving stock instance Eq Errors
+deriving stock instance Generic Errors
+deriving anyclass instance Function Errors
+deriving anyclass instance CoArbitrary Errors
+
+deriving stock instance Generic FsErrorType
+deriving anyclass instance Function FsErrorType
+deriving anyclass instance CoArbitrary FsErrorType
+
+deriving stock instance Eq Partial
+deriving stock instance Generic Partial
+deriving anyclass instance Function Partial
+deriving anyclass instance CoArbitrary Partial
+
+deriving stock instance Eq PutCorruption
+deriving stock instance Generic PutCorruption
+deriving anyclass instance Function PutCorruption
+deriving anyclass instance CoArbitrary PutCorruption
+
+deriving stock instance Eq Blob
+deriving stock instance Generic Blob
+deriving anyclass instance Function Blob
+deriving anyclass instance CoArbitrary Blob


### PR DESCRIPTION
See the commit messages for an explanation of the changes.

Currently, we only add fault injection to the `CreateSnapshot` and `OpenSnapshot` actions. This can be extended to other actions, but it would require even more infrastructure. For now, the snapshot functions are the main focus, because we want to test that corruption/disk faults are handled properly.