### PR TITLE
Test snapshot corruption

### DIFF
--- a/test/Test/Util/FS.hs
+++ b/test/Test/Util/FS.hs
@@ -22,10 +22,16 @@ module Test.Util.FS (
   , assertNumOpenHandles
     -- * Equality
   , approximateEqStream
+    -- * List directory
+  , DirEntry (..)
+  , listDirectoryFiles
+  , listDirectoryRecursive
+  , listDirectoryRecursiveFiles
     -- * Corruption
   , flipFileBit
   , hFlipBit
     -- * Arbitrary
+    -- ** Modifiers
   , NoCleanupErrors (..)
   ) where
 
@@ -37,8 +43,10 @@ import           Control.Monad.Class.MonadThrow (MonadCatch, MonadThrow)
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Monad.Primitive (PrimMonad)
 import           Data.Bit (MVector (..), flipBit)
+import           Data.Foldable (foldlM)
 import           Data.Primitive.ByteArray (newPinnedByteArray, setByteArray)
 import           Data.Primitive.Types (sizeOf)
+import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Stack
 import           System.FS.API as FS
@@ -47,7 +55,8 @@ import           System.FS.BlockIO.IO
 import           System.FS.BlockIO.Sim (fromHasFS)
 import           System.FS.IO
 import           System.FS.Sim.Error
-import           System.FS.Sim.MockFS
+import           System.FS.Sim.MockFS (HandleMock, MockFS, numOpenHandles,
+                     openHandles, pretty)
 import           System.FS.Sim.STM
 import qualified System.FS.Sim.Stream as Stream
 import           System.FS.Sim.Stream (InternalInfo (..), Stream (..))
@@ -229,6 +238,78 @@ approximateEqStream (UnsafeStream infoXs xs) (UnsafeStream infoYs ys) =
       (_, _)               -> False
 
 {-------------------------------------------------------------------------------
+  List directory
+-------------------------------------------------------------------------------}
+
+-- TODO: test the list directory functions
+
+data DirEntry a = Directory a | File a
+  deriving stock (Show, Eq, Ord, Functor)
+
+-- | List all files and directories in the given directory and recusively in all
+-- sub-directories.
+listDirectoryRecursive ::
+     Monad m
+  => HasFS m h
+  -> FsPath
+  -> m (Set (DirEntry FsPath))
+listDirectoryRecursive hfs = go Set.empty (mkFsPath [])
+  where
+    go !acc relPath absPath = do
+        pcs <- listDirectory hfs absPath
+        foldlM (\acc' -> go' acc' relPath absPath) acc pcs
+
+    go' !acc relPath absPath pc = do
+        let
+          p = mkFsPath [pc]
+          relPath' = relPath </> p
+          absPath' = absPath </> p
+        isFile <- doesFileExist hfs absPath'
+        if isFile then
+          pure (File relPath' `Set.insert` acc)
+        else do
+          isDirectory <- doesDirectoryExist hfs absPath'
+          if isDirectory then
+            go (Directory relPath' `Set.insert` acc) relPath' absPath'
+          else
+            error $ printf
+              "listDirectoryRecursive: %s is not a file or directory"
+              (show relPath')
+
+-- | List files in the given directory and recursively in all sub-directories.
+listDirectoryRecursiveFiles ::
+     Monad m
+  => HasFS m h
+  -> FsPath
+  -> m (Set FsPath)
+listDirectoryRecursiveFiles hfs dir = do
+    dirEntries <- listDirectoryRecursive hfs dir
+    foldlM f Set.empty dirEntries
+  where
+    f !acc (File p) = pure $ Set.insert p acc
+    f !acc _        = pure acc
+
+-- | List files in the given directory
+listDirectoryFiles ::
+     Monad m
+  => HasFS m h
+  -> FsPath
+  -> m (Set FsPath)
+listDirectoryFiles hfs = go Set.empty
+  where
+    go !acc absPath = do
+        pcs <- listDirectory hfs absPath
+        foldlM go' acc pcs
+
+    go' !acc pc = do
+        let path = mkFsPath [pc]
+        isFile <- doesFileExist hfs path
+        if isFile then
+          pure (path `Set.insert` acc)
+        else
+          pure acc
+
+{-------------------------------------------------------------------------------
   Corruption
 -------------------------------------------------------------------------------}
 
@@ -262,8 +343,12 @@ hFlipBit hfs h bitOffset = do
     void $ hPutBufExactlyAt hfs h buf bufOff count off
 
 {-------------------------------------------------------------------------------
-  Arbitrary
+  Arbitrary: modifiers
 -------------------------------------------------------------------------------}
+
+--
+-- NoCleanupErrors
+--
 
 -- | No errors on closing file handles and removing files
 newtype NoCleanupErrors = NoCleanupErrors Errors
@@ -283,8 +368,9 @@ instance Arbitrary NoCleanupErrors where
   -- The shrinker for 'Errors' does not re-introduce 'hCloseE' and 'removeFile'.
   shrink (NoCleanupErrors errs) = NoCleanupErrors <$> shrink errs
 
-newtype TestOpenMode = TestOpenMode OpenMode
-  deriving stock Show
+{-------------------------------------------------------------------------------
+  Arbitrary: orphans
+-------------------------------------------------------------------------------}
 
 instance Arbitrary OpenMode where
   arbitrary = genOpenMode


### PR DESCRIPTION
A next step would be to apply the same explicit corruption method to the statemachine tests.

In parallel, we can add silent corruption to `fs-sim`, which currently only simulates noisy corruption. We could use this silent corruption simulation to eventually replace the explicit `flipFileBit` calls