### PR TITLE
Fix prototype issue with non-normalised, but structurally empty merging trees

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -722,6 +722,7 @@ library prototypes
     , tasty
     , tasty-hunit
     , tasty-quickcheck
+    , transformers
 
   ghc-options:
     -Wno-incomplete-uni-patterns -Wno-partial-fields

--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -50,7 +50,24 @@ module ScheduledMerges (
     representationShape,
     Event,
     EventAt(..),
-    EventDetail(..)
+    EventDetail(..),
+    MergingTree(..),
+    MergingTreeState(..),
+    PendingMerge(..),
+    IncomingRun(..),
+    MergingRun(..),
+    MergingRunState(..),
+    MergePolicy(..),
+    IsMergeType(..),
+    TreeMergeType(..),
+    LevelMergeType(..),
+    MergeDebt(..),
+    Run,
+    supplyCreditsMergingTree,
+    remainingDebtMergingTree,
+    treeInvariant,
+    mergek,
+    mergeBatchSize,
   ) where
 
 import           Prelude hiding (lookup)
@@ -1356,3 +1373,9 @@ instance (QC.Arbitrary v, QC.Arbitrary b) => QC.Arbitrary (Update v b) where
       , (1, Mupsert <$> QC.arbitrary)
       , (1, pure Delete)
       ]
+
+instance QC.Arbitrary LevelMergeType where
+  arbitrary = QC.elements [MergeMidLevel, MergeLastLevel]
+
+instance QC.Arbitrary TreeMergeType where
+  arbitrary = QC.elements [MergeLevel, MergeUnion]

--- a/prototypes/ScheduledMergesTest.hs
+++ b/prototypes/ScheduledMergesTest.hs
@@ -6,12 +6,14 @@ import           Control.Monad.ST
 import           Control.Tracer (Tracer (Tracer))
 import qualified Control.Tracer as Tracer
 import           Data.Foldable (traverse_)
+import qualified Data.Map as Map
 import           Data.STRef
 
 import           ScheduledMerges as LSM
 
 import qualified Test.QuickCheck as QC
-import           Test.QuickCheck (Property)
+import           Test.QuickCheck (Arbitrary (arbitrary, shrink), Property)
+import           Test.QuickCheck.Exception (isDiscard)
 import           Test.Tasty
 import           Test.Tasty.HUnit (HasCallStack, testCase)
 import           Test.Tasty.QuickCheck (testProperty, (=/=), (===))
@@ -21,6 +23,7 @@ tests = testGroup "Unit and property tests"
     [ testCase "test_regression_empty_run" test_regression_empty_run
     , testCase "test_merge_again_with_incoming" test_merge_again_with_incoming
     , testProperty "prop_union" prop_union
+    , testProperty "prop_MergingTree" prop_MergingTree
     ]
 
 -- | Results in an empty run on level 2.
@@ -195,6 +198,180 @@ mkTable tr ks = do
     return t
 
 -------------------------------------------------------------------------------
+-- tests for MergingTree
+--
+
+prop_MergingTree :: T -> QC.InfiniteList SmallCredit -> Property
+prop_MergingTree TCompleted{} _ = QC.discard
+prop_MergingTree (TOngoing MCompleted{}) _ = QC.discard
+prop_MergingTree t credits =
+    QC.ioProperty $ runWithTracer $ \_tr ->
+      stToIO $ do
+        tree <- fromT t
+        go tree (QC.getInfiniteList credits)
+        (d', _) <- LSM.remainingDebtMergingTree tree
+        return $
+          QC.classify (d' <= 0) "got completed" $
+            True
+  where
+    go tree (SmallCredit c : cs) = do
+        c' <- LSM.supplyCreditsMergingTree c tree
+        treeInvariant tree
+        if c' > 0 then return ()
+                  else go tree cs
+    go _ _ = error "infinite list is finite"
+
+newtype SmallCredit = SmallCredit Credit
+  deriving stock Show
+
+instance Arbitrary SmallCredit where
+  arbitrary = SmallCredit <$> QC.chooseInt (1, 10)
+  shrink (SmallCredit c) = [SmallCredit c' | c' <- shrink c, c' > 0]
+
+-- simplified non-ST version of MergingTree
+data T = TCompleted Run
+       | TOngoing (M TreeMergeType)
+       | TPendingLevel [I] (Maybe T)  -- not both empty!
+       | TPendingUnion [T]  -- at least 2 children
+  deriving stock Show
+
+-- simplified non-ST version of IncomingRun
+data I = ISingle Run
+       | IMerging (M LevelMergeType)
+  deriving stock Show
+
+-- simplified non-ST version of MergingRun
+data M t = MCompleted t Run
+         | MOngoing
+             t
+             MergeDebt  -- debt bounded by input sizes
+             [NonEmptyRun]  -- at least 2 inputs
+  deriving stock Show
+
+newtype NonEmptyRun = NonEmptyRun { getNonEmptyRun :: Run }
+  deriving stock Show
+
+fromT :: T -> ST s (MergingTree s)
+fromT t = do
+    state <- case t of
+      TCompleted r -> return (CompletedTreeMerge r)
+      TOngoing mr  -> OngoingTreeMerge <$> fromM mr
+      TPendingLevel is mt ->
+        fmap PendingTreeMerge $
+          PendingLevelMerge <$> traverse fromI is <*> traverse fromT mt
+      TPendingUnion ts -> do
+        fmap PendingTreeMerge $ PendingUnionMerge <$> traverse fromT ts
+    MergingTree <$> newSTRef state
+
+fromI :: I -> ST s (IncomingRun s)
+fromI (ISingle r)  = return (Single r)
+fromI (IMerging m) = Merging MergePolicyTiering <$> fromM m
+
+fromM :: IsMergeType t => M t -> ST s (MergingRun t s)
+fromM m = do
+    let (mergeType, state) = case m of
+          MCompleted mt r  -> (mt, CompletedMerge r)
+          MOngoing mt d rs -> (mt, OngoingMerge d rs' (mergek mt rs'))
+            where rs' = map getNonEmptyRun rs
+    MergingRun mergeType <$> newSTRef state
+
+completeT :: T -> Run
+completeT (TCompleted r) = r
+completeT (TOngoing m)   = completeM m
+completeT (TPendingLevel is t) =
+    mergek MergeLevel (map completeI is <> maybe [] (pure . completeT) t)
+completeT (TPendingUnion ts) =
+    mergek MergeUnion (map completeT ts)
+
+completeI :: I -> Run
+completeI (ISingle r)  = r
+completeI (IMerging m) = completeM m
+
+completeM :: IsMergeType t => M t -> Run
+completeM (MCompleted _ r)   = r
+completeM (MOngoing mt _ rs) = mergek mt (map getNonEmptyRun rs)
+
+instance Arbitrary T where
+  arbitrary = QC.frequency
+      [ (1, TCompleted <$> arbitrary)
+      , (1, TOngoing <$> arbitrary)
+      , (1, do
+          (incoming, tree) <- arbitrary
+             `QC.suchThat` (\(i, t) -> length i + length t > 0)
+          return (TPendingLevel incoming tree))
+      , (1, do
+          n <- QC.frequency
+            [ (3, pure 2)
+            , (1, QC.chooseInt (3, 8))
+            ]
+          TPendingUnion <$> QC.vectorOf n (QC.scale (`div` n) arbitrary))
+      ]
+
+  shrink (TCompleted r) =
+      [ TCompleted r'
+      | r' <- shrink r
+      ]
+  shrink tree@(TOngoing m) =
+      [ TCompleted (completeT tree) ]
+   <> [ TOngoing m'
+      | m' <- shrink m
+      ]
+  shrink tree@(TPendingLevel is t) =
+      [ TCompleted (completeT tree) ]
+   <> [ t' | Just t' <- [t] ]
+   <> [ TPendingLevel (is ++ [ISingle r]) Nothing  -- move into regular levels
+      | Just (TCompleted r) <- [t]
+      ]
+   <> [ TPendingLevel is' t'
+      | (is', t') <- shrink (is, t)
+      , length is' + length t' > 0
+      ]
+  shrink tree@(TPendingUnion ts) =
+      [ TCompleted (completeT tree) ]
+   <> ts
+   <> [ TPendingUnion ts'
+      | ts' <- shrink ts
+      , length ts' > 1
+      ]
+
+instance Arbitrary I where
+  arbitrary = QC.oneof [ISingle <$> arbitrary, IMerging <$> arbitrary]
+  shrink (ISingle r)  = [ISingle r' | r' <- shrink r]
+  shrink (IMerging m) = [ISingle (completeM m)] <> [IMerging m' | m' <- shrink m]
+
+instance (Arbitrary t, IsMergeType t) => Arbitrary (M t) where
+  arbitrary = QC.frequency
+      [ (1, MCompleted <$> arbitrary <*> arbitrary)
+      , (1, do
+          mt <- arbitrary
+          n <- QC.chooseInt (2, 8)
+          rs <- QC.vectorOf n (QC.scale (`div` n) arbitrary)
+          let totalWork = sum (map (length . getNonEmptyRun) rs)
+          workRemaining <- QC.chooseInt (1, totalWork)
+          unspentCredits <- QC.chooseInt (0, min mergeBatchSize workRemaining - 1)
+          let d = MergeDebt unspentCredits workRemaining
+          return (MOngoing mt d rs))
+      ]
+
+  shrink (MCompleted mt r) =
+      [ MCompleted mt r' | r' <- shrink r ]
+  shrink m@(MOngoing mt (MergeDebt c d) rs) =
+      [ MCompleted mt (completeM m) ]
+   <> [ MOngoing mt (MergeDebt c' d') rs'
+      | rs' <- shrink rs
+      , length rs' > 1
+      , let d' = min d (sum (map (length . getNonEmptyRun) rs))
+      , let c' = min c (d' - 1)
+      ]
+
+instance Arbitrary NonEmptyRun where
+  arbitrary = do
+      s <- QC.getSize
+      n <- QC.chooseInt (1, min s 40 + 1)
+      NonEmptyRun . Map.fromList <$> QC.vector n
+  shrink (NonEmptyRun r) = [NonEmptyRun r' | r' <- shrink r, not (null r')]
+
+-------------------------------------------------------------------------------
 -- tracing and expectations on LSM shape
 --
 
@@ -205,8 +382,11 @@ runWithTracer action = do
     events <- stToIO $ newSTRef []
     let tracer = Tracer $ Tracer.emit $ \e -> modifySTRef events (e :)
     action tracer `catch` \e -> do
-      ev <- reverse <$> stToIO (readSTRef events)
-      throwIO (Traced e ev)
+      if isDiscard e  -- don't intercept these
+        then throwIO e
+        else do
+          ev <- reverse <$> stToIO (readSTRef events)
+          throwIO (Traced e ev)
 
 data TracedException = Traced SomeException [Event]
   deriving stock (Show)


### PR DESCRIPTION
# Description

Best reviewed commit by commit.

Fixes #550. Also does some refactoring. The new test catches the issue reliably, but requires a lot of boilerplate, with the definition of a new type. It might be possible to reduce that somewhat, e.g. by unifying the `MTree` and `T` datatype, but it's not clear that's worthwhile.

The final commit was part of an attempt to improve the situation, but currently is not really needed. It might still be a good direction to go in, allowing to handle invariant violations in a pure manner, instead of through exceptions. Should I keep it?


