### PR TITLE
Bugfix: synchronise the snapshot directory and its contents

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1173,15 +1173,18 @@ createSnapshot snap label tableType t = do
         snapLevels <- toSnapLevels (tableLevels content)
 
         -- Hard link runs into the named snapshot directory
-        snapLevels' <- snapshotRuns reg hbio snapUc snapDir snapLevels
+        snapLevels' <- snapshotRuns reg snapUc snapDir snapLevels
+
+        -- Release the table content
+        releaseTableContent reg content
 
         let snapMetaData = SnapshotMetaData label tableType (tableConfig t) snapWriteBufferNumber snapLevels'
             SnapshotMetaDataFile contentPath = Paths.snapshotMetaDataFile snapDir
             SnapshotMetaDataChecksumFile checksumPath = Paths.snapshotMetaDataChecksumFile snapDir
         writeFileSnapshotMetaData hfs contentPath checksumPath snapMetaData
 
-        -- Release the table content
-        releaseTableContent reg content
+        -- Make the directory and its contents durable.
+        FS.synchroniseDirectoryRecursive hfs hbio (Paths.getNamedSnapshotDir snapDir)
 
 {-# SPECIALISE openSnapshot ::
      Session IO h

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -200,7 +200,7 @@ prop_WriteAndOpen fs hbio wb =
     withActionRegistry $ \reg -> do
       let paths = Run.runFsPaths written
           paths' = paths { runNumber = RunNumber 17}
-      hardLinkRunFiles reg fs hbio NoHardLinkDurable paths paths'
+      hardLinkRunFiles reg fs hbio paths paths'
       loaded <- openFromDisk fs hbio CacheRunData (simplePath 17)
 
       Run.size written @=? Run.size loaded


### PR DESCRIPTION
Not all the snapshot directory contents were being synchronised, and arguably not in the correct order. The synchronisation now only happens at the very end of taking a snapshot. Because of this, if other parts of the `createSnapshot` function fail, then we won't have flushed file and directory contents to disk unnecessarily.