### PR TITLE
New merging run credit counter strategy using an atomic pair of counters

### DIFF
--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -321,14 +321,8 @@ deriving anyclass instance NoThunks MergePolicyForLevel
 deriving stock instance Generic NumRuns
 deriving anyclass instance NoThunks NumRuns
 
-deriving stock instance Generic (UnspentCreditsVar s)
-deriving anyclass instance Typeable s => NoThunks (UnspentCreditsVar s)
-
-deriving stock instance Generic (StepsPerformedVar s)
-deriving anyclass instance Typeable s => NoThunks (StepsPerformedVar s)
-
-deriving stock instance Generic (SpentCreditsVar s)
-deriving anyclass instance Typeable s => NoThunks (SpentCreditsVar s)
+deriving stock instance Generic (CreditsVar s)
+deriving anyclass instance Typeable s => NoThunks (CreditsVar s)
 
 deriving stock instance Generic MergeKnownCompleted
 deriving anyclass instance NoThunks MergeKnownCompleted

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -673,7 +673,7 @@ addRunToLevels tr conf@TableConfig{..} resolve hfs hbio root uc r0 reg levels = 
           OneShot -> do
             let !required = MR.Credits (unNumEntries (V.foldMap' Run.size rs))
             let !thresh = creditThresholdForLevel conf ln
-            MR.supplyCredits mr thresh required
+            _leftoverCredits <- MR.supplyCredits mr thresh required
             -- This ensures the merge is really completed. However, we don't
             -- release the merge yet and only briefly inspect the resulting run.
             bracket (MR.expectCompleted mr) releaseRef $ \r ->
@@ -802,7 +802,8 @@ supplyCredits conf c levels =
         Merging mp mr -> do
           let !c' = scaleCreditsForMerge mp mr c
           let !thresh = creditThresholdForLevel conf ln
-          MR.supplyCredits mr thresh c'
+          _leftoverCredits <- MR.supplyCredits mr thresh c'
+          return ()
 
 -- | Scale a number of credits to a number of merge steps to be performed, based
 -- on the merging run.

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -818,7 +818,7 @@ scaleCreditsForMerge LevelTiering _ (Credits c) =
     -- runs come in).
     MR.Credits (c * (1 + 4))
 
-scaleCreditsForMerge LevelLevelling (DeRef mr) (Credits c) =
+scaleCreditsForMerge LevelLevelling mr (Credits c) =
     -- A levelling merge has 1 input run and one resident run, which is (up
     -- to) 4x bigger than the others. It needs to be completed before
     -- another run comes in.
@@ -828,7 +828,7 @@ scaleCreditsForMerge LevelLevelling (DeRef mr) (Credits c) =
     -- worst-case upper bound by looking at the sizes of the input runs.
     -- As as result, merge work would/could be more evenly distributed over
     -- time when the resident run is smaller than the worst case.
-    let NumRuns n = MR.mergeNumRuns mr
+    let NumRuns n = MR.numRuns mr
        -- same as division rounding up: ceiling (c * n / 4)
     in MR.Credits ((c * n + 3) `div` 4)
 

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -673,7 +673,7 @@ addRunToLevels tr conf@TableConfig{..} resolve hfs hbio root uc r0 reg levels = 
           OneShot -> do
             let !required = MR.Credits (unNumEntries (V.foldMap' Run.size rs))
             let !thresh = creditThresholdForLevel conf ln
-            MR.supplyCredits required thresh mr
+            MR.supplyCredits mr thresh required
             -- This ensures the merge is really completed. However, we don't
             -- release the merge yet and only briefly inspect the resulting run.
             bracket (MR.expectCompleted mr) releaseRef $ \r ->
@@ -802,7 +802,7 @@ supplyCredits conf c levels =
         Merging mp mr -> do
           let !c' = scaleCreditsForMerge mp mr c
           let !thresh = creditThresholdForLevel conf ln
-          MR.supplyCredits c' thresh mr
+          MR.supplyCredits mr thresh c'
 
 -- | Scale a number of credits to a number of merge steps to be performed, based
 -- on the merging run.
@@ -837,4 +837,4 @@ scaleCreditsForMerge LevelLevelling (DeRef mr) (Credits c) =
 creditThresholdForLevel :: TableConfig -> LevelNo -> MR.CreditThreshold
 creditThresholdForLevel conf (LevelNo _i) =
     let AllocNumEntries (NumEntries x) = confWriteBufferAlloc conf
-    in  MR.CreditThreshold x
+    in  MR.CreditThreshold (MR.Credits x)

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE MultiWayIf      #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies    #-}
@@ -363,7 +364,9 @@ pattern CreditsPair :: SpentCredits -> UnspentCredits -> Int
 pattern CreditsPair sc uc <- (unpackCreditsPair -> (sc, uc))
   where
     CreditsPair sc uc = packCreditsPair sc uc
+#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
 {-# INLINE CreditsPair #-}
+#endif
 {-# COMPLETE CreditsPair #-}
 
 -- TODO: test pack/unpack round trip with the minBound & maxBounds

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE MultiWayIf      #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies    #-}
 
 {- HLINT ignore "Use when" -}
 
@@ -17,11 +19,8 @@ module Database.LSMTree.Internal.MergingRun (
     -- $credittracking
   , Credits (..)
   , CreditThreshold (..)
-  , UnspentCreditsVar (..)
-  , SpentCreditsVar (..)
-  , StepsPerformedVar (..)
-  , readUnspentCredits
-  , readSpentCredits
+  , SuppliedCredits (..)
+  , atomicReadSuppliedCredits
 
   -- * Concurrency
   -- $concurrency
@@ -29,24 +28,26 @@ module Database.LSMTree.Internal.MergingRun (
     -- * Internal state
   , MergingRunState (..)
   , MergeKnownCompleted (..)
+  , CreditsVar (..)
   ) where
 
 import           Control.ActionRegistry
 import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.DeepSeq (NFData (..))
-import           Control.Monad (void, when)
+import           Control.Monad (when)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadCatch (bracketOnError),
                      MonadMask)
 import           Control.Monad.Primitive
 import           Control.RefCount
+import           Data.Bits
 import           Data.Maybe (fromMaybe)
 import           Data.Primitive.MutVar
 import           Data.Primitive.PrimVar
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.Assertions (assert)
-import           Database.LSMTree.Internal.Entry (NumEntries (..), unNumEntries)
+import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.Merge (Merge, MergeType (..),
                      StepResult (..))
@@ -59,28 +60,31 @@ import           System.FS.API (HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
 
 data MergingRun m h = MergingRun {
-      mergeNumRuns           :: !NumRuns
-      -- | Sum of number of entries in the input runs
-    , mergeNumEntries        :: !NumEntries
+      mergeNumRuns        :: !NumRuns
+      -- | Sum of number of entries in the input runs.
+      -- This also corresponds to the total merging debt.
+    , mergeNumEntries     :: !NumEntries
 
       -- See $credittracking
 
-      -- | The current number of credits supplied but as yet /unspent/.
-    , mergeUnspentCreditsVar :: !(UnspentCreditsVar (PrimState m))
-      -- | The current number of credits supplied but already spent. Note that
-      -- the total number of credits supplied is this plus the unspent credits.
-    , mergeSpentCreditsVar   :: !(SpentCreditsVar (PrimState m))
-      -- | The current number of merging steps actually performed. This is
-      -- always at least as big as the total number of credits supplied.
-    , mergeStepsPerformedVar :: !(StepsPerformedVar (PrimState m))
+      -- | A pair of counters for tracking supplied credits:
+      --
+      -- 1. The supplied credits that have been spent on merging steps plus the
+      --    supplied credits that are in the process of being spent.
+      -- 2. The supplied credits that have not been spent and are available to
+      --    spend.
+      --
+      -- The counters are always read & modified together atomically.
+      --
+    , mergeCreditsVar     :: !(CreditsVar (PrimState m))
 
       -- | A variable that caches knowledge about whether the merge has been
       -- completed. If 'MergeKnownCompleted', then we are sure the merge has
       -- been completed, otherwise if 'MergeMaybeCompleted' we have to check the
       -- 'MergingRunState'.
-    , mergeKnownCompleted    :: !(MutVar (PrimState m) MergeKnownCompleted)
-    , mergeState             :: !(StrictMVar m (MergingRunState m h))
-    , mergeRefCounter        :: !(RefCounter m)
+    , mergeKnownCompleted :: !(MutVar (PrimState m) MergeKnownCompleted)
+    , mergeState          :: !(StrictMVar m (MergingRunState m h))
+    , mergeRefCounter     :: !(RefCounter m)
     }
 
 instance RefCounted m (MergingRun m h) where
@@ -100,7 +104,7 @@ data MergingRunState m h =
       !(Merge m h)
 
 data MergeKnownCompleted = MergeKnownCompleted | MergeMaybeCompleted
-  deriving stock (Show, Eq, Read)
+  deriving stock Eq
 
 instance NFData MergeKnownCompleted where
   rnf MergeKnownCompleted = ()
@@ -177,9 +181,7 @@ unsafeNew ::
   -> MergingRunState m h
   -> m (Ref (MergingRun m h))
 unsafeNew mergeNumRuns mergeNumEntries knownCompleted state = do
-    mergeUnspentCreditsVar <- UnspentCreditsVar <$> newPrimVar 0
-    mergeSpentCreditsVar   <- SpentCreditsVar   <$> newPrimVar 0
-    mergeStepsPerformedVar <- StepsPerformedVar <$> newPrimVar 0
+    mergeCreditsVar <- CreditsVar <$> newPrimVar 0
     case state of
       OngoingMerge{}   -> assert (knownCompleted == MergeMaybeCompleted) (pure ())
       CompletedMerge{} -> pure ()
@@ -189,9 +191,7 @@ unsafeNew mergeNumRuns mergeNumEntries knownCompleted state = do
       MergingRun {
         mergeNumRuns
       , mergeNumEntries
-      , mergeUnspentCreditsVar
-      , mergeSpentCreditsVar
-      , mergeStepsPerformedVar
+      , mergeCreditsVar
       , mergeKnownCompleted
       , mergeState
       , mergeRefCounter
@@ -225,198 +225,179 @@ duplicateRuns (DeRef mr) =
 
 {- $credittracking
 
-  The credits concept we use here comes from amortised analysis of data
-  structures (see the Bankers Method from Okasaki), though here we use it for
-  tracking the scheduled (i.e. incremental) merge.
+The credits concept we use here comes from amortised analysis of data
+structures (see the Bankers Method from Okasaki). Though here we use it not as
+an analysis method but within the code itself for tracking the state of the
+scheduled (i.e. incremental) merge.
 
-  In the prototype things are relatively simple: we simulate performing merge
-  work in batches (based on a threshold) and the credit tracking reflects this
-  by tracking unspent credits (and the debt corresponding to the remaining
-  merge work to do). The implementation does this too, we accumulate unspent
-  credits until they reach a threshold at which point we do a batch of merging
-  work. Unlike the prototype, the implementation tracks both credits supplied
-  but as yet unspent and also tracks credits supplied and spent.
+In the prototype things are relatively simple: we simulate performing merge
+work in batches (based on a threshold) and the credit tracking reflects this by
+tracking unspent credits (and the debt corresponding to the remaining merge
+work to do).
 
-  In the prototype, the credits spent equals the merge steps performed. The
-  real implementation is more complicated: we distinguish credit supplied from
-  merge steps actually performed. When we spend credits on merging work, the
-  number of steps we perform is not guaranteed to be the same as the credits
-  supplied. For example we may ask to do 100 credits of merging work, but the
-  merge code (for perfectly sensible efficiency reasons) will decide to do 102
-  units of merging work. The rule is that we may do (slightly) more work than
-  the credits supplied but not less.
+The implementation is similar but somewhat more complex. We also accumulate
+unspent credits until they reach a threshold at which point we do a batch of
+merging work. Unlike the prototype, the implementation tracks both credits
+spent credits as yet unspent. We will elaborate on why and how below.
 
-  Thus we track three things:
+In the prototype, the credits spent equals the merge steps performed. The
+same holds in the real implementation, but making it so is more complicated.
+When we spend credits on merging work, the number of steps we perform is not
+guaranteed to be the same as the credits supplied. For example we may ask to do
+100 credits of merging work, but the merge code (for perfectly sensible
+efficiency reasons) will decide to do 102 units of merging work. The rule is
+that we may do (slightly) more work than the credits supplied but not less.
+To account for this we spend more credits, corresponding to the excess merging
+work performed. We spend them by borrowing them from the unspent credits, which
+may leave the unspent credits with a negative balance.
 
-   * credits unspent ('UnspentCreditsVar')
-   * credits spent ('SpentCreditsVar')
-   * steps performed ('StepsPerformedVar')
+Furthermore, the real implementation has to cope with concurrency: multiple
+threads sharing the same 'MergingRun' and calling 'supplyCredits' concurrently.
+The credit accounting thus needs to define the state of the credits while
+merging work is in progress by some thread. The approach we take is to define
+spent credits to include those that are in the process of being spent, leaving
+unspent credits as those that are available for a thread to spend on merging
+work.
 
-  The credits supplied is the sum of the credits spent and unspent. The credits
-  supplied and the steps performed will be close but not exactly the same in
-  general. Though the steps performed may never be less than the credits
-  supplied. These are the use cases:
+Thus we track two things:
 
-  * The total of spent credits + the total of unspent credits is used by the
-    snapshot feature to restore merge work on snapshot load that was lost during
-    snapshot creation.
+ * credits spent ('SpentCredits'): credits supplied that have been or are in
+   the process of being spent on performing merging steps; and
 
-  * For simplicity, merges are allowed to do more steps than requested. However,
-    it does mean that once we do more steps next time a batch of work is done,
-    then we should account for the surplus of steps performed by the previous
-    batch. The total of spent credits - the number of performed merge steps is
-    used to compute this surplus, and adjust for it.
+ * credits unspent ('UnspentCredits'): credits supplied that are not yet spent
+   and are thus available to spend.
 
-    TODO: we should reconsider at some later point in time whether this surplus
-    adjustment is necessary. It does not make a difference for correctness, but
-    it does mean we get a slightly better distribution of work over time. For
-    sensible batch sizes and workloads without many duplicate keys, it probably
-    won't make much of a difference. However, without this calculation the
-    surplus can accumulate over time, so if we're really pedantic about work
-    distribution then this is the way to go.
+The credits supplied is the sum of the credits spent and unspent.
 
-  In the presence of async exceptions, we offer a weaker guarantee regarding
-  consistency of the accumulated, unspent credits and the merge state: a merge
-  /may/ progress more than the number of credits that were taken. If an async
-  exception happens at some point during merging work, then we put back all the
-  credits we took beforehand. This makes the implementation simple, and merges
-  will still finish in time. It would be bad if we did not put back credits,
-  because then a merge might not finish in time, which will mess up the shape of
-  the levels tree.
-
-  Async exceptions are allowed to mess up the consistency between the the merge
-  state, the merge steps performed variable, and the spent credits variable.
-  There is an important invariant that we maintain, even in the presence of
-  async exceptions: @merge steps actually performed >= recorded merge steps
-  performed >= recorded spent credits@. TODO: and this makes it correct (?).
-
-  Plausibly we could rationalise down to just two counters. The idea would be
-  to track spent and unspent credits as before. When more merging work is done
-  than requested, the surplus can be subtracted from the unspent credits. This
-  may result in the unspent credits being negative for a while, which is ok.
-
+The credits spent and the steps performed (or in the process of being
+performed) will typically be equal. They are not guaranteed to be equal
+presence of exceptions (synchronous or asynchronous). In this case we offer a
+weaker guarantee: : a merge /may/ progress more steps than the number of
+credits that were spent. If an exception happens at some point during merging
+work, we will \"unspend\" all the credits we intended to spend, but we will not
+revert all merging steps that we already successfully performed before the
+exception. Thus we may do more merging steps than the credits we accounted as
+spent. This makes the implementation simple, and merges will still finish in
+time. It would be bad if we did not put back credits, because then a merge
+might not finish in time, which will mess up the shape of the levels tree.
 -}
 
 newtype Credits = Credits Int
+  deriving stock (Eq, Ord)
+  deriving newtype (Num, Real, Enum, Integral)
 
--- | Credits are accumulated until they go over the 'CreditThreshold', after
--- which a batch of merge work will be performed. Configuring this threshold
--- should allow to achieve a nice balance between spreading out I/O and
--- achieving good (concurrent) performance.
-newtype CreditThreshold = CreditThreshold { getCreditThreshold :: Int }
-
-newtype UnspentCreditsVar s = UnspentCreditsVar (PrimVar s Int)
-newtype SpentCreditsVar   s = SpentCreditsVar   (PrimVar s Int)
-newtype StepsPerformedVar s = StepsPerformedVar (PrimVar s Int)
-
-{-# INLINE readUnspentCredits #-}
-{-# INLINE readSpentCredits #-}
-{-# INLINE readStepsPerformed #-}
-readUnspentCredits :: PrimMonad m => UnspentCreditsVar (PrimState m) -> m Int
-readSpentCredits   :: PrimMonad m => SpentCreditsVar   (PrimState m) -> m Int
-readStepsPerformed :: PrimMonad m => StepsPerformedVar (PrimState m) -> m Int
-readUnspentCredits (UnspentCreditsVar v) = readPrimVar v
-readSpentCredits   (SpentCreditsVar   v) = readPrimVar v
-readStepsPerformed (StepsPerformedVar v) = atomicReadInt v
-
-{-# INLINE writeSpentCredits #-}
-{-# INLINE writeStepsPerformed #-}
-writeSpentCredits   :: PrimMonad m => SpentCreditsVar   (PrimState m) -> Int -> m ()
-writeStepsPerformed :: PrimMonad m => StepsPerformedVar (PrimState m) -> Int -> m ()
-writeSpentCredits   (SpentCreditsVar   v) x = writePrimVar v x
-writeStepsPerformed (StepsPerformedVar v) x = atomicWriteInt v x
-
-{-# SPECIALISE addUnspentCredits ::
-     UnspentCreditsVar RealWorld
-  -> Credits
-  -> IO Credits #-}
--- | Add credits to unspent credits. Returns the /estimate/ of what the new
--- total of unspent credits is. The /actual/ total might have been changed again
--- by a different thread.
-addUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> Credits
-  -> m Credits
-addUnspentCredits (UnspentCreditsVar !var) (Credits c) =
-    Credits . (c+) <$> fetchAddInt var c
-
-{-# SPECIALISE tryTakeUnspentCredits ::
-     UnspentCreditsVar RealWorld
-  -> CreditThreshold
-  -> Credits
-  -> IO (Maybe Credits) #-}
--- | In a CAS-loop, subtract credits from the unspent credits to get it below
--- the threshold again. If succesful, return Just that many credits, or Nothing
--- otherwise.
+{-# INLINE numEntriesToTotalDebt #-}
+-- | The total debt of the merging run is exactly the sum total number of
+-- entries across all the input runs to be merged.
 --
--- The number of taken credits is a multiple of creditsThresh, so that the
--- amount of merging work that we do each time is relatively uniform.
+numEntriesToTotalDebt :: NumEntries -> Credits
+numEntriesToTotalDebt (NumEntries n) = Credits n
+
+-- | Unspent credits are accumulated until they go over the 'CreditThreshold',
+-- after which a batch of merge work will be performed. Configuring this
+-- threshold should allow to achieve a nice balance between spreading out
+-- I\/O and achieving good (concurrent) performance.
 --
--- Nothing can be returned if the variable has already gone below the threshold,
--- which may happen if another thread is concurrently doing the same loop on
--- 'mergeUnspentCreditsVar'.
-tryTakeUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> CreditThreshold
-  -> Credits
-  -> m (Maybe Credits)
-tryTakeUnspentCredits
-    unspentCreditsVar@(UnspentCreditsVar !var)
-    thresh@(CreditThreshold !creditsThresh)
-    (Credits !before)
-  | before < creditsThresh = pure Nothing
-  | otherwise = do
-      -- numThresholds is guaranteed to be >= 1
-      let !numThresholds = before `div` creditsThresh
-          !creditsToTake = numThresholds * creditsThresh
-          !after = before - creditsToTake
-      assert (after < creditsThresh) $ pure ()
-      before' <- casInt var before after
-      if before' == before then
-        pure (Just (Credits creditsToTake))
-      else
-        tryTakeUnspentCredits unspentCreditsVar thresh (Credits before')
+-- Note that ideally the batch size for different LSM levels should be
+-- co-prime so that merge work at different levels is not synchronised.
+--
+newtype CreditThreshold = CreditThreshold Credits
 
-{-# SPECIALISE putBackUnspentCredits ::
-     UnspentCreditsVar RealWorld
-  -> Credits
-  -> IO () #-}
-putBackUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> Credits
-  -> m ()
-putBackUnspentCredits (UnspentCreditsVar !var) (Credits !x) =
-    void $ fetchAddInt var x
+-- | The supplied credits is simply the sum of all the credits that have been
+-- (successfully) supplied to a merging run via 'supplyCredits'.
+--
+-- The supplied credits is also the sum of the 'SpentCredits' and
+-- 'UnspentCredits'.
+--
+-- Note that due to asynchronous exceptions this counter can decrease as well
+-- as increase. This can happen if a thread calling 'supplyCredits' is
+-- interrupted after the credits have been added to the supplied credits but
+-- before the corresponding merging work has been completed, in which case the
+-- supplied credits will be removed again.
+--
+newtype SuppliedCredits = SuppliedCredits Credits
 
-{-# SPECIALISE takeAllUnspentCredits ::
-     UnspentCreditsVar RealWorld
-  -> IO Credits #-}
--- | In a CAS-loop, subtract all unspent credits and return them.
-takeAllUnspentCredits ::
-     PrimMonad m
-  => UnspentCreditsVar (PrimState m)
-  -> m Credits
-takeAllUnspentCredits (UnspentCreditsVar !var) = do
-    prev <- readPrimVar var
-    casLoop prev
+-- | The spent credits are supplied credits that have been spent on performing
+-- merging steps plus the supplied credits that are in the process of being
+-- spent (by some thread calling 'supplyCredits').
+--
+newtype SpentCredits = SpentCredits Credits
+
+-- | 40 bit unsigned number
+instance Bounded SpentCredits where
+    minBound = SpentCredits 0
+    maxBound = SpentCredits (Credits (1 `unsafeShiftL` 40 - 1))
+
+-- | The unspent credits are supplied credits that have not yet been spent on
+-- performing merging steps and are available to spend.
+--
+-- Note: unspent credits may be negative! This can occur when more merge
+-- steps were performed than there were credits to cover. In this case the
+-- credits are borrowed from the unspent credits, which may result in the
+-- current unspent credits being negative for a time.
+--
+newtype UnspentCredits = UnspentCredits Credits
+
+-- | 24 bit signed number
+instance Bounded UnspentCredits where
+    minBound = UnspentCredits (Credits ((-1) `unsafeShiftL` 23))
+    maxBound = UnspentCredits (Credits (  1  `unsafeShiftL` 23 - 1))
+
+-- | This holds the pair of the 'SpentCredits' and the 'UnspentCredits'. All
+-- operations on this pair are atomic.
+--
+-- The model to think about is a @TVar (SpentCredits, UnspentCredits)@ but the
+-- physical representation is a single mutable unboxed 64bit signed @Int@,
+-- using 40 bits for the spent credits and 24 for the unspent credits. The
+-- spent credits are unsigned, while the unspent credits are signed, so 40 bits
+-- and 23+1 bits respectively. This imposes a limit of just over 1 trillion for
+-- the spent credits and thus run size, and 8.3 million for the unspent credits
+-- (23 + sign bit).
+--
+-- If these limits ever become restrictive, then the implementation could be
+-- changed to use a TVar or a double-word CAS (DWCAS, i.e. 128bit).
+--
+newtype CreditsVar s = CreditsVar (PrimVar s Int)
+
+pattern CreditsPair :: SpentCredits -> UnspentCredits -> Int
+pattern CreditsPair sc uc <- (unpackCreditsPair -> (sc, uc))
   where
-    casLoop !prev = do
-      prev' <- casInt var prev 0
-      if prev' == prev then
-        pure (Credits prev)
-      else
-        casLoop prev'
+    CreditsPair sc uc = packCreditsPair sc uc
+{-# INLINE CreditsPair #-}
+{-# COMPLETE CreditsPair #-}
+
+-- TODO: test pack/unpack round trip with the minBound & maxBounds
+
+{-# INLINE packCreditsPair #-}
+packCreditsPair :: SpentCredits -> UnspentCredits -> Int
+packCreditsPair (SpentCredits (Credits sc)) (UnspentCredits (Credits uc)) =
+      sc `unsafeShiftL` 24
+  .|. (uc .&. 0xffffff)
+
+{-# INLINE unpackCreditsPair #-}
+unpackCreditsPair :: Int -> (SpentCredits, UnspentCredits)
+unpackCreditsPair cp =
+    -- we use unsigned shift for spent, and sign extending shift for unspent
+    ( SpentCredits   (Credits (w2i (i2w cp `unsafeShiftR` 24)))
+    , UnspentCredits (Credits ((cp `unsafeShiftL` 40) `unsafeShiftR` 40))
+    )
+  where
+    i2w :: Int -> Word
+    w2i :: Word -> Int
+    i2w = fromIntegral
+    w2i = fromIntegral
+
+{-------------------------------------------------------------------------------
+  Credit transactions
+-------------------------------------------------------------------------------}
 
 {- $concurrency
 
-Merging runs can be shared across tables, which means that multiple threads
-can contribute to the same merge concurrently. The design to contribute
-credits to the same merging run is largely lock-free. It ensures consistency
-of the unspent credits and the merge state, while allowing threads to
-progress without waiting on other threads.
+Merging runs can be shared across tables, which means that multiple threads can
+contribute to the same merge concurrently. The design to contribute credits to
+the same merging run is largely lock-free. It ensures consistency of the
+unspent credits and the merge state, while allowing threads to progress without
+waiting on other threads.
 
 The entry point for merging is 'supplyCredits'. This may be called by
 concurrent threads that share the same merging run. No locks are held
@@ -429,140 +410,412 @@ We get the easy things out of the way first: the 'mergeKnownCompleted'
 variable is purely an optimisation. It starts out as 'MergeMaybeCompleted'
 and is only ever modified once to 'MergeKnownCompleted'. It is modified with
 the merge lock held, but read without the lock. It does not matter if a thread
-sees a stale value of 'MergeMaybeCompleted'. We can analyse the remainder of
+reads a stale value of 'MergeMaybeCompleted'. We can analyse the remainder of
 the algorithm as if we were always in the 'MergeMaybeCompleted' state.
 
 Variable access and locks:
 
-* 'UnspentCreditsVar' is only operated upon using atomic read & modify (CAS or
-  atomic add\/sub), and without the merge lock held. It's value can increase
-  or decrease.
-* 'SpentCreditsVar' is only read and written with the merge lock held. It's
-  value increases monotonically. We can use ordinary non-atomic access because
-  this variable is only read or written with the merge lock held.
-* 'StepsPerformedVar' is only modified with the merge lock held, but is read
-  without the lock. It's value increases monotonically. We must use atomic
-  read and write because this variable is read outside of the merge lock.
-  Thus atomic reads of this variable will see a valid but possibly old value
-  of the variable. The use of the value read must accommodate this.
+* 'CreditsVar' contains the pair of the current 'SpentCredits' and
+  'UnspentCredits'. Is only operated upon using transactions (atomic CAS),
+  and most of these transactions are done without the merge lock held.
+  The two constituent components can increase and decrease, but the total
+  supplied credits (sum of spent and unspent) can only increase.
 
-First, credits are added atomically to 'UnspentCreditsVar' that holds the
-current total of unspent credits. If this addition exceeded the threshold, then
-credits are atomically subtracted from the 'UnspentCreditsVar' to get it below
-the threshold. The number of subtracted credits is then the number of merge
-steps that will be performed. While doing the merging work, a (more expensive)
-MVar lock is taken to ensure that the merging work itself is performed only
-sequentially. If at some point, doing the merge work resulted in the merge
-being done, then the merge is converted into a new run.
+* 'MergeState' contains the state of the merge itself. It is protected by the
+  merge lock.
+
+First, we use 'atomicDepositCredits' to deposit credits (atomically) to the
+unspent pot in the 'CreditsVar'. This is guaranteed to never cause the supplied
+credits to exceed the total debt for the merging run, and so there may be some
+leftover credits. This returns the snapshot of the new spent, unspent (and thus
+supplied) credits as a result of the deposit.
+
+We now test to see if we are in one of three cases:
+
+1. definitely close enough to the end of the merge to complete it;
+
+2. not case 1, but enough unspent credits have accumulated to do a batch of
+   merge work;
+
+3. not case 1 or 2, not enough credits to do any merge work.
+
+To test if we are in case 1, we check if the supplied credits has reached the
+total merge debt (the number of input merge entries). This test of \"have we
+supplied enough credits to pay off the debt" is monotonic: the debt is fixed
+and the credits supplied increases monotonically. We then do another credit
+accounting transaction: `atomicSpendAllCredits` that transfers all credits in
+the unspent pot to the spent pot. This may transfer zero credits if another
+thread got there first. The amount transferred is returned and we then attempt
+to perform that number of merging steps. While doing the merging work, the
+(more expensive) merge lock is taken to ensure that the merging work itself is
+performed only sequentially. Note that it is not guaranteed that the merge gets
+completed, neither by this thread nor another. While one thread will succeed in
+transferring the credits, it may be interrupted during the merge (by an async
+exception) and have to \"unspend\" the credits again (i.e. transfer them back).
+This does not matter because the merge will be completed in 'expectCompleted'.
+Completing early is an optimisation.
+
+For case 2, we test if the (snapshot of the) unspent credits are over the batch
+threshold. If so we do another accounting transaction: 'atomicSpendBatchCredits'
+that attempts to transfer one or more batches of unspent credits (a multiple of
+the batch size) to the spent pot, and returning the credits transferred. If
+multiple concurrent threads are doing the same then only one will succeed in
+transferring credits, while the others will find they transferred zero. The
+unsuccessful threads will do no work, while the successful one will take the
+merge lock and try to perform the number of merge steps corresponding to the
+credits transferred.
+
+For case 3 there is nothing further to do.
+
+In case 1 and 2, if an exception occurs then the credits that were in the
+process of being spent are transferred back from the spent to the unspent pot
+using 'atomicUnspendCredits'. This is what means the spent credits does not
+increase monotonically, even though the supplied credits do increase
+monotonically.
+
+In case 1 and 2, once performing merge steps is done, if it turns out that
+excess merge steps were performed then we must do a further accounting
+transaction: 'atomicSpendGivenCredits' to spend the excess credits. This is
+done without respect to the balance of the unspent credits, which may result in
+the unspent credit balance becoming negative. This is ok, and will result in
+more credits having to be supplied next time before reaching the credit batch
+threshold. The unspent credits can not be negative by the time the merge is
+complete because the performing of merge steps cannot do excess steps when it
+reaches the end of the merge.
 
 -}
 
-{-# SPECIALISE supplyCredits ::
-     Credits
+{-# INLINE atomicReadCredits #-}
+atomicReadCredits ::
+     PrimMonad m
+  => CreditsVar (PrimState m)
+  -> m (SpentCredits, UnspentCredits)
+atomicReadCredits (CreditsVar v) =
+    unpackCreditsPair <$> atomicReadInt v
+
+{-# INLINE atomicReadSuppliedCredits #-}
+atomicReadSuppliedCredits ::
+     PrimMonad m
+  => CreditsVar (PrimState m)
+  -> m SuppliedCredits
+atomicReadSuppliedCredits (CreditsVar v) = do
+    cp <- atomicReadInt v
+    let !supplied =
+           case cp of
+             CreditsPair (SpentCredits   spent)
+                         (UnspentCredits unspent) -> spent + unspent
+    return (SuppliedCredits supplied)
+
+{-# INLINE atomicModifyInt #-}
+-- | Atomically modify a single mutable integer variable, using a CAS loop.
+atomicModifyInt ::
+     PrimMonad m
+  => PrimVar (PrimState m) Int
+  -> (Int -> (Int, a))
+  -> m a
+atomicModifyInt var f =
+    readPrimVar var >>= casLoop
+  where
+    casLoop !before = do
+      let (!after, !result) = f before
+      before' <- casInt var before after
+      if before' == before
+        then return result
+        else casLoop before'
+
+{-# SPECIALISE atomicDepositCredits ::
+     CreditsVar RealWorld
+  -> Credits
+  -> Credits
+  -> IO (SuppliedCredits, SpentCredits, UnspentCredits, Credits) #-}
+-- | Atomically: add to the unspent credits pot, subject to the supplied
+-- credits not exceeding the total debt. Return the new spent and unspent
+-- credits, plus any leftover credits in excess of the total debt.
+--
+-- This is the only operation that changes the total supplied credits, and in
+-- a non-decreasing way. Hence overall the supplied credits is monotonically
+-- non-decreasing.
+--
+atomicDepositCredits ::
+     PrimMonad m
+  => CreditsVar (PrimState m)
+  -> Credits -- ^ total debt
+  -> Credits -- ^ to deposit
+  -> m (SuppliedCredits, SpentCredits, UnspentCredits, Credits)
+atomicDepositCredits (CreditsVar var) totalDebt credits =
+    assert (credits >= 0) $
+    atomicModifyInt var $ \(CreditsPair (SpentCredits   !spent)
+                                        (UnspentCredits !unspent)) ->
+      let !supplied  = spent + unspent
+          !leftover  = max 0 (supplied + credits - totalDebt)
+          !deposit   = credits - leftover
+          !unspent'  = unspent + deposit
+          !after     = CreditsPair (SpentCredits   spent)
+                                   (UnspentCredits unspent')
+          !supplied' = spent + unspent'
+          result     = (SuppliedCredits supplied',
+                        SpentCredits    spent,
+                        UnspentCredits  unspent',
+                                        leftover)
+       in assert (supplied' >= supplied) $
+          assert (unspent'  >= unspent) $
+          assert (deposit   >= 0) $
+          assert (leftover  >= 0) $
+          (after, result)
+
+{-# SPECIALISE atomicSpendBatchCredits ::
+     CreditsVar RealWorld
   -> CreditThreshold
-  -> Ref (MergingRun IO h)
+  -> IO Credits #-}
+-- | Atomically: transfer credits from the unspent pot into the spent pot, and
+-- return the number transferred.
+--
+-- The number transferred will be a non-negative multiple of the credit
+-- threshold. This can be zero if the current number of unspent credits is less
+-- than the threshold. The unspent credits afterwards will be less than the
+-- threshold.
+--
+-- The total supplied credits is unchanged.
+--
+atomicSpendBatchCredits ::
+     PrimMonad m
+  => CreditsVar (PrimState m)
+  -> CreditThreshold
+  -> m Credits
+atomicSpendBatchCredits (CreditsVar var) (CreditThreshold batchThreshold) =
+    atomicModifyInt var $ \(CreditsPair (SpentCredits   !spent)
+                                        (UnspentCredits !unspent)) ->
+      -- numBatches may be zero, in which case the result will be zero
+      let !nBatches = unspent `div` batchThreshold
+          !spend    = nBatches * batchThreshold
+          !spent'   = spent   + spend
+          !unspent' = unspent - spend
+          !after    = CreditsPair (SpentCredits   spent')
+                                  (UnspentCredits unspent')
+       in assert (spend >= 0) $
+          assert (unspent' < batchThreshold) $
+          assert (spent' + unspent' == spent + unspent) $
+          (after, spend)
+
+{-# SPECIALISE atomicSpendAllCredits ::
+     CreditsVar RealWorld
+  -> IO Credits #-}
+-- | Atomically: transfer all unspent credits into the spent pot, and return
+-- the number transferred (which may be zero, or negative).
+--
+-- The total supplied credits is unchanged.
+--
+atomicSpendAllCredits ::
+     PrimMonad m
+  => CreditsVar (PrimState m)
+  -> m Credits
+atomicSpendAllCredits (CreditsVar var) =
+    atomicModifyInt var $ \(CreditsPair (SpentCredits   !spent)
+                                        (UnspentCredits !unspent)) ->
+      let spent'   = spent + unspent
+          unspent' = 0
+          after    = CreditsPair (SpentCredits   spent')
+                                 (UnspentCredits unspent')
+       in assert (spent' + unspent' == spent + unspent) $
+          (after, unspent)
+
+{-# SPECIALISE atomicSpendGivenCredits ::
+     CreditsVar RealWorld
+  -> Credits
+  -> IO () #-}
+-- | Atomically: transfer the given number of credits from the unspent pot to
+-- the spent pot. The new unspent credits balance may be negative.
+--
+-- The total supplied credits is unchanged.
+--
+atomicSpendGivenCredits ::
+     PrimMonad m
+  => CreditsVar (PrimState m)
+  -> Credits
+  -> m ()
+atomicSpendGivenCredits (CreditsVar var) spend =
+    assert (spend >= 0) $
+    atomicModifyInt var $ \(CreditsPair (SpentCredits   !spent)
+                                        (UnspentCredits !unspent)) ->
+      let spent'   = spent   + spend
+          unspent' = unspent - spend
+          after    = CreditsPair (SpentCredits   spent')
+                                 (UnspentCredits unspent')
+       in assert (spent' + unspent' == spent + unspent) $
+          (after, ())
+
+{-# SPECIALISE atomicUnspendCredits ::
+     CreditsVar RealWorld
+  -> Credits
+  -> IO () #-}
+-- | Atomically: transfer the given number of credits from the spent pot to
+-- the unspent pot.
+--
+-- The total supplied credits is unchanged.
+--
+atomicUnspendCredits ::
+     PrimMonad m
+  => CreditsVar (PrimState m)
+  -> Credits
+  -> m ()
+atomicUnspendCredits (CreditsVar var) unspend =
+    assert (unspend >= 0) $
+    atomicModifyInt var $ \(CreditsPair (SpentCredits   !spent)
+                                        (UnspentCredits !unspent)) ->
+      let spent'   = spent   - unspend
+          unspent' = unspent + unspend
+          after    = CreditsPair (SpentCredits   spent')
+                                 (UnspentCredits unspent')
+       in assert (spent' + unspent' == spent + unspent) $
+          (after, ())
+
+{-------------------------------------------------------------------------------
+  The main algorithms
+-------------------------------------------------------------------------------}
+
+{-# SPECIALISE supplyCredits ::
+     Ref (MergingRun IO h)
+  -> CreditThreshold
+  -> Credits
   -> IO () #-}
 -- | Supply the given amount of credits to a merging run. This /may/ cause an
 -- ongoing merge to progress.
 supplyCredits ::
      forall m h. (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
-  => Credits
+  => Ref (MergingRun m h)
   -> CreditThreshold
-  -> Ref (MergingRun m h)
+  -> Credits
   -> m ()
-supplyCredits (Credits c) creditsThresh (DeRef MergingRun {..}) = do
+supplyCredits (DeRef mrun@MergingRun {mergeKnownCompleted})
+              !creditBatchThreshold !credits = do
     mergeCompleted <- readMutVar mergeKnownCompleted
+    case mergeCompleted of
+      MergeKnownCompleted -> pure ()
+      MergeMaybeCompleted -> supplyCredits' mrun creditBatchThreshold credits
 
-    -- The merge is already finished
-    if mergeCompleted == MergeKnownCompleted then
-      pure ()
-    else do
-      -- unspentCredits' is our /estimate/ of what the new total of unspent
-      -- credits is.
-      Credits unspentCredits' <- addUnspentCredits mergeUnspentCreditsVar (Credits c)
-      stepsPerformed <- readStepsPerformed mergeStepsPerformedVar
+{-# SPECIALISE supplyCredits' ::
+     MergingRun IO h
+  -> CreditThreshold
+  -> Credits
+  -> IO () #-}
+supplyCredits' ::
+     forall m h. (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
+  => MergingRun m h
+  -> CreditThreshold
+  -> Credits
+  -> m ()
+supplyCredits' MergingRun {
+                 mergeNumEntries,
+                 mergeCreditsVar,
+                 mergeState,
+                 mergeKnownCompleted
+               }
+               creditBatchThreshold@(CreditThreshold !batchThreshold)
+               !credits =
+    assert (credits >= 0) $ do
+    -- Atomically add credits to the unspent credits (but not allowing
+    -- 'suppliedCredits' to exceed the total debt), and return a consistent
+    -- snapshot of the new supplied, spent and unspent credits, and any
+    -- leftover credits that would exceed the debt limit.
+    let totalDebt = numEntriesToTotalDebt mergeNumEntries
+    (SuppliedCredits suppliedCredits, -- sum of spent and unspent
+     SpentCredits    spentCredits,
+     UnspentCredits  unspentCredits,
+                     leftoverCredits)
+      <- atomicDepositCredits mergeCreditsVar totalDebt credits
 
-      if stepsPerformed + unspentCredits' >= unNumEntries mergeNumEntries then do
-        -- We can finish the merge immediately
-        isMergeDone <-
-          bracketOnError (takeAllUnspentCredits mergeUnspentCreditsVar)
-                         (putBackUnspentCredits mergeUnspentCreditsVar)
-                         (stepMerge mergeSpentCreditsVar mergeStepsPerformedVar
-                                    mergeState)
-        when isMergeDone $ completeMerge mergeState mergeKnownCompleted
-      else if unspentCredits' >= getCreditThreshold creditsThresh then do
-        -- We can do some merging work without finishing the merge immediately
-        isMergeDone <-
-          -- Try to take some unspent credits. The number of taken credits is
-          -- the number of merging steps we will try to do.
-          --
-          -- If an error happens during the body, then we put back as many
-          -- credits as we took, even if the merge has progressed. See Note
-          -- [Merge Batching] to see why this is okay.
-          bracketOnError
-            (tryTakeUnspentCredits mergeUnspentCreditsVar creditsThresh (Credits unspentCredits'))
-            (mapM_ (putBackUnspentCredits mergeUnspentCreditsVar)) $ \case
-              Nothing -> pure False
-              Just c' -> stepMerge mergeSpentCreditsVar mergeStepsPerformedVar
-                                   mergeState c'
+    assert (suppliedCredits <= totalDebt &&
+            suppliedCredits == spentCredits + unspentCredits &&
+            leftoverCredits >= 0 && leftoverCredits <= credits)
+           (return ())
 
-        -- If we just finished the merge, then we convert the output of the
-        -- merge into a new run. i.e., we complete the merge.
+    if
+      | suppliedCredits == totalDebt -> do
+        -- If the credit tracking says we've supplied enough credits (to meet
+        -- the total merge debt) then we can (try to) do the work to finish
+        -- the merge immediately.
         --
+        -- We try to transfer all the remaining unspent credits into the spent
+        -- pot and then perform the remaining merge steps. We may race with
+        -- another thread trying to do the same, so we may end up transferring
+        -- zero credits and thus not be the thread to do the final merge
+        -- steps. But if it is us that finishes the merge steps then we also
+        -- complete the merge (to release resources).
+        --
+        -- If an exception occurs (sync or async) then we reverse the transfer
+        -- of the unspent credits.
+        weFinishedMerge <-
+          bracketOnError
+            (atomicSpendAllCredits mergeCreditsVar)
+            (atomicUnspendCredits mergeCreditsVar)
+            (performMergeSteps mergeState mergeCreditsVar)
         -- If an async exception happens before we get to perform the
         -- completion, then that is fine. The next supplyCredits will
         -- complete the merge.
-        when isMergeDone $ completeMerge mergeState mergeKnownCompleted
-      else
-        -- Just accumulate credits, because we are not over the threshold yet
-        pure ()
+        when weFinishedMerge $ completeMerge mergeState mergeKnownCompleted
 
-{-# SPECIALISE stepMerge ::
-     SpentCreditsVar RealWorld
-  -> StepsPerformedVar RealWorld
-  -> StrictMVar IO (MergingRunState IO h)
+      | unspentCredits >= batchThreshold -> do
+        -- If the unspent credits have reached the threshold then we will try
+        -- to perform a batch of merging work.
+        --
+        -- We try to transfer a batch of credits from the unspent to spent pot
+        -- and then spend the transferred amount on merging work. If we race
+        -- with another thread trying to do the same then we may end up
+        -- transferring zero credits, in which case we do no merging work.
+        --
+        -- If an exception occurs while merging (sync or async) then we
+        -- reverse the transfer of the unspent credits.
+        weFinishedMerge <-
+          bracketOnError
+            (atomicSpendBatchCredits mergeCreditsVar creditBatchThreshold)
+            (atomicUnspendCredits mergeCreditsVar)
+            (performMergeSteps mergeState mergeCreditsVar)
+        -- If an async exception happens before we get to perform the
+        -- completion, then that is fine. The next supplyCredits will
+        -- complete the merge.
+        when weFinishedMerge $ completeMerge mergeState mergeKnownCompleted
+
+      -- Otherwise just accumulate credits (which we did already above),
+      -- because we are not over the threshold yet.
+      | otherwise -> pure ()
+
+{-# SPECIALISE performMergeSteps ::
+     StrictMVar IO (MergingRunState IO h)
+  -> CreditsVar RealWorld
   -> Credits
   -> IO Bool #-}
-stepMerge ::
+performMergeSteps ::
      (MonadMVar m, MonadMask m, MonadSTM m, MonadST m)
-  => SpentCreditsVar (PrimState m)
-  -> StepsPerformedVar (PrimState m)
-  -> StrictMVar m (MergingRunState m h)
+  => StrictMVar m (MergingRunState m h)
+  -> CreditsVar (PrimState m)
   -> Credits
   -> m Bool
-stepMerge spentCreditsVar stepsPerformedVar mergeVar (Credits c) =
+performMergeSteps _ _ (Credits credits) | credits <= 0 =
+    -- If we raced with another thread then we may find we have no work to do,
+    -- in which case we do not need to wait on the MVar, but can just carry on.
+    pure False
+
+performMergeSteps mergeVar creditsVar (Credits credits) =
     withMVar mergeVar $ \case
-      CompletedMerge{} -> pure False
-      (OngoingMerge _rs m) -> do
-        stepsPerformed <- readStepsPerformed stepsPerformedVar
-        spentCredits <- readSpentCredits spentCreditsVar
-
-        -- If we previously performed too many merge steps, then we perform
-        -- fewer now.
-        let stepsToDo = max 0 (spentCredits + c - stepsPerformed)
-        -- Merge.steps guarantees that @stepsDone >= stepsToDo@ /unless/ the
-        -- merge was just now finished.
+      CompletedMerge{}   -> pure False
+      OngoingMerge _rs m -> do
+        -- We have dealt with the case of credits <= 0 above,
+        -- so here we know credits is positive
+        let stepsToDo = credits
         (stepsDone, stepResult) <- Merge.steps m stepsToDo
-        assert (case stepResult of
-                  MergeInProgress -> stepsDone >= stepsToDo
-                  MergeDone       -> True
-                ) $ pure ()
+        assert (stepsDone >= stepsToDo) (pure ())
+        -- Merge.steps guarantees that @stepsDone >= stepsToDo@ /unless/ the
+        -- merge was just now finished and excess credit was supplied. But
+        -- elsewhere we guarantee that we do not supply credit in excess of
+        -- the total debt, so the inequality should hold here always.
 
-        -- This should be the only point at which we write to these variables.
-        --
-        -- It is guaranteed that @stepsPerformed' >= spentCredits'@ /unless/ the
-        -- merge was just now finished.
-        let !stepsPerformed' = stepsPerformed + stepsDone
-        let !spentCredits'   = spentCredits + c
-        -- It is guaranteed that
-        -- @readStepsPerformed stepsPerformedVar >= readSpentCredits spentCreditsVar@,
-        -- /unless/ the merge was just now finished.
-        writeStepsPerformed stepsPerformedVar stepsPerformed'
-        writeSpentCredits spentCreditsVar spentCredits'
-        assert (case stepResult of
-                  MergeInProgress -> stepsPerformed' >= spentCredits'
-                  MergeDone       -> True
-              ) $ pure ()
+        -- If excess merging steps were done then we must account for that.
+        -- We do so by borrowing the excess from the unspent credits pot and
+        -- spending them, i.e. doing a transfer from unspent to spent. This
+        -- may result in the unspent credits pot becoming negative.
+        let stepsExcess = Credits (stepsDone - stepsToDo)
+        when (stepsExcess > 0) $
+          atomicSpendGivenCredits creditsVar stepsExcess
 
         pure $ stepResult == MergeDone
 
@@ -582,6 +835,8 @@ completeMerge mergeVar mergeKnownCompletedVar = do
       (OngoingMerge rs m) -> do
         -- first try to complete the merge before performing other side effects,
         -- in case the completion fails
+        --TODO: Run.fromMutable claims not to be exception safe
+        -- may need to use uninteruptible mask
         r <- Merge.complete m
         V.forM_ rs releaseRef
         -- Cache the knowledge that we completed the merge
@@ -600,11 +855,18 @@ expectCompleted (DeRef MergingRun {..}) = do
     knownCompleted <- readMutVar mergeKnownCompleted
     -- The merge is not guaranteed to be complete, so we do the remaining steps
     when (knownCompleted == MergeMaybeCompleted) $ do
-      stepsPerformed <- readStepsPerformed mergeStepsPerformedVar
-      let !credits = Credits (unNumEntries mergeNumEntries - stepsPerformed)
-      isMergeDone <- stepMerge mergeSpentCreditsVar mergeStepsPerformedVar
-                               mergeState credits
-      when isMergeDone $ completeMerge mergeState mergeKnownCompleted
+      (SpentCredits   spentCredits,
+       UnspentCredits unspentCredits) <- atomicReadCredits mergeCreditsVar
+      let !totalDebt       = numEntriesToTotalDebt mergeNumEntries
+          !suppliedCredits = spentCredits + unspentCredits
+          !credits         = assert (suppliedCredits <= totalDebt) $
+                             totalDebt - spentCredits
+--TODO: the following ought to be true and the right answer:
+--        !credits         = assert (suppliedCredits == totalDebt) $
+--                           unspentCredits
+      -- what about exception safety
+      weFinishedMerge <- performMergeSteps mergeState mergeCreditsVar credits
+      when weFinishedMerge $ completeMerge mergeState mergeKnownCompleted
       -- TODO: can we think of a check to see if we did not do too much work
       -- here?
     withMVar mergeState $ \case

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -474,13 +474,12 @@ instance DecodeVersioned RunNumber where
 -- SnapIncomingRun
 
 instance Encode (SnapIncomingRun RunNumber) where
-  encode (SnapMergingRun mpfl nr ne uc sc smrs) =
-       encodeListLen 7
+  encode (SnapMergingRun mpfl nr ne sc smrs) =
+       encodeListLen 6
     <> encodeWord 0
     <> encode mpfl
     <> encode nr
     <> encode ne
-    <> encode uc
     <> encode sc
     <> encode smrs
   encode (SnapSingleRun x) =
@@ -493,9 +492,9 @@ instance DecodeVersioned (SnapIncomingRun RunNumber) where
       n <- decodeListLen
       tag <- decodeWord
       case (n, tag) of
-        (7, 0) -> SnapMergingRun <$>
+        (6, 0) -> SnapMergingRun <$>
           decodeVersioned v <*> decodeVersioned v <*> decodeVersioned v <*>
-          decodeVersioned v <*> decodeVersioned v <*> decodeVersioned v
+          decodeVersioned v <*> decodeVersioned v
         (2, 1) -> SnapSingleRun <$> decodeVersioned v
         _ -> fail ("[SnapMergingRun] Unexpected combination of list length and tag: " <> show (n, tag))
 
@@ -521,14 +520,6 @@ instance DecodeVersioned MergePolicyForLevel where
         1 -> pure LevelLevelling
         _ -> fail ("[MergePolicyForLevel] Unexpected tag: " <> show tag)
 
--- UnspentCredits
-
-instance Encode UnspentCredits where
-  encode (UnspentCredits x) = encodeInt x
-
-instance DecodeVersioned UnspentCredits where
-  decodeVersioned V0 = UnspentCredits <$> decodeInt
-
 -- SnapMergingRunState
 
 instance Encode (SnapMergingRunState RunNumber) where
@@ -552,13 +543,13 @@ instance DecodeVersioned (SnapMergingRunState RunNumber) where
                                    <*> decodeVersioned v
         _ -> fail ("[SnapMergingRunState] Unexpected combination of list length and tag: " <> show (n, tag))
 
--- SpentCredits
+-- SuppliedCredits
 
-instance Encode SpentCredits where
-  encode (SpentCredits x) = encodeInt x
+instance Encode SuppliedCredits where
+  encode (SuppliedCredits x) = encodeInt x
 
-instance DecodeVersioned SpentCredits where
-  decodeVersioned V0 = SpentCredits <$> decodeInt
+instance DecodeVersioned SuppliedCredits where
+  decodeVersioned V0 = SuppliedCredits <$> decodeInt
 
 -- MergeType
 

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -17,7 +17,7 @@ import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Merge (MergeType (..))
 import           Database.LSMTree.Internal.MergeSchedule
-import           Database.LSMTree.Internal.MergingRun
+import           Database.LSMTree.Internal.MergingRun hiding (SuppliedCredits)
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.Snapshot.Codec
@@ -171,9 +171,8 @@ testAll test = [
     , test (Proxy @(SnapIncomingRun RunNumber))
     , test (Proxy @NumRuns)
     , test (Proxy @MergePolicyForLevel)
-    , test (Proxy @UnspentCredits)
     , test (Proxy @(SnapMergingRunState RunNumber))
-    , test (Proxy @SpentCredits)
+    , test (Proxy @SuppliedCredits)
     , test (Proxy @MergeType)
     ]
 
@@ -278,12 +277,12 @@ deriving newtype instance Arbitrary RunNumber
 instance Arbitrary (SnapIncomingRun RunNumber) where
   arbitrary = oneof [
         SnapMergingRun <$> arbitrary <*> arbitrary <*> arbitrary
-                       <*> arbitrary <*> arbitrary <*> arbitrary
+                       <*> arbitrary <*> arbitrary
       , SnapSingleRun <$> arbitrary
       ]
-  shrink (SnapMergingRun a b c d e f) =
-      [ SnapMergingRun a' b' c' d' e' f'
-      | (a', b', c', d', e', f') <- shrink (a, b, c, d, e, f) ]
+  shrink (SnapMergingRun a b c d e) =
+      [ SnapMergingRun a' b' c' d' e'
+      | (a', b', c', d', e') <- shrink (a, b, c, d, e) ]
   shrink (SnapSingleRun a)  = SnapSingleRun <$> shrink a
 
 deriving newtype instance Arbitrary NumRuns
@@ -291,8 +290,6 @@ deriving newtype instance Arbitrary NumRuns
 instance Arbitrary MergePolicyForLevel where
   arbitrary = elements [LevelTiering, LevelLevelling]
   shrink _ = []
-
-deriving newtype instance Arbitrary UnspentCredits
 
 instance Arbitrary (SnapMergingRunState RunNumber) where
   arbitrary = oneof [
@@ -303,5 +300,5 @@ instance Arbitrary (SnapMergingRunState RunNumber) where
   shrink (SnapOngoingMerge x y) =
       [ SnapOngoingMerge x' y' | (x', y') <- shrink (x, y) ]
 
-deriving newtype instance Arbitrary SpentCredits
+deriving newtype instance Arbitrary SuppliedCredits
 


### PR DESCRIPTION
The intention is to simplify things and make them more obviously correct
in the presence of concurrency. This should have the bonus of making it
easier to reliably determine leftover/excess supplied credits (which is
something we want for supplying credits to trees of merging runs).

The approach is to change the counters from three independent counters,
to just two, which are modified together as a pair atomically.
Previously we tracked the credits spent and unspent, and the steps
performed. We did not explicitly keep track of credits that were in the
process of being spent.

Now we track spent and unspent (and not steps performed), but the spent
credits includes those that are in the process of being spent. We keep
these together in a single atomic variable, and so all operations on the
pair are atomic. This makes the concurrency story much simpler because
all credit tracking changes are atomic. We avoid having to track steps
performed by accounting differently for the difference between credits
used for merging and steps performed: we simply borrow more credits from
the unspent pot, allowing the pot to become negative.