### PR TITLE
`s-r-p` for `quickcheck-lockstep` with more verbose counterexamples

### DIFF
--- a/cabal.project.release
+++ b/cabal.project.release
@@ -38,3 +38,9 @@ source-repository-package
   subdir:
     fs-api
     fs-sim
+
+-- quickcheck-lockstep with more verbose counterexamples
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/quickcheck-lockstep
+  tag: 845cd66d03d0410618c660dbcb21f58f66cf0931


### PR DESCRIPTION
This is useful for debugging test failures in the presence of disk faults.

