### PR TITLE
fix: move FileFormatError to Paths

### DIFF
--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -34,7 +34,6 @@ import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Merge (MergeType (..))
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun (NumRuns (..))
-import           Database.LSMTree.Internal.Run (FileFormatError (..))
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Snapshot
 import qualified System.FS.API as FS

--- a/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
@@ -4,7 +4,6 @@ module Test.Database.LSMTree.Internal.Snapshot.FS (tests) where
 import           Codec.CBOR.Read (DeserialiseFailure)
 import           Control.Exception
 import           Database.LSMTree.Internal.CRC32C
-import           Database.LSMTree.Internal.Run
 import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.Snapshot.Codec
 import           System.FS.API


### PR DESCRIPTION
Move FileFormatError to Paths module to allow reuse in validating the write buffer files.