### PR TITLE
Make `WriteBufferBlobs` functions exception safe

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -381,6 +381,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Snapshot.FS
     Test.Database.LSMTree.Internal.Vector
     Test.Database.LSMTree.Internal.Vector.Growing
+    Test.Database.LSMTree.Internal.WriteBufferBlobs.FS
     Test.Database.LSMTree.Model.Table
     Test.Database.LSMTree.Monoidal
     Test.Database.LSMTree.StateMachine

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -24,7 +24,6 @@
 --
 module Database.LSMTree.Internal.WriteBufferBlobs (
     WriteBufferBlobs (..),
-    fromBlobFile,
     new,
     open,
     addBlob,
@@ -103,14 +102,23 @@ import           System.FS.API (HasFS)
 --
 data WriteBufferBlobs m h =
      WriteBufferBlobs {
-       blobFile           :: !(Ref (BlobFile m h))
 
-       -- | The manually tracked file pointer.
-     , blobFilePointer    :: !(FilePointer m)
+       -- | The blob file
+       --
+       -- INVARIANT: the file may contain garbage bytes, but no blob reference
+       -- ('RawBlobRef', 'WeakBlobRef', or 'StrongBlobRef) will reference these
+       -- bytes.
+      blobFile           :: !(Ref (BlobFile m h))
 
-       -- The 'WriteBufferBlobs' is a shared reference-counted object type
-     , writeBufRefCounter :: !(RefCounter m)
-     }
+      -- | The manually tracked file pointer.
+      --
+      -- INVARIANT: the file pointer points to a file offset at or beyond the
+      -- file size.
+    , blobFilePointer    :: !(FilePointer m)
+
+      -- The 'WriteBufferBlobs' is a shared reference-counted object type
+    , writeBufRefCounter :: !(RefCounter m)
+    }
 
 instance NFData h => NFData (WriteBufferBlobs m h) where
   rnf (WriteBufferBlobs a b c) = rnf a `seq` rnf b `seq` rnf c
@@ -119,6 +127,12 @@ instance RefCounted m (WriteBufferBlobs m h) where
   getRefCounter = writeBufRefCounter
 
 {-# SPECIALISE new :: HasFS IO h -> FS.FsPath -> IO (Ref (WriteBufferBlobs IO h)) #-}
+-- | Create a new 'WriteBufferBlobs' with a new file.
+--
+-- REF: the resulting reference must be released once it is no longer used.
+--
+-- ASYNC: this should be called with asynchronous exceptions masked because it
+-- allocates/creates resources.
 new ::
      (PrimMonad m, MonadMask m)
   => HasFS m h
@@ -128,22 +142,33 @@ new fs blobFileName = open fs blobFileName FS.MustBeNew
 
 {-# SPECIALISE open :: HasFS IO h -> FS.FsPath -> FS.AllowExisting -> IO (Ref (WriteBufferBlobs IO h)) #-}
 -- | Open a `WriteBufferBlobs` file and sets the file pointer to the end of the file.
+--
+-- REF: the resulting reference must be released once it is no longer used.
+--
+-- ASYNC: this should be called with asynchronous exceptions masked because it
+-- allocates/creates resources.
 open ::
      (PrimMonad m, MonadMask m)
   => HasFS m h
   -> FS.FsPath
   -> FS.AllowExisting
   -> m (Ref (WriteBufferBlobs m h))
--- TODO: make exception safe
 open fs blobFileName blobFileAllowExisting = do
     -- Must use read/write mode because we write blobs when adding, but
     -- we can also be asked to retrieve blobs at any time.
-    --
-    -- TODO: openBlobFile should be called with exceptions masked
-    fromBlobFile fs =<< openBlobFile fs blobFileName (FS.ReadWriteMode blobFileAllowExisting)
+    bracketOnError
+      (openBlobFile fs blobFileName (FS.ReadWriteMode blobFileAllowExisting))
+      releaseRef
+      (fromBlobFile fs)
 
 {-# SPECIALISE fromBlobFile :: HasFS IO h -> Ref (BlobFile IO h) -> IO (Ref (WriteBufferBlobs IO h)) #-}
--- | Make a `WriteBufferBlobs` from a `BlobFile` and set the file pointer to the end of the file.
+-- | Make a `WriteBufferBlobs` from a `BlobFile` and set the file pointer to the
+-- end of the file.
+--
+-- REF: the resulting reference must be released once it is no longer used.
+--
+-- ASYNC: this should be called with asynchronous exceptions masked because it
+-- allocates/creates resources.
 fromBlobFile ::
      (PrimMonad m, MonadMask m)
   => HasFS m h
@@ -162,6 +187,14 @@ fromBlobFile fs blobFile = do
       }
 
 {-# SPECIALISE addBlob :: HasFS IO h -> Ref (WriteBufferBlobs IO h) -> SerialisedBlob -> IO BlobSpan #-}
+-- | Append a blob.
+--
+-- If no exception is returned, then the file pointer will be set to exactly the
+-- file size.
+--
+-- If an exception is returned, the file pointer points to a file
+-- offset at or beyond the file size. The bytes between the old and new offset
+-- might be garbage or missing.
 addBlob :: (PrimMonad m, MonadThrow m)
         => HasFS m h
         -> Ref (WriteBufferBlobs m h)
@@ -169,7 +202,12 @@ addBlob :: (PrimMonad m, MonadThrow m)
         -> m BlobSpan
 addBlob fs (DeRef WriteBufferBlobs {blobFile, blobFilePointer}) blob = do
     let blobsize = sizeofBlob blob
+    -- If an exception happens after updating the file pointer, then no write
+    -- takes place. The next 'addBlob' will start writing at the new file
+    -- offset, so there are going to be some uninitialised bytes in the file.
     bloboffset <- updateFilePointer blobFilePointer blobsize
+    -- If an exception happens while writing the blob, the bytes in the file
+    -- might be corrupted.
     BlobFile.writeBlob fs blobFile blob bloboffset
     return BlobSpan {
       blobSpanOffset = bloboffset,
@@ -178,6 +216,13 @@ addBlob fs (DeRef WriteBufferBlobs {blobFile, blobFilePointer}) blob = do
 
 -- | Helper function to make a 'RawBlobRef' that points into a
 -- 'WriteBufferBlobs'.
+--
+-- This function should only be used on the result of 'addBlob' on the same
+-- 'WriteBufferBlobs'. For example:
+--
+-- @
+--  'addBlob' hfs wbb blob >>= \\span -> pure ('mkRawBlobRef' wbb span)
+-- @
 mkRawBlobRef :: Ref (WriteBufferBlobs m h)
              -> BlobSpan
              -> RawBlobRef m h
@@ -189,6 +234,13 @@ mkRawBlobRef (DeRef WriteBufferBlobs {blobFile = DeRef blobfile}) blobspan =
 
 -- | Helper function to make a 'WeakBlobRef' that points into a
 -- 'WriteBufferBlobs'.
+--
+-- This function should only be used on the result of 'addBlob' on the same
+-- 'WriteBufferBlobs'. For example:
+--
+-- @
+--  'addBlob' hfs wbb blob >>= \\span -> pure ('mkWeakBlobRef' wbb span)
+-- @
 mkWeakBlobRef :: Ref (WriteBufferBlobs m h)
               -> BlobSpan
               -> WeakBlobRef m h

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -33,6 +33,7 @@ import qualified Test.Database.LSMTree.Internal.Snapshot.Codec
 import qualified Test.Database.LSMTree.Internal.Snapshot.FS
 import qualified Test.Database.LSMTree.Internal.Vector
 import qualified Test.Database.LSMTree.Internal.Vector.Growing
+import qualified Test.Database.LSMTree.Internal.WriteBufferBlobs.FS
 import qualified Test.Database.LSMTree.Model.Table
 import qualified Test.Database.LSMTree.Monoidal
 import qualified Test.Database.LSMTree.StateMachine
@@ -74,6 +75,7 @@ main = do
     , Test.Database.LSMTree.Internal.Snapshot.FS.tests
     , Test.Database.LSMTree.Internal.Vector.tests
     , Test.Database.LSMTree.Internal.Vector.Growing.tests
+    , Test.Database.LSMTree.Internal.WriteBufferBlobs.FS.tests
     , Test.Database.LSMTree.Model.Table.tests
     , Test.Database.LSMTree.Monoidal.tests
     , Test.Database.LSMTree.UnitTests.tests

--- a/test/Test/Database/LSMTree/Internal/WriteBufferBlobs/FS.hs
+++ b/test/Test/Database/LSMTree/Internal/WriteBufferBlobs/FS.hs
@@ -1,0 +1,84 @@
+module Test.Database.LSMTree.Internal.WriteBufferBlobs.FS (tests) where
+
+import           Control.Concurrent.Class.MonadSTM.Strict
+import           Control.Monad
+import           Control.Monad.Class.MonadThrow
+import           Control.RefCount
+import           Database.LSMTree.Extras.Generators ()
+import           Database.LSMTree.Internal.BlobRef (readRawBlobRef)
+import           Database.LSMTree.Internal.Serialise (SerialisedBlob)
+import           Database.LSMTree.Internal.WriteBufferBlobs
+import           System.FS.API
+import           System.FS.Sim.Error hiding (genErrors)
+import qualified System.FS.Sim.MockFS as MockFS
+import           Test.Tasty
+import           Test.Tasty.QuickCheck as QC
+import           Test.Util.FS
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Internal.WriteBufferBlobs.FS" [
+      testProperty "prop_fault_WriteBufferBlobs" prop_fault_WriteBufferBlobs
+    ]
+
+-- Test that opening and releasing a 'WriteBufferBlobs' properly cleans handles
+-- and files in the presence of disk faults. Also test that we can write then
+-- read blobs correctly in the presence of disk faults.
+--
+-- By testing 'open', we also test 'new'.
+prop_fault_WriteBufferBlobs ::
+     Bool -- ^ create the file or not
+  -> AllowExisting
+  -> NoCleanupErrors
+  -> Errors
+  -> NoCleanupErrors
+  -> SerialisedBlob
+  -> SerialisedBlob
+  -> Property
+prop_fault_WriteBufferBlobs doCreateFile ae
+  (NoCleanupErrors openErrors)
+  errs
+  (NoCleanupErrors releaseErrors)
+  b1 b2 =
+    ioProperty $
+    withSimErrorHasFS propPost MockFS.empty emptyErrors $ \hfs fsVar errsVar -> do
+      when doCreateFile $
+        withFile hfs path (WriteMode MustBeNew) $ \_ -> pure ()
+      eith <- try @_ @FsError $
+        bracket (acquire hfs errsVar) (release errsVar) $ \wbb -> do
+          fs' <- atomically $ readTMVar fsVar
+          let prop = propNumOpenHandles 1 fs' .&&. propNumDirEntries root 1 fs'
+          props <- blobRoundtrips hfs errsVar wbb
+          pure (prop .&&. props)
+      pure $ case eith of
+        Left{}     -> do
+          label "FsError" $ property True
+        Right prop ->
+          label "Success" $ prop
+  where
+    root = mkFsPath []
+    path = mkFsPath ["wbb"]
+
+    acquire hfs errsVar = withErrors errsVar openErrors $ open hfs path ae
+
+    -- Test that we can roundtrip blobs
+    blobRoundtrips hfs errsVar wbb = withErrors errsVar errs $ do
+        props <-
+          forM [b1, b2] $ \b -> do
+            bspan <- addBlob hfs wbb b
+            let bref = mkRawBlobRef wbb bspan
+            b' <- readRawBlobRef hfs bref
+            pure (b === b')
+        pure $ conjoin props
+
+    release errsVar wbb = withErrors errsVar releaseErrors $ releaseRef wbb
+
+    propPost fs = propNoOpenHandles fs .&&.
+        if doCreateFile then
+          case ae of
+            AllowExisting ->
+              -- TODO: fix, see the TODO on openBlobFile
+              propNoDirEntries root fs .||. propNumDirEntries root 1 fs
+            MustBeNew ->
+              propNumDirEntries root 1 fs
+        else
+          propNoDirEntries root fs


### PR DESCRIPTION
This builds on top of #520