### PR TITLE
fix: move checkCRC to CRC32C

### DIFF
--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -34,8 +34,7 @@ import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Merge (MergeType (..))
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun (NumRuns (..))
-import           Database.LSMTree.Internal.Run (ChecksumError (..),
-                     FileFormatError (..))
+import           Database.LSMTree.Internal.Run (FileFormatError (..))
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Snapshot
 import qualified System.FS.API as FS


### PR DESCRIPTION
Move checkCRC to the CRC32C module to allow reuse in validating the write buffer files.

@mheinzel reopening as PR into main.