### PR TITLE
Table union porting: change merge credit tracking strategy and return leftovers

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -366,6 +366,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Index.Ordinary
     Test.Database.LSMTree.Internal.Lookup
     Test.Database.LSMTree.Internal.Merge
+    Test.Database.LSMTree.Internal.MergingRun
     Test.Database.LSMTree.Internal.MergingTree
     Test.Database.LSMTree.Internal.Monkey
     Test.Database.LSMTree.Internal.PageAcc

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -320,14 +320,8 @@ deriving anyclass instance NoThunks MergePolicyForLevel
 deriving stock instance Generic NumRuns
 deriving anyclass instance NoThunks NumRuns
 
-deriving stock instance Generic (UnspentCreditsVar s)
-deriving anyclass instance Typeable s => NoThunks (UnspentCreditsVar s)
-
-deriving stock instance Generic (TotalStepsVar s)
-deriving anyclass instance Typeable s => NoThunks (TotalStepsVar s)
-
-deriving stock instance Generic (SpentCreditsVar s)
-deriving anyclass instance Typeable s => NoThunks (SpentCreditsVar s)
+deriving stock instance Generic (CreditsVar s)
+deriving anyclass instance Typeable s => NoThunks (CreditsVar s)
 
 deriving stock instance Generic MergeKnownCompleted
 deriving anyclass instance NoThunks MergeKnownCompleted

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -893,7 +893,7 @@ scaleCreditsForMerge LevelTiering _ (Credits c) =
     -- runs come in).
     MR.Credits (c * (1 + 4))
 
-scaleCreditsForMerge LevelLevelling (DeRef mr) (Credits c) =
+scaleCreditsForMerge LevelLevelling mr (Credits c) =
     -- A levelling merge has 1 input run and one resident run, which is (up
     -- to) 4x bigger than the others. It needs to be completed before
     -- another run comes in.
@@ -903,7 +903,7 @@ scaleCreditsForMerge LevelLevelling (DeRef mr) (Credits c) =
     -- worst-case upper bound by looking at the sizes of the input runs.
     -- As as result, merge work would/could be more evenly distributed over
     -- time when the resident run is smaller than the worst case.
-    let NumRuns n = MR.mergeNumRuns mr
+    let NumRuns n = MR.numRuns mr
        -- same as division rounding up: ceiling (c * n / 4)
     in MR.Credits ((c * n + 3) `div` 4)
 

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -746,7 +746,7 @@ addRunToLevels tr conf@TableConfig{..} resolve hfs hbio root uc r0 reg levels ul
           OneShot -> do
             let !required = MR.Credits (unNumEntries (V.foldMap' Run.size rs))
             let !thresh = creditThresholdForLevel conf ln
-            MR.supplyCredits required thresh mr
+            MR.supplyCredits mr thresh required
             -- This ensures the merge is really completed. However, we don't
             -- release the merge yet and only briefly inspect the resulting run.
             bracket (MR.expectCompleted mr) releaseRef $ \r ->
@@ -877,7 +877,7 @@ supplyCredits conf c levels =
         Merging mp mr -> do
           let !c' = scaleCreditsForMerge mp mr c
           let !thresh = creditThresholdForLevel conf ln
-          MR.supplyCredits c' thresh mr
+          MR.supplyCredits mr thresh c'
 
 -- | Scale a number of credits to a number of merge steps to be performed, based
 -- on the merging run.
@@ -912,4 +912,4 @@ scaleCreditsForMerge LevelLevelling (DeRef mr) (Credits c) =
 creditThresholdForLevel :: TableConfig -> LevelNo -> MR.CreditThreshold
 creditThresholdForLevel conf (LevelNo _i) =
     let AllocNumEntries (NumEntries x) = confWriteBufferAlloc conf
-    in  MR.CreditThreshold x
+    in  MR.CreditThreshold (MR.Credits x)

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -746,7 +746,7 @@ addRunToLevels tr conf@TableConfig{..} resolve hfs hbio root uc r0 reg levels ul
           OneShot -> do
             let !required = MR.Credits (unNumEntries (V.foldMap' Run.size rs))
             let !thresh = creditThresholdForLevel conf ln
-            MR.supplyCredits mr thresh required
+            _leftoverCredits <- MR.supplyCredits mr thresh required
             -- This ensures the merge is really completed. However, we don't
             -- release the merge yet and only briefly inspect the resulting run.
             bracket (MR.expectCompleted mr) releaseRef $ \r ->
@@ -877,7 +877,8 @@ supplyCredits conf c levels =
         Merging mp mr -> do
           let !c' = scaleCreditsForMerge mp mr c
           let !thresh = creditThresholdForLevel conf ln
-          MR.supplyCredits mr thresh c'
+          _leftoverCredits <- MR.supplyCredits mr thresh c'
+          return ()
 
 -- | Scale a number of credits to a number of merge steps to be performed, based
 -- on the merging run.

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -8,25 +8,27 @@
 -- | An incremental merge of multiple runs.
 module Database.LSMTree.Internal.MergingRun (
     -- * Merging run
-    MergingRun (..)
+    MergingRun
   , NumRuns (..)
   , new
   , newCompleted
   , duplicateRuns
   , supplyCredits
   , expectCompleted
+  , snapshot
+  , numRuns
 
     -- * Credit tracking
     -- $credittracking
   , Credits (..)
   , CreditThreshold (..)
   , SuppliedCredits (..)
-  , atomicReadSuppliedCredits
 
   -- * Concurrency
   -- $concurrency
 
     -- * Internal state
+  , pattern MergingRun
   , MergingRunState (..)
   , MergeKnownCompleted (..)
   , CreditsVar (..)
@@ -219,6 +221,24 @@ duplicateRuns (DeRef mr) =
       CompletedMerge r  -> V.singleton <$> dupRef r
       OngoingMerge rs _ -> withActionRegistry $ \reg ->
         V.mapM (\r -> withRollback reg (dupRef r) releaseRef) rs
+
+-- | Take a snapshot of the state of a merging run.
+snapshot ::
+     (PrimMonad m, MonadMVar m)
+  => Ref (MergingRun m h)
+  -> m (MergingRunState m h,
+        SuppliedCredits,
+        NumRuns,
+        NumEntries)
+snapshot (DeRef MergingRun {..}) = do
+    state <- readMVar mergeState
+    (SpentCredits   spent,
+     UnspentCredits unspent) <- atomicReadCredits mergeCreditsVar
+    let supplied = SuppliedCredits (spent + unspent)
+    return (state, supplied, mergeNumRuns, mergeNumEntries)
+
+numRuns :: Ref (MergingRun m h) -> NumRuns
+numRuns (DeRef MergingRun {mergeNumRuns}) = mergeNumRuns
 
 {-------------------------------------------------------------------------------
   Credits
@@ -475,19 +495,6 @@ atomicReadCredits ::
   -> m (SpentCredits, UnspentCredits)
 atomicReadCredits (CreditsVar v) =
     unpackCreditsPair <$> atomicReadInt v
-
-{-# INLINE atomicReadSuppliedCredits #-}
-atomicReadSuppliedCredits ::
-     PrimMonad m
-  => CreditsVar (PrimState m)
-  -> m SuppliedCredits
-atomicReadSuppliedCredits (CreditsVar v) = do
-    cp <- atomicReadInt v
-    let !supplied =
-           case cp of
-             CreditsPair (SpentCredits   spent)
-                         (UnspentCredits unspent) -> spent + unspent
-    return (SuppliedCredits supplied)
 
 {-# INLINE atomicModifyInt #-}
 -- | Atomically modify a single mutable integer variable, using a CAS loop.

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -28,6 +28,7 @@ import           Control.ActionRegistry
 import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.Concurrent.Class.MonadSTM (MonadSTM)
 import           Control.DeepSeq (NFData (..))
+import           Control.Exception (assert)
 import           Control.Monad (void)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow (MonadMask)
@@ -462,9 +463,10 @@ fromSnapLevels reg hfs hbio conf@TableConfig{..} uc resolve dir (SnapLevels leve
                 -- When a snapshot is created, merge progress is lost, so we
                 -- have to redo merging work here. SuppliedCredits tracks how
                 -- many credits were supplied before the snapshot was taken.
-                MR.supplyCredits mr (creditThresholdForLevel conf ln)
-                                 (MR.Credits sc)
-                return mr
+                leftoverCredits <- MR.supplyCredits
+                                     mr (creditThresholdForLevel conf ln)
+                                     (MR.Credits sc)
+                assert (leftoverCredits == 0) $ return mr
 
     dupRun r = withRollback reg (dupRef r) releaseRef
 

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -140,13 +140,13 @@ instance NFData r => NFData (SnapLevel r) where
   rnf (SnapLevel a b) = rnf a `seq` rnf b
 
 data SnapIncomingRun r =
-    SnapMergingRun !MergePolicyForLevel !NumRuns !NumEntries !UnspentCredits !(SnapMergingRunState r)
+    SnapMergingRun !MergePolicyForLevel !NumRuns !NumEntries !UnspentCredits !SpentCredits !(SnapMergingRunState r)
   | SnapSingleRun !r
   deriving stock (Show, Eq, Functor, Foldable, Traversable)
 
 instance NFData r => NFData (SnapIncomingRun r) where
-  rnf (SnapMergingRun a b c d e) =
-      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e
+  rnf (SnapMergingRun a b c d e f) =
+      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f
   rnf (SnapSingleRun a) = rnf a
 
 -- | The total number of unspent credits. This total is used in combination with
@@ -158,12 +158,12 @@ newtype UnspentCredits = UnspentCredits { getUnspentCredits :: Int }
 
 data SnapMergingRunState r =
     SnapCompletedMerge !r
-  | SnapOngoingMerge !(V.Vector r) !SpentCredits !MergeType
+  | SnapOngoingMerge !(V.Vector r) !MergeType
   deriving stock (Show, Eq, Functor, Foldable, Traversable)
 
 instance NFData r => NFData (SnapMergingRunState r) where
-  rnf (SnapCompletedMerge a)   = rnf a
-  rnf (SnapOngoingMerge a b c) = rnf a `seq` rnf b `seq` rnf c
+  rnf (SnapCompletedMerge a) = rnf a
+  rnf (SnapOngoingMerge a b) = rnf a `seq` rnf b
 
 -- | The total number of spent credits. This total is used in combination with
 -- 'UnspentCedits' on snapshot load to restore merging work that was lost when
@@ -198,33 +198,28 @@ toSnapIncomingRun ::
   => IncomingRun m h
   -> m (SnapIncomingRun (Ref (Run m h)))
 toSnapIncomingRun (Single r) = pure (SnapSingleRun r)
--- We need to know how many credits were yet unspent so we can restore merge
--- work on snapshot load. No need to snapshot the contents of totalStepsVar
--- here, since we still start counting from 0 again when loading the snapshot.
 toSnapIncomingRun (Merging mergePolicy (DeRef MR.MergingRun {..})) = do
+    -- We need to know how many credits were spend and yet unspent so we can
+    -- restore merge work on snapshot load. No need to snapshot the contents
+    -- of totalStepsVar here, since we still start counting from 0 again when
+    -- loading the snapshot.
     unspentCredits <- readPrimVar (MR.getUnspentCreditsVar mergeUnspentCredits)
-    smrs <- withMVar mergeState $ \mrs -> toSnapMergingRunState mrs
+    spentCredits   <- readPrimVar (MR.getSpentCreditsVar mergeSpentCredits)
+    smrs <- toSnapMergingRunState <$> readMVar mergeState
     pure $
       SnapMergingRun
         mergePolicy
         mergeNumRuns
         mergeNumEntries
         (UnspentCredits unspentCredits)
+        (SpentCredits spentCredits)
         smrs
 
-{-# SPECIALISE toSnapMergingRunState ::
-     MR.MergingRunState IO h
-  -> IO (SnapMergingRunState (Ref (Run IO h))) #-}
 toSnapMergingRunState ::
-     PrimMonad m
-  => MR.MergingRunState m h
-  -> m (SnapMergingRunState (Ref (Run m h)))
-toSnapMergingRunState (MR.CompletedMerge r) = pure (SnapCompletedMerge r)
--- We need to know how many credits were spent already so we can restore merge
--- work on snapshot load.
-toSnapMergingRunState (MR.OngoingMerge rs (MR.SpentCreditsVar spentCreditsVar) m) = do
-    spentCredits <- readPrimVar spentCreditsVar
-    pure (SnapOngoingMerge rs (SpentCredits spentCredits) (Merge.mergeType m))
+     MR.MergingRunState m h
+  -> SnapMergingRunState (Ref (Run m h))
+toSnapMergingRunState (MR.CompletedMerge r)  = SnapCompletedMerge r
+toSnapMergingRunState (MR.OngoingMerge rs m) = SnapOngoingMerge rs (Merge.mergeType m)
 
 {-------------------------------------------------------------------------------
   Write Buffer
@@ -458,12 +453,13 @@ fromSnapLevels reg hfs hbio conf@TableConfig{..} uc resolve dir (SnapLevels leve
           -> m (IncomingRun m h)
         fromSnapIncomingRun (SnapSingleRun run) = do
             Single <$> dupRun run
-        fromSnapIncomingRun (SnapMergingRun mpfl nr ne unspentCredits smrs) = do
+        fromSnapIncomingRun (SnapMergingRun mpfl nr ne unspentCredits
+                                            spentCredits smrs) = do
             Merging mpfl <$> case smrs of
               SnapCompletedMerge run ->
                 withRollback reg (MR.newCompleted nr ne run) releaseRef
 
-              SnapOngoingMerge runs spentCredits mt -> do
+              SnapOngoingMerge runs mt -> do
                 rn <- uniqueToRunNumber <$> incrUniqCounter uc
                 mr <- withRollback reg
                   (MR.new hfs hbio resolve caching alloc mt (mkPath rn) runs)

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -192,14 +192,16 @@ toSnapIncomingRun ::
   => IncomingRun m h
   -> m (SnapIncomingRun (Ref (Run m h)))
 toSnapIncomingRun (Single r) = pure (SnapSingleRun r)
-toSnapIncomingRun (Merging mergePolicy (DeRef MR.MergingRun {..})) = do
+toSnapIncomingRun (Merging mergePolicy mergingRun) = do
     -- We need to know how many credits were spend and yet unspent so we can
     -- restore merge work on snapshot load. No need to snapshot the contents
     -- of totalStepsVar here, since we still start counting from 0 again when
     -- loading the snapshot.
-    MR.SuppliedCredits (MR.Credits suppliedCredits)
-         <- MR.atomicReadSuppliedCredits mergeCreditsVar
-    smrs <- toSnapMergingRunState <$> readMVar mergeState
+    (mergingRunState,
+     MR.SuppliedCredits (MR.Credits suppliedCredits),
+     mergeNumRuns,
+     mergeNumEntries) <- MR.snapshot mergingRun
+    let smrs = toSnapMergingRunState mergingRunState
     pure $
       SnapMergingRun
         mergePolicy

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -7,9 +7,8 @@ module Database.LSMTree.Internal.Snapshot (
   , SnapLevels (..)
   , SnapLevel (..)
   , SnapIncomingRun (..)
-  , UnspentCredits (..)
+  , SuppliedCredits (..)
   , SnapMergingRunState (..)
-  , SpentCredits (..)
     -- * Conversion to levels snapshot format
   , toSnapLevels
     -- * Write buffer
@@ -35,7 +34,6 @@ import           Control.Monad.Class.MonadThrow (MonadMask)
 import           Control.Monad.Primitive (PrimMonad)
 import           Control.RefCount
 import           Data.Foldable (sequenceA_, traverse_)
-import           Data.Primitive.PrimVar
 import           Data.Text (Text)
 import           Data.Traversable (for)
 import qualified Data.Vector as V
@@ -140,19 +138,22 @@ instance NFData r => NFData (SnapLevel r) where
   rnf (SnapLevel a b) = rnf a `seq` rnf b
 
 data SnapIncomingRun r =
-    SnapMergingRun !MergePolicyForLevel !NumRuns !NumEntries !UnspentCredits !SpentCredits !(SnapMergingRunState r)
+    SnapMergingRun !MergePolicyForLevel
+                   !NumRuns
+                   !NumEntries
+                   !SuppliedCredits
+                   !(SnapMergingRunState r)
   | SnapSingleRun !r
   deriving stock (Show, Eq, Functor, Foldable, Traversable)
 
 instance NFData r => NFData (SnapIncomingRun r) where
-  rnf (SnapMergingRun a b c d e f) =
-      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e `seq` rnf f
+  rnf (SnapMergingRun a b c d e) =
+      rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e
   rnf (SnapSingleRun a) = rnf a
 
--- | The total number of unspent credits. This total is used in combination with
--- 'SpentCredits' on snapshot load to restore merging work that was lost when
--- the snapshot was created.
-newtype UnspentCredits = UnspentCredits { getUnspentCredits :: Int }
+-- | The total number of supplied credits. This total is used on snapshot load
+-- to restore merging work that was lost when the snapshot was created.
+newtype SuppliedCredits = SuppliedCredits { getSuppliedCredits :: Int }
   deriving stock (Show, Eq, Read)
   deriving newtype NFData
 
@@ -164,13 +165,6 @@ data SnapMergingRunState r =
 instance NFData r => NFData (SnapMergingRunState r) where
   rnf (SnapCompletedMerge a) = rnf a
   rnf (SnapOngoingMerge a b) = rnf a `seq` rnf b
-
--- | The total number of spent credits. This total is used in combination with
--- 'UnspentCedits' on snapshot load to restore merging work that was lost when
--- the snapshot was created.
-newtype SpentCredits = SpentCredits { getSpentCredits :: Int }
-  deriving stock (Show, Eq, Read)
-  deriving newtype NFData
 
 {-------------------------------------------------------------------------------
   Conversion to levels snapshot format
@@ -203,16 +197,15 @@ toSnapIncomingRun (Merging mergePolicy (DeRef MR.MergingRun {..})) = do
     -- restore merge work on snapshot load. No need to snapshot the contents
     -- of totalStepsVar here, since we still start counting from 0 again when
     -- loading the snapshot.
-    unspentCredits <- readPrimVar (MR.getUnspentCreditsVar mergeUnspentCredits)
-    spentCredits   <- readPrimVar (MR.getSpentCreditsVar mergeSpentCredits)
+    MR.SuppliedCredits (MR.Credits suppliedCredits)
+         <- MR.atomicReadSuppliedCredits mergeCreditsVar
     smrs <- toSnapMergingRunState <$> readMVar mergeState
     pure $
       SnapMergingRun
         mergePolicy
         mergeNumRuns
         mergeNumEntries
-        (UnspentCredits unspentCredits)
-        (SpentCredits spentCredits)
+        (SuppliedCredits suppliedCredits)
         smrs
 
 toSnapMergingRunState ::
@@ -453,8 +446,8 @@ fromSnapLevels reg hfs hbio conf@TableConfig{..} uc resolve dir (SnapLevels leve
           -> m (IncomingRun m h)
         fromSnapIncomingRun (SnapSingleRun run) = do
             Single <$> dupRun run
-        fromSnapIncomingRun (SnapMergingRun mpfl nr ne unspentCredits
-                                            spentCredits smrs) = do
+        fromSnapIncomingRun (SnapMergingRun mpfl nr ne
+                                            (SuppliedCredits sc) smrs) = do
             Merging mpfl <$> case smrs of
               SnapCompletedMerge run ->
                 withRollback reg (MR.newCompleted nr ne run) releaseRef
@@ -465,12 +458,10 @@ fromSnapLevels reg hfs hbio conf@TableConfig{..} uc resolve dir (SnapLevels leve
                   (MR.new hfs hbio resolve caching alloc mt (mkPath rn) runs)
                   releaseRef
                 -- When a snapshot is created, merge progress is lost, so we
-                -- have to redo merging work here. UnspentCredits and
-                -- SpentCredits track how many credits were supplied before the
-                -- snapshot was taken.
-                let c = getUnspentCredits unspentCredits
-                      + getSpentCredits spentCredits
-                MR.supplyCredits (MR.Credits c) (creditThresholdForLevel conf ln) mr
+                -- have to redo merging work here. SuppliedCredits tracks how
+                -- many credits were supplied before the snapshot was taken.
+                MR.supplyCredits mr (creditThresholdForLevel conf ln)
+                                 (MR.Credits sc)
                 return mr
 
     dupRun r = withRollback reg (dupRef r) releaseRef

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -474,13 +474,14 @@ instance DecodeVersioned RunNumber where
 -- SnapIncomingRun
 
 instance Encode (SnapIncomingRun RunNumber) where
-  encode (SnapMergingRun mpfl nr ne uc smrs) =
-       encodeListLen 6
+  encode (SnapMergingRun mpfl nr ne uc sc smrs) =
+       encodeListLen 7
     <> encodeWord 0
     <> encode mpfl
     <> encode nr
     <> encode ne
     <> encode uc
+    <> encode sc
     <> encode smrs
   encode (SnapSingleRun x) =
        encodeListLen 2
@@ -492,9 +493,9 @@ instance DecodeVersioned (SnapIncomingRun RunNumber) where
       n <- decodeListLen
       tag <- decodeWord
       case (n, tag) of
-        (6, 0) -> SnapMergingRun <$>
+        (7, 0) -> SnapMergingRun <$>
           decodeVersioned v <*> decodeVersioned v <*> decodeVersioned v <*>
-          decodeVersioned v <*> decodeVersioned v
+          decodeVersioned v <*> decodeVersioned v <*> decodeVersioned v
         (2, 1) -> SnapSingleRun <$> decodeVersioned v
         _ -> fail ("[SnapMergingRun] Unexpected combination of list length and tag: " <> show (n, tag))
 
@@ -535,11 +536,10 @@ instance Encode (SnapMergingRunState RunNumber) where
          encodeListLen 2
       <> encodeWord 0
       <> encode x
-  encode (SnapOngoingMerge rs tc l) =
-         encodeListLen 4
+  encode (SnapOngoingMerge rs l) =
+         encodeListLen 3
       <> encodeWord 1
       <> encode rs
-      <> encode tc
       <> encode l
 
 instance DecodeVersioned (SnapMergingRunState RunNumber) where
@@ -548,8 +548,8 @@ instance DecodeVersioned (SnapMergingRunState RunNumber) where
       tag <- decodeWord
       case (n, tag) of
         (2, 0) -> SnapCompletedMerge <$> decodeVersioned v
-        (4, 1) -> SnapOngoingMerge <$>
-          decodeVersioned v <*> decodeVersioned v <*> decodeVersioned v
+        (3, 1) -> SnapOngoingMerge <$> decodeVersioned v
+                                   <*> decodeVersioned v
         _ -> fail ("[SnapMergingRunState] Unexpected combination of list length and tag: " <> show (n, tag))
 
 -- SpentCredits

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -474,13 +474,12 @@ instance DecodeVersioned RunNumber where
 -- SnapIncomingRun
 
 instance Encode (SnapIncomingRun RunNumber) where
-  encode (SnapMergingRun mpfl nr ne uc sc smrs) =
-       encodeListLen 7
+  encode (SnapMergingRun mpfl nr ne sc smrs) =
+       encodeListLen 6
     <> encodeWord 0
     <> encode mpfl
     <> encode nr
     <> encode ne
-    <> encode uc
     <> encode sc
     <> encode smrs
   encode (SnapSingleRun x) =
@@ -493,9 +492,9 @@ instance DecodeVersioned (SnapIncomingRun RunNumber) where
       n <- decodeListLen
       tag <- decodeWord
       case (n, tag) of
-        (7, 0) -> SnapMergingRun <$>
+        (6, 0) -> SnapMergingRun <$>
           decodeVersioned v <*> decodeVersioned v <*> decodeVersioned v <*>
-          decodeVersioned v <*> decodeVersioned v <*> decodeVersioned v
+          decodeVersioned v <*> decodeVersioned v
         (2, 1) -> SnapSingleRun <$> decodeVersioned v
         _ -> fail ("[SnapMergingRun] Unexpected combination of list length and tag: " <> show (n, tag))
 
@@ -521,14 +520,6 @@ instance DecodeVersioned MergePolicyForLevel where
         1 -> pure LevelLevelling
         _ -> fail ("[MergePolicyForLevel] Unexpected tag: " <> show tag)
 
--- UnspentCredits
-
-instance Encode UnspentCredits where
-  encode (UnspentCredits x) = encodeInt x
-
-instance DecodeVersioned UnspentCredits where
-  decodeVersioned V0 = UnspentCredits <$> decodeInt
-
 -- SnapMergingRunState
 
 instance Encode (SnapMergingRunState RunNumber) where
@@ -552,13 +543,13 @@ instance DecodeVersioned (SnapMergingRunState RunNumber) where
                                    <*> decodeVersioned v
         _ -> fail ("[SnapMergingRunState] Unexpected combination of list length and tag: " <> show (n, tag))
 
--- SpentCredits
+-- SuppliedCredits
 
-instance Encode SpentCredits where
-  encode (SpentCredits x) = encodeInt x
+instance Encode SuppliedCredits where
+  encode (SuppliedCredits x) = encodeInt x
 
-instance DecodeVersioned SpentCredits where
-  decodeVersioned V0 = SpentCredits <$> decodeInt
+instance DecodeVersioned SuppliedCredits where
+  decodeVersioned V0 = SuppliedCredits <$> decodeInt
 
 -- MergeType
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Test.Database.LSMTree.Internal.Index.Compact
 import qualified Test.Database.LSMTree.Internal.Index.Ordinary
 import qualified Test.Database.LSMTree.Internal.Lookup
 import qualified Test.Database.LSMTree.Internal.Merge
+import qualified Test.Database.LSMTree.Internal.MergingRun
 import qualified Test.Database.LSMTree.Internal.MergingTree
 import qualified Test.Database.LSMTree.Internal.Monkey
 import qualified Test.Database.LSMTree.Internal.PageAcc
@@ -59,6 +60,7 @@ main = do
     , Test.Database.LSMTree.Internal.Entry.tests
     , Test.Database.LSMTree.Internal.Lookup.tests
     , Test.Database.LSMTree.Internal.Merge.tests
+    , Test.Database.LSMTree.Internal.MergingRun.tests
     , Test.Database.LSMTree.Internal.MergingTree.tests
     , Test.Database.LSMTree.Internal.Monkey.tests
     , Test.Database.LSMTree.Internal.PageAcc.tests

--- a/test/Test/Database/LSMTree/Internal/MergingRun.hs
+++ b/test/Test/Database/LSMTree/Internal/MergingRun.hs
@@ -1,0 +1,57 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Database.LSMTree.Internal.MergingRun (tests) where
+
+import           Database.LSMTree.Internal.MergingRun
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Internal.MergingRun"
+    [ testProperty "prop_CreditsPair" prop_CreditsPair
+    ]
+
+-- | The representation of CreditsPair should round trip properly. This is
+-- non-trivial because it uses a packed bit the representation.
+--
+prop_CreditsPair :: SpentCredits -> UnspentCredits -> Property
+prop_CreditsPair spentCredits unspentCredits =
+    tabulate "bounds" [spentCreditsBound, unspentCreditsBound] $
+    let cp :: Int
+        !cp = CreditsPair spentCredits unspentCredits
+     in case cp of
+          CreditsPair spentCredits' unspentCredits' ->
+            (spentCredits, unspentCredits) === (spentCredits', unspentCredits')
+  where
+    spentCreditsBound
+      | spentCredits == minBound = "spentCredits == minBound"
+      | spentCredits == maxBound = "spentCredits == maxBound"
+      | otherwise                = "spentCredits == other"
+
+    unspentCreditsBound
+      | unspentCredits == minBound = "unspentCredits == minBound"
+      | unspentCredits == maxBound = "unspentCredits == maxBound"
+      | otherwise                  = "unspentCredits == other"
+
+deriving newtype instance Enum SpentCredits
+deriving newtype instance Enum UnspentCredits
+
+deriving stock instance Show Credits
+deriving stock instance Show SpentCredits
+deriving stock instance Show UnspentCredits
+
+instance Arbitrary SpentCredits where
+  arbitrary =
+    frequency [ (1, pure minBound)
+              , (1, pure maxBound)
+              , (10, arbitraryBoundedEnum)
+              ]
+
+instance Arbitrary UnspentCredits where
+  arbitrary =
+    frequency [ (1, pure minBound)
+              , (1, pure maxBound)
+              , (10, arbitraryBoundedEnum)
+              ]
+

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -278,12 +278,12 @@ deriving newtype instance Arbitrary RunNumber
 instance Arbitrary (SnapIncomingRun RunNumber) where
   arbitrary = oneof [
         SnapMergingRun <$> arbitrary <*> arbitrary <*> arbitrary
-                       <*> arbitrary <*> arbitrary
+                       <*> arbitrary <*> arbitrary <*> arbitrary
       , SnapSingleRun <$> arbitrary
       ]
-  shrink (SnapMergingRun a b c d e) =
-      [ SnapMergingRun a' b' c' d' e'
-      | (a', b', c', d', e') <- shrink (a, b, c, d, e) ]
+  shrink (SnapMergingRun a b c d e f) =
+      [ SnapMergingRun a' b' c' d' e' f'
+      | (a', b', c', d', e', f') <- shrink (a, b, c, d, e, f) ]
   shrink (SnapSingleRun a)  = SnapSingleRun <$> shrink a
 
 deriving newtype instance Arbitrary NumRuns
@@ -297,11 +297,11 @@ deriving newtype instance Arbitrary UnspentCredits
 instance Arbitrary (SnapMergingRunState RunNumber) where
   arbitrary = oneof [
         SnapCompletedMerge <$> arbitrary
-      , SnapOngoingMerge <$> arbitrary <*> arbitrary <*> arbitrary
+      , SnapOngoingMerge <$> arbitrary <*> arbitrary
       ]
   shrink (SnapCompletedMerge x) = SnapCompletedMerge <$> shrink x
-  shrink (SnapOngoingMerge x y z)   =
-      [ SnapOngoingMerge x' y' z' | (x', y', z') <- shrink (x, y, z) ]
+  shrink (SnapOngoingMerge x y) =
+      [ SnapOngoingMerge x' y' | (x', y') <- shrink (x, y) ]
 
 deriving newtype instance Arbitrary SpentCredits
 

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -17,7 +17,7 @@ import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Merge (MergeType (..))
 import           Database.LSMTree.Internal.MergeSchedule
-import           Database.LSMTree.Internal.MergingRun
+import           Database.LSMTree.Internal.MergingRun hiding (SuppliedCredits)
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.Snapshot.Codec
@@ -171,9 +171,8 @@ testAll test = [
     , test (Proxy @(SnapIncomingRun RunNumber))
     , test (Proxy @NumRuns)
     , test (Proxy @MergePolicyForLevel)
-    , test (Proxy @UnspentCredits)
     , test (Proxy @(SnapMergingRunState RunNumber))
-    , test (Proxy @SpentCredits)
+    , test (Proxy @SuppliedCredits)
     , test (Proxy @MergeType)
     ]
 
@@ -278,12 +277,12 @@ deriving newtype instance Arbitrary RunNumber
 instance Arbitrary (SnapIncomingRun RunNumber) where
   arbitrary = oneof [
         SnapMergingRun <$> arbitrary <*> arbitrary <*> arbitrary
-                       <*> arbitrary <*> arbitrary <*> arbitrary
+                       <*> arbitrary <*> arbitrary
       , SnapSingleRun <$> arbitrary
       ]
-  shrink (SnapMergingRun a b c d e f) =
-      [ SnapMergingRun a' b' c' d' e' f'
-      | (a', b', c', d', e', f') <- shrink (a, b, c, d, e, f) ]
+  shrink (SnapMergingRun a b c d e) =
+      [ SnapMergingRun a' b' c' d' e'
+      | (a', b', c', d', e') <- shrink (a, b, c, d, e) ]
   shrink (SnapSingleRun a)  = SnapSingleRun <$> shrink a
 
 deriving newtype instance Arbitrary NumRuns
@@ -291,8 +290,6 @@ deriving newtype instance Arbitrary NumRuns
 instance Arbitrary MergePolicyForLevel where
   arbitrary = elements [LevelTiering, LevelLevelling]
   shrink _ = []
-
-deriving newtype instance Arbitrary UnspentCredits
 
 instance Arbitrary (SnapMergingRunState RunNumber) where
   arbitrary = oneof [
@@ -303,5 +300,5 @@ instance Arbitrary (SnapMergingRunState RunNumber) where
   shrink (SnapOngoingMerge x y) =
       [ SnapOngoingMerge x' y' | (x', y') <- shrink (x, y) ]
 
-deriving newtype instance Arbitrary SpentCredits
+deriving newtype instance Arbitrary SuppliedCredits
 


### PR DESCRIPTION
More porting of changes for table union from the prototype into the implementation: when supplying credits to a MergingRun we want to return the leftover/unused credits. This is needed because supplying of credits to a union merge will require that all credits get spent, but union merges are made up of many ongoing merging runs.

This turns out to be more tricky than at first appearance. The existing strategy for tracking credits (unspent, spent and merge steps performed) made it very difficult to figure out how to account leftover credits.

So the major change in this PR is to change the MergingRun credit tracking strategy

The intention is to simplify things and make them more obviously correct in the presence of concurrency. This also make it easier to reliably determine leftover/excess supplied credits.

The approach is to change the counters from three independent counters, to just two, which are modified together as a pair atomically. Previously we tracked the credits spent and unspent, and the steps performed. We did not explicitly keep track of credits that were in the process of being spent.

Now we track spent and unspent (and not steps performed), but the spent credits includes those that are in the process of being spent. We keep these together in a single atomic variable, and so all operations on the pair are atomic. This makes the concurrency story much simpler because all credit tracking changes are atomic. We avoid having to track steps performed by accounting differently for the difference between credits used for merging and steps performed: we simply borrow more credits from the unspent pot, allowing the pot to become negative.