### PR TITLE
Fix out-of-bounds array access in `hFlipBit`.

### DIFF
--- a/test/Test/FS.hs
+++ b/test/Test/FS.hs
@@ -124,16 +124,19 @@ createFile hfs p = withFile hfs p (WriteMode MustBeNew) $ \_ -> pure ()
 data WithBitOffset a = WithBitOffset Int a
   deriving stock Show
 
+bitLength :: BS.ByteString -> Int
+bitLength bs = BS.length bs * 8
+
 instance Arbitrary (WithBitOffset ByteString) where
   arbitrary = do
       bs <- arbitrary `suchThat` (\bs -> BS.length bs > 0)
-      bitOffset <- chooseInt (0, BS.length bs - 1)
+      bitOffset <- chooseInt (0, bitLength bs - 1)
       pure $ WithBitOffset bitOffset bs
   shrink (WithBitOffset bitOffset bs) =
       [ WithBitOffset bitOffset' bs'
       | bs' <- shrink bs
       , BS.length bs' > 0
-      , let bitOffset' = max 0 $ min (BS.length bs' - 1) bitOffset
+      , let bitOffset' = max 0 $ min (bitLength bs' - 1) bitOffset
       ] ++ [
         WithBitOffset bitOffset' bs
       | bitOffset' <- max 0 <$> shrink bitOffset

--- a/test/Test/Util/FS.hs
+++ b/test/Test/Util/FS.hs
@@ -364,7 +364,7 @@ hFlipBit hfs h bitOffset = do
     -- least the size of a machine word.
     let n = sizeOf (0 :: Word)
     buf <- newPinnedByteArray n
-    setByteArray buf 0 n (0 :: Word)
+    setByteArray buf 0 1 (0 :: Word)
     -- Read the bit at the given offset
     let (byteOffset, i) = bitOffset `quotRem` 8
         bufOff = BufferOffset 0


### PR DESCRIPTION
Resolves #549