### PR TITLE
Prototype: change credit scaling, using nominal vs physical credit

### DIFF
--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -523,10 +523,12 @@ assertST p = assert p $ return ()
 -- Merging credits
 --
 
--- | Credits for keeping track of merge progress. These credits
--- correspond directly to merge steps performed. We also call these \"physical\"
--- credits (since they correspond to steps done), and as opposed to \"nominal\"
--- credits in 'NominalCredit' and 'NominalDebt'.
+-- | Credits for keeping track of merge progress. These credits correspond
+-- directly to merge steps performed.
+--
+-- We also call these \"physical\" credits (since they correspond to steps
+-- done), and as opposed to \"nominal\" credits in 'NominalCredit' and
+-- 'NominalDebt'.
 type Credit = Int
 
 -- | Debt for keeping track of the total merge work to do.
@@ -989,9 +991,32 @@ lookupsTree k = go
 -- Nominal credits
 --
 
+-- | Nominal credit is the credit supplied to each level as we insert update
+-- operations, one credit per update operation inserted.
+--
+-- Nominal credit must be supplied up to the 'NominalDebt' to ensure the merge
+-- is complete.
+--
+-- Nominal credits are a similar order of magnitude to physical credits (see
+-- 'Credit') but not the same, and we have to scale linearly to convert between
+-- them. Physical credits are the actual number of inputs to the merge, which
+-- may be somewhat more or somewhat less than the number of update operations
+-- we will insert before we need the merge to be complete.
+--
 newtype NominalCredit = NominalCredit Credit
   deriving stock Show
 
+-- | The nominal debt for a merging run is the worst case (minimum) number of
+-- update operations we expect to insert before we expect the merge to be
+-- complete.
+--
+-- We require that an equal amount of nominal credit is supplied before we can
+-- expect a merge to be complete.
+--
+-- We scale linearly to convert nominal credits to physical credits, such that
+-- the nominal debt and physical debt are both considered \"100%\", and so that
+-- both debts are paid off at exactly the same time.
+--
 newtype NominalDebt = NominalDebt Credit
   deriving stock Show
 

--- a/prototypes/ScheduledMergesTest.hs
+++ b/prototypes/ScheduledMergesTest.hs
@@ -73,7 +73,7 @@ test_regression_empty_run =
           ]
 
         -- finish merge
-        LSM.supplyMergeCredits lsm 16
+        LSM.supplyMergeCredits lsm (NominalCredit 16)
 
         expectShape lsm
           0
@@ -143,7 +143,7 @@ test_merge_again_with_incoming =
           ]
 
         -- complete the merge (20 entries, but credits get scaled up by 1.25)
-        LSM.supplyMergeCredits lsm 16
+        LSM.supplyMergeCredits lsm (NominalCredit 16)
 
         expectShape lsm
           0
@@ -272,7 +272,7 @@ fromP (PMergingRun m) = PreExistingMergingRun <$> fromM m
 fromM :: IsMergeType t => M t -> ST s (MergingRun t s)
 fromM m = do
     let (mergeType, mergeDebt, state) = case m of
-          MCompleted mt md r  -> (mt, md, CompletedMerge r)
+          MCompleted  mt md r  -> (mt, md, CompletedMerge r)
           MOngoing mt md mc rs -> (mt, md, OngoingMerge mc rs' (mergek mt rs'))
             where rs' = map getNonEmptyRun rs
     MergingRun mergeType mergeDebt <$> newSTRef state


### PR DESCRIPTION
Previously we've had a somewhat complex method to scale credits from
those supplied in a level (1 per update) to the credits used in merging.

The existing scheme has a number of downsides:
* no clear distinction between scaled and unscaled credits, what does
  each one measure?
* complex, needs scaling dependent of the merge-policy
* always uses worst case supply of credits so often finishes early
* rounding errors compound problem of credit over-supply
* no satisfactory way to check we do not over-supply credits
* contributing credits to a merge from multiple handles will cause the
  merge to finish earlier than any of the handles needs it to finish,
  thus doing work more eagerly than necessary.

The new scheme involves:
* distinguishing physical vs nominal credits, with a clear definition
  for each measure
* converting between nominal and physical without merge policy
* physical debt is no longer worst case but matches actual cost
* integer rounding errors do not compound
* we can assert that we reach the nominal and physical debt totals at
  the same moment (when the merge is done) and thus we can assert no
  over-supply of physical credits.
* we can avoid supplying credits too quickly to a merge that is shared
  between multiple handles, each one only pushes it as far as it needs.