### PR TITLE
QLS: give all actions errors

### DIFF
--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -63,6 +63,7 @@ module Test.Database.LSMTree.StateMachine (
   , Blob (..)
   , StateModel (..)
   , Action (..)
+  , Action' (..)
   ) where
 
 import           Control.ActionRegistry (AbortActionRegistryError (..),
@@ -569,7 +570,8 @@ initModelState = ModelState Model.initModel initStats
   Type synonyms
 -------------------------------------------------------------------------------}
 
-type Act h a = Action (Lockstep (ModelState h)) (Either Model.Err a)
+type Act h a = Action (Lockstep (ModelState h)) a
+type Act' h a = Action' h (Either Model.Err a)
 type Var h a = ModelVar (ModelState h) a
 type Val h a = ModelValue (ModelState h) a
 type Obs h a = Observable (ModelState h) a
@@ -610,82 +612,17 @@ instance ( Show (Class.TableConfig h)
          , Typeable h
          ) => StateModel (Lockstep (ModelState h)) where
   data instance Action (Lockstep (ModelState h)) a where
-    -- Tables
-    New :: C k v b
-        => {-# UNPACK #-} !(PrettyProxy (k, v, b))
-        -> Class.TableConfig h
-        -> Act h (WrapTable h IO k v b)
-    Close :: C k v b
-          => Var h (WrapTable h IO k v b)
-          -> Act h ()
-    -- Queries
-    Lookups :: C k v b
-            => V.Vector k -> Var h (WrapTable h IO k v b)
-            -> Act h (V.Vector (LookupResult v (WrapBlobRef h IO b)))
-    RangeLookup :: (C k v b, Ord k)
-                => R.Range k -> Var h (WrapTable h IO k v b)
-                -> Act h (V.Vector (QueryResult k v (WrapBlobRef h IO b)))
-    -- Cursor
-    NewCursor :: C k v b
-              => Maybe k
-              -> Var h (WrapTable h IO k v b)
-              -> Act h (WrapCursor h IO k v b)
-    CloseCursor :: C k v b
-                => Var h (WrapCursor h IO k v b)
-                -> Act h ()
-    ReadCursor :: C k v b
-               => Int
-               -> Var h (WrapCursor h IO k v b)
-               -> Act h (V.Vector (QueryResult k v (WrapBlobRef h IO b)))
-    -- Updates
-    Updates :: C k v b
-            => V.Vector (k, R.Update v b) -> Var h (WrapTable h IO k v b)
-            -> Act h ()
-    Inserts :: C k v b
-            => V.Vector (k, v, Maybe b) -> Var h (WrapTable h IO k v b)
-            -> Act h ()
-    Deletes :: C k v b
-            => V.Vector k -> Var h (WrapTable h IO k v b)
-            -> Act h ()
-    Mupserts :: C k v b
-             => V.Vector (k, v) -> Var h (WrapTable h IO k v b)
-             -> Act h ()
-    -- Blobs
-    RetrieveBlobs :: B b
-                  => Var h (V.Vector (WrapBlobRef h IO b))
-                  -> Act h (V.Vector (WrapBlob b))
-    -- Snapshots
-    CreateSnapshot ::
-         C k v b
-      => Maybe (Either SilentCorruption Errors)
-      -> R.SnapshotLabel -> R.SnapshotName -> Var h (WrapTable h IO k v b)
-      -> Act h ()
-    OpenSnapshot   ::
-         C k v b
-      => {-# UNPACK #-} !(PrettyProxy (k, v, b))
-      -> Maybe Errors
-      -> R.SnapshotLabel -> R.SnapshotName
-      -> Act h (WrapTable h IO k v b)
-    DeleteSnapshot :: R.SnapshotName -> Act h ()
-    ListSnapshots  :: Act h [R.SnapshotName]
-    -- Duplicate tables
-    Duplicate :: C k v b
-              => Var h (WrapTable h IO k v b)
-              -> Act h (WrapTable h IO k v b)
-    -- Table union
-    Union :: C k v b
-          => Var h (WrapTable h IO k v b)
-          -> Var h (WrapTable h IO k v b)
-          -> Act h (WrapTable h IO k v b)
-    Unions :: C k v b
-           => NonEmpty (Var h (WrapTable h IO k v b))
-           -> Act h (WrapTable h IO k v b)
+    Action :: Maybe Errors -> Action' h a -> Act h a
 
   initialState    = Lockstep.Defaults.initialState initModelState
   nextState       = Lockstep.Defaults.nextState
   precondition    = Lockstep.Defaults.precondition
   arbitraryAction = Lockstep.Defaults.arbitraryAction
   shrinkAction    = Lockstep.Defaults.shrinkAction
+
+  -- Does not use the default implementation, because that would print "Action".
+  -- We print the name of the inner 'Action'' instead.
+  actionName (Action _ action') = head . words . show $ action'
 
 deriving stock instance Show (Class.TableConfig h)
                      => Show (LockstepAction (ModelState h) a)
@@ -694,9 +631,107 @@ instance ( Eq (Class.TableConfig h)
          , Typeable h
          ) => Eq (LockstepAction (ModelState h) a) where
   (==) :: LockstepAction (ModelState h) a -> LockstepAction (ModelState h) a -> Bool
+  Action merrs1 x == Action merrs2 y = merrs1 == merrs2 && x == y
+    where
+      _coveredAllCases :: Action (Lockstep (ModelState h)) a -> ()
+      _coveredAllCases = \case
+          Action{} -> ()
+
+data Action' h a where
+  -- Tables
+  New ::
+       C k v b
+    => {-# UNPACK #-} !(PrettyProxy (k, v, b))
+    -> Class.TableConfig h
+    -> Act' h (WrapTable h IO k v b)
+  Close ::
+       C k v b
+    => Var h (WrapTable h IO k v b)
+    -> Act' h ()
+  -- Queries
+  Lookups ::
+       C k v b
+    => V.Vector k -> Var h (WrapTable h IO k v b)
+    -> Act' h (V.Vector (LookupResult v (WrapBlobRef h IO b)))
+  RangeLookup ::
+       (C k v b, Ord k)
+    => R.Range k -> Var h (WrapTable h IO k v b)
+    -> Act' h (V.Vector (QueryResult k v (WrapBlobRef h IO b)))
+  -- Cursor
+  NewCursor ::
+       C k v b
+    => Maybe k
+    -> Var h (WrapTable h IO k v b)
+    -> Act' h (WrapCursor h IO k v b)
+  CloseCursor ::
+       C k v b
+    => Var h (WrapCursor h IO k v b)
+    -> Act' h ()
+  ReadCursor ::
+       C k v b
+    => Int
+    -> Var h (WrapCursor h IO k v b)
+    -> Act' h (V.Vector (QueryResult k v (WrapBlobRef h IO b)))
+  -- Updates
+  Updates ::
+       C k v b
+    => V.Vector (k, R.Update v b) -> Var h (WrapTable h IO k v b)
+    -> Act' h ()
+  Inserts ::
+       C k v b
+    => V.Vector (k, v, Maybe b) -> Var h (WrapTable h IO k v b)
+    -> Act' h ()
+  Deletes ::
+       C k v b
+    => V.Vector k -> Var h (WrapTable h IO k v b)
+    -> Act' h ()
+  Mupserts ::
+       C k v b
+    => V.Vector (k, v) -> Var h (WrapTable h IO k v b)
+    -> Act' h ()
+  -- Blobs
+  RetrieveBlobs ::
+       B b
+    => Var h (V.Vector (WrapBlobRef h IO b))
+    -> Act' h (V.Vector (WrapBlob b))
+  -- Snapshots
+  CreateSnapshot ::
+       C k v b
+    => Maybe SilentCorruption
+    -> R.SnapshotLabel -> R.SnapshotName -> Var h (WrapTable h IO k v b)
+    -> Act' h ()
+  OpenSnapshot   ::
+       C k v b
+    => {-# UNPACK #-} !(PrettyProxy (k, v, b))
+    -> R.SnapshotLabel -> R.SnapshotName
+    -> Act' h (WrapTable h IO k v b)
+  DeleteSnapshot :: R.SnapshotName -> Act' h ()
+  ListSnapshots  :: Act' h [R.SnapshotName]
+  -- Duplicate tables
+  Duplicate ::
+       C k v b
+    => Var h (WrapTable h IO k v b)
+    -> Act' h (WrapTable h IO k v b)
+  -- Table union
+  Union ::
+       C k v b
+    => Var h (WrapTable h IO k v b)
+    -> Var h (WrapTable h IO k v b)
+    -> Act' h (WrapTable h IO k v b)
+  Unions ::
+       C k v b
+    => NonEmpty (Var h (WrapTable h IO k v b))
+    -> Act' h (WrapTable h IO k v b)
+
+deriving stock instance Show (Class.TableConfig h)
+                     => Show (Action' h a)
+
+instance ( Eq (Class.TableConfig h)
+         , Typeable h
+         ) => Eq (Action' h a) where
   x == y = go x y
     where
-      go :: LockstepAction (ModelState h) a -> LockstepAction (ModelState h) a -> Bool
+      go :: Action' h a -> Action' h a -> Bool
       go
         (New (PrettyProxy :: PrettyProxy kvb) conf1)
         (New (PrettyProxy :: PrettyProxy kvb) conf2) =
@@ -723,12 +758,12 @@ instance ( Eq (Class.TableConfig h)
           Just mups1 == cast mups2 && Just var1 == cast var2
       go (RetrieveBlobs vars1) (RetrieveBlobs vars2) =
           Just vars1 == cast vars2
-      go (CreateSnapshot merrs1 label1 name1 var1) (CreateSnapshot merrs2 label2 name2 var2) =
-          merrs1 == merrs2 && label1 == label2 && name1 == name2 && Just var1 == cast var2
+      go (CreateSnapshot mcorr1 label1 name1 var1) (CreateSnapshot mcorr2 label2 name2 var2) =
+          mcorr1 == mcorr2 && label1 == label2 && name1 == name2 && Just var1 == cast var2
       go
-        (OpenSnapshot (PrettyProxy :: PrettyProxy kvb) merrs1 label1 name1)
-        (OpenSnapshot (PrettyProxy :: PrettyProxy kvb) merrs2 label2 name2) =
-          merrs1 == merrs2 && label1 == label2 && name1 == name2
+        (OpenSnapshot (PrettyProxy :: PrettyProxy kvb) label1 name1)
+        (OpenSnapshot (PrettyProxy :: PrettyProxy kvb) label2 name2) =
+          label1 == label2 && name1 == name2
       go (DeleteSnapshot name1) (DeleteSnapshot name2) =
           name1 == name2
       go ListSnapshots ListSnapshots =
@@ -741,7 +776,7 @@ instance ( Eq (Class.TableConfig h)
           Just vars1 == cast vars2
       go _  _ = False
 
-      _coveredAllCases :: LockstepAction (ModelState h) a -> ()
+      _coveredAllCases :: Action' h a -> ()
       _coveredAllCases = \case
           New{} -> ()
           Close{} -> ()
@@ -860,26 +895,26 @@ instance ( Eq (Class.TableConfig h)
           stats' = updateStats action (lookupVar ctx) state state' result stats
 
   usedVars :: LockstepAction (ModelState h) a -> [AnyGVar (ModelOp (ModelState h))]
-  usedVars = \case
-      New _ _                         -> []
-      Close tableVar                  -> [SomeGVar tableVar]
-      Lookups _ tableVar              -> [SomeGVar tableVar]
-      RangeLookup _ tableVar          -> [SomeGVar tableVar]
-      NewCursor _ tableVar            -> [SomeGVar tableVar]
-      CloseCursor cursorVar           -> [SomeGVar cursorVar]
-      ReadCursor _ cursorVar          -> [SomeGVar cursorVar]
-      Updates _ tableVar              -> [SomeGVar tableVar]
-      Inserts _ tableVar              -> [SomeGVar tableVar]
-      Deletes _ tableVar              -> [SomeGVar tableVar]
-      Mupserts _ tableVar             -> [SomeGVar tableVar]
-      RetrieveBlobs blobsVar          -> [SomeGVar blobsVar]
-      CreateSnapshot _ _ _ tableVar   -> [SomeGVar tableVar]
-      OpenSnapshot{}                  -> []
-      DeleteSnapshot _                -> []
-      ListSnapshots                   -> []
-      Duplicate tableVar              -> [SomeGVar tableVar]
-      Union table1Var table2Var       -> [SomeGVar table1Var, SomeGVar table2Var]
-      Unions tableVars                -> [SomeGVar tableVar | tableVar <- NE.toList tableVars]
+  usedVars (Action _ action') = case action' of
+      New _ _                       -> []
+      Close tableVar                -> [SomeGVar tableVar]
+      Lookups _ tableVar            -> [SomeGVar tableVar]
+      RangeLookup _ tableVar        -> [SomeGVar tableVar]
+      NewCursor _ tableVar          -> [SomeGVar tableVar]
+      CloseCursor cursorVar         -> [SomeGVar cursorVar]
+      ReadCursor _ cursorVar        -> [SomeGVar cursorVar]
+      Updates _ tableVar            -> [SomeGVar tableVar]
+      Inserts _ tableVar            -> [SomeGVar tableVar]
+      Deletes _ tableVar            -> [SomeGVar tableVar]
+      Mupserts _ tableVar           -> [SomeGVar tableVar]
+      RetrieveBlobs blobsVar        -> [SomeGVar blobsVar]
+      CreateSnapshot _ _ _ tableVar -> [SomeGVar tableVar]
+      OpenSnapshot{}                -> []
+      DeleteSnapshot _              -> []
+      ListSnapshots                 -> []
+      Duplicate tableVar            -> [SomeGVar tableVar]
+      Union table1Var table2Var     -> [SomeGVar table1Var, SomeGVar table2Var]
+      Unions tableVars              -> [SomeGVar tableVar | tableVar <- NE.toList tableVars]
 
   arbitraryWithVars ::
        ModelVarContext (ModelState h)
@@ -1021,7 +1056,7 @@ instance ( Eq (Class.TableConfig h)
     -> LockstepAction (ModelState h) a
     -> Realized (RealMonad h IO) a
     -> Obs h a
-  observeReal _proxy action result = case action of
+  observeReal _proxy (Action _ action') result = case action' of
       New{}            -> OEither $ bimap OId (const OTable) result
       Close{}          -> OEither $ bimap OId OId result
       Lookups{}        -> OEither $
@@ -1049,7 +1084,7 @@ instance ( Eq (Class.TableConfig h)
        Proxy (RealMonad h IO)
     -> LockstepAction (ModelState h) a
     -> Maybe (Dict (Show (Realized (RealMonad h IO) a)))
-  showRealResponse _ = \case
+  showRealResponse _ (Action _ action') = case action' of
       New{}            -> Nothing
       Close{}          -> Just Dict
       Lookups{}        -> Nothing
@@ -1065,7 +1100,7 @@ instance ( Eq (Class.TableConfig h)
       CreateSnapshot{} -> Just Dict
       OpenSnapshot{}   -> Nothing
       DeleteSnapshot{} -> Just Dict
-      ListSnapshots    -> Just Dict
+      ListSnapshots{}  -> Just Dict
       Duplicate{}      -> Nothing
       Union{}          -> Nothing
       Unions{}         -> Nothing
@@ -1081,7 +1116,7 @@ instance ( Eq (Class.TableConfig h)
     -> LockstepAction (ModelState h) a
     -> Realized (RealMonad h (IOSim s)) a
     -> Obs h a
-  observeReal _proxy action result = case action of
+  observeReal _proxy (Action _ action') result = case action' of
       New{}            -> OEither $ bimap OId (const OTable) result
       Close{}          -> OEither $ bimap OId OId result
       Lookups{}        -> OEither $
@@ -1109,7 +1144,7 @@ instance ( Eq (Class.TableConfig h)
        Proxy (RealMonad h (IOSim s))
     -> LockstepAction (ModelState h) a
     -> Maybe (Dict (Show (Realized (RealMonad h (IOSim s)) a)))
-  showRealResponse _ = \case
+  showRealResponse _ (Action _ action') = case action' of
       New{}            -> Nothing
       Close{}          -> Just Dict
       Lookups{}        -> Nothing
@@ -1125,7 +1160,7 @@ instance ( Eq (Class.TableConfig h)
       CreateSnapshot{} -> Just Dict
       OpenSnapshot{}   -> Nothing
       DeleteSnapshot{} -> Just Dict
-      ListSnapshots    -> Just Dict
+      ListSnapshots{}  -> Just Dict
       Duplicate{}      -> Nothing
       Union{}          -> Nothing
       Unions{}         -> Nothing
@@ -1158,73 +1193,113 @@ instance ( Eq (Class.TableConfig h)
   Interpreter for the model
 -------------------------------------------------------------------------------}
 
+-- TODO: there are a bunch of TODO(err) in 'runMode;' on the last argument to
+-- 'Model.runModelMWithInjectedErrors'. This last argument defines how the model
+-- should respond to injected errors. Since we don't generate injected errors
+-- for most of these actions yet, they are left open. We will fill these in as
+-- we start generating injected errors for these actions and testing with them.
+
 runModel ::
      ModelLookUp (ModelState h)
   -> LockstepAction (ModelState h) a
   -> Model.Model -> (Val h a, Model.Model)
-runModel lookUp = \case
+runModel lookUp (Action merrs action') = case action' of
     New _ _cfg ->
       wrap MTable
-      . Model.runModelM (Model.new Model.TableConfig)
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.new Model.TableConfig)
+          (pure ()) -- TODO(err)
     Close tableVar ->
       wrap MUnit
-      . Model.runModelM (Model.close (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.close (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     Lookups ks tableVar ->
       wrap (MVector . fmap (MLookupResult . fmap MBlobRef))
-      . Model.runModelM (Model.lookups ks (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.lookups ks (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     RangeLookup range tableVar ->
       wrap (MVector . fmap (MQueryResult . fmap MBlobRef))
-      . Model.runModelM (Model.rangeLookup range (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.rangeLookup range (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     NewCursor offset tableVar ->
       wrap MCursor
-      . Model.runModelM (Model.newCursor offset (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.newCursor offset (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     CloseCursor cursorVar ->
       wrap MUnit
-      . Model.runModelM (Model.closeCursor (getCursor $ lookUp cursorVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.closeCursor (getCursor $ lookUp cursorVar))
+          (pure ()) -- TODO(err)
     ReadCursor n cursorVar ->
       wrap (MVector . fmap (MQueryResult . fmap MBlobRef))
-      . Model.runModelM (Model.readCursor n (getCursor $ lookUp cursorVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.readCursor n (getCursor $ lookUp cursorVar))
+          (pure ()) -- TODO(err)
     Updates kups tableVar ->
       wrap MUnit
-      . Model.runModelM (Model.updates Model.getResolve kups (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.updates Model.getResolve kups (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     Inserts kins tableVar ->
       wrap MUnit
-      . Model.runModelM (Model.inserts Model.getResolve kins (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.inserts Model.getResolve kins (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     Deletes kdels tableVar ->
       wrap MUnit
-      . Model.runModelM (Model.deletes Model.getResolve kdels (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.deletes Model.getResolve kdels (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     Mupserts kmups tableVar ->
       wrap MUnit
-      . Model.runModelM (Model.mupserts Model.getResolve kmups (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.mupserts Model.getResolve kmups (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     RetrieveBlobs blobsVar ->
       wrap (MVector . fmap (MBlob . WrapBlob))
-      . Model.runModelM (Model.retrieveBlobs (getBlobRefs . lookUp $ blobsVar))
-    CreateSnapshot mcorrOrErrs label name tableVar ->
-      wrap MUnit .
-        let mCreateSnapshot = Model.createSnapshot label name (getTable $ lookUp tableVar)
-        in case sequence mcorrOrErrs of
-              Left _corrs -> Model.runModelM (mCreateSnapshot >> Model.corruptSnapshot name)
-              Right merrs -> Model.runModelMWithInjectedErrors merrs mCreateSnapshot (pure ())
-    OpenSnapshot _ merrs label name ->
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.retrieveBlobs (getBlobRefs . lookUp $ blobsVar))
+          (pure ()) -- TODO(err)
+    CreateSnapshot mcorr label name tableVar ->
+      wrap MUnit
+        . Model.runModelMWithInjectedErrors merrs
+            (do Model.createSnapshot label name (getTable $ lookUp tableVar)
+                forM_ mcorr $ \_ -> Model.corruptSnapshot name)
+            (pure ()) -- TODO(err)
+    OpenSnapshot _ label name ->
       wrap MTable
       . Model.runModelMWithInjectedErrors merrs
           (Model.openSnapshot label name)
           (pure ())
     DeleteSnapshot name ->
       wrap MUnit
-      . Model.runModelM (Model.deleteSnapshot name)
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.deleteSnapshot name)
+          (pure ()) -- TODO(err)
     ListSnapshots ->
       wrap (MList . fmap MSnapshotName)
-      . Model.runModelM Model.listSnapshots
+      . Model.runModelMWithInjectedErrors merrs
+          Model.listSnapshots
+          (pure ()) -- TODO(err)
     Duplicate tableVar ->
       wrap MTable
-      . Model.runModelM (Model.duplicate (getTable $ lookUp tableVar))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.duplicate (getTable $ lookUp tableVar))
+          (pure ()) -- TODO(err)
     Union table1Var table2Var ->
       wrap MTable
-      . Model.runModelM (Model.union Model.getResolve (getTable $ lookUp table1Var) (getTable $ lookUp table2Var))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.union Model.getResolve (getTable $ lookUp table1Var) (getTable $ lookUp table2Var))
+          (pure ()) -- TODO(err)
     Unions tableVars ->
       wrap MTable
-      . Model.runModelM (Model.unions Model.getResolve (fmap (getTable . lookUp) tableVars))
+      . Model.runModelMWithInjectedErrors merrs
+          (Model.unions Model.getResolve (fmap (getTable . lookUp) tableVars))
+          (pure ()) -- TODO(err)
   where
     getTable ::
          ModelValue (ModelState h) (WrapTable h IO k v b)
@@ -1249,6 +1324,13 @@ wrap f = first (MEither . bimap MErr f)
   Interpreters for @'IOLike' m@
 -------------------------------------------------------------------------------}
 
+-- TODO: there are a bunch of TODO(err) in 'runIO' and 'runIOSim' below on the
+-- last argument to 'Model.runModelMWithInjectedErrors'. This last argument
+-- defines how the SUT should recover from actions that accidentally succeeded
+-- in the presence of disk faults. Since we don't generate injected errors for
+-- most of these actions yet, they are left open. We will fill these in as we
+-- start generating injected errors for these actions and testing with them.
+
 runIO ::
      forall a h. Class.IsTable h
   => LockstepAction (ModelState h) a
@@ -1261,59 +1343,87 @@ runIO action lookUp = ReaderT $ \ !env -> do
          RealEnv h IO
       -> LockstepAction (ModelState h) a
       -> IO (Realized IO a)
-    aux env = \case
-        New _ cfg -> catchErr handlers $
-          WrapTable <$> Class.new session cfg
-        Close tableVar -> catchErr handlers $
-          Class.close (unwrapTable $ lookUp' tableVar)
-        Lookups ks tableVar -> catchErr handlers $
-          fmap (fmap WrapBlobRef) <$> Class.lookups (unwrapTable $ lookUp' tableVar) ks
-        RangeLookup range tableVar -> catchErr handlers $
-          fmap (fmap WrapBlobRef) <$> Class.rangeLookup (unwrapTable $ lookUp' tableVar) range
-        NewCursor offset tableVar -> catchErr handlers $
-          WrapCursor <$> Class.newCursor offset (unwrapTable $ lookUp' tableVar)
-        CloseCursor cursorVar -> catchErr handlers $
-          Class.closeCursor (Proxy @h) (unwrapCursor $ lookUp' cursorVar)
-        ReadCursor n cursorVar -> catchErr handlers $
-          fmap (fmap WrapBlobRef) <$> Class.readCursor (Proxy @h) n (unwrapCursor $ lookUp' cursorVar)
-        Updates kups tableVar -> catchErr handlers $
-          Class.updates (unwrapTable $ lookUp' tableVar) kups
-        Inserts kins tableVar -> catchErr handlers $
-          Class.inserts (unwrapTable $ lookUp' tableVar) kins
-        Deletes kdels tableVar -> catchErr handlers $
-          Class.deletes (unwrapTable $ lookUp' tableVar) kdels
-        Mupserts kmups tableVar -> catchErr handlers $
-          Class.mupserts (unwrapTable $ lookUp' tableVar) kmups
-        RetrieveBlobs blobRefsVar -> catchErr handlers $
-          fmap WrapBlob <$> Class.retrieveBlobs (Proxy @h) session (unwrapBlobRef <$> lookUp' blobRefsVar)
-        CreateSnapshot mcorrOrErrs label name tableVar ->
-          let rCreateSnapshot = Class.createSnapshot label name (unwrapTable $ lookUp' tableVar) in
-          case sequence mcorrOrErrs of
-            Left corr -> do
-              rCreateSnapshot
-              Class.corruptSnapshot (bitChoice corr) name (unwrapTable $ lookUp' tableVar)
-              pure (Right ())
-            Right merrs ->
-              runRealWithInjectedErrors "CreateSnapshot" env merrs
-                rCreateSnapshot
-                (\() -> Class.deleteSnapshot session name)
-        OpenSnapshot _ merrs label name ->
+    aux env (Action merrs action') = case action' of
+        New _ cfg ->
+          runRealWithInjectedErrors "New" env merrs
+            (WrapTable <$> Class.new session cfg)
+            (\_ -> pure ()) -- TODO(err)
+        Close tableVar ->
+          runRealWithInjectedErrors "Close" env merrs
+            (Class.close (unwrapTable $ lookUp' tableVar))
+            (\_ -> pure ()) -- TODO(err)
+        Lookups ks tableVar ->
+          runRealWithInjectedErrors "Lookups" env merrs
+            (fmap (fmap WrapBlobRef) <$> Class.lookups (unwrapTable $ lookUp' tableVar) ks)
+            (\_ -> pure ()) -- TODO(err)
+        RangeLookup range tableVar ->
+          runRealWithInjectedErrors "RangeLookup" env merrs
+            (fmap (fmap WrapBlobRef) <$> Class.rangeLookup (unwrapTable $ lookUp' tableVar) range)
+            (\_ -> pure ()) -- TODO(err)
+        NewCursor offset tableVar ->
+          runRealWithInjectedErrors "NewCursor" env merrs
+            (WrapCursor <$> Class.newCursor offset (unwrapTable $ lookUp' tableVar))
+            (\_ -> pure ()) -- TODO(err)
+        CloseCursor cursorVar ->
+          runRealWithInjectedErrors "CloseCursor" env merrs
+            (Class.closeCursor (Proxy @h) (unwrapCursor $ lookUp' cursorVar))
+            (\_ -> pure ()) -- TODO(err)
+        ReadCursor n cursorVar ->
+          runRealWithInjectedErrors "ReadCursor" env merrs
+            (fmap (fmap WrapBlobRef) <$> Class.readCursor (Proxy @h) n (unwrapCursor $ lookUp' cursorVar))
+            (\_ -> pure ()) -- TODO(err)
+        Updates kups tableVar ->
+          runRealWithInjectedErrors "Updates" env merrs
+            (Class.updates (unwrapTable $ lookUp' tableVar) kups)
+            (\_ -> pure ()) -- TODO(err)
+        Inserts kins tableVar ->
+          runRealWithInjectedErrors "Inserts" env merrs
+            (Class.inserts (unwrapTable $ lookUp' tableVar) kins)
+            (\_ -> pure ()) -- TODO(err)
+        Deletes kdels tableVar ->
+          runRealWithInjectedErrors "Deletes" env merrs
+            (Class.deletes (unwrapTable $ lookUp' tableVar) kdels)
+            (\_ -> pure ()) -- TODO(err)
+        Mupserts kmups tableVar ->
+          runRealWithInjectedErrors "Mupserts" env merrs
+            (Class.mupserts (unwrapTable $ lookUp' tableVar) kmups)
+            (\_ -> pure ()) -- TODO(err)
+        RetrieveBlobs blobRefsVar ->
+          runRealWithInjectedErrors "RetrieveBlobs" env merrs
+            (fmap WrapBlob <$> Class.retrieveBlobs (Proxy @h) session (unwrapBlobRef <$> lookUp' blobRefsVar))
+            (\_ -> pure ()) -- TODO(err)
+        CreateSnapshot mcorr label name tableVar ->
+          let table = unwrapTable $ lookUp' tableVar in
+          runRealWithInjectedErrors "CreateSnapshot" env merrs
+            (do Class.createSnapshot label name table
+                forM_ mcorr $ \corr -> Class.corruptSnapshot (bitChoice corr) name table)
+            (\() -> Class.deleteSnapshot session name) -- TODO(err)
+        OpenSnapshot _ label name ->
           runRealWithInjectedErrors "OpenSnapshot" env merrs
             (WrapTable <$> Class.openSnapshot session label name)
             (\(WrapTable t) -> Class.close t)
-        DeleteSnapshot name -> catchErr handlers $
-          Class.deleteSnapshot session name
-        ListSnapshots -> catchErr handlers $
-          Class.listSnapshots session
-        Duplicate tableVar -> catchErr handlers $
-          WrapTable <$> Class.duplicate (unwrapTable $ lookUp' tableVar)
-        Union table1Var table2Var -> catchErr handlers $
-          WrapTable <$> Class.union (unwrapTable $ lookUp' table1Var) (unwrapTable $ lookUp' table2Var)
-        Unions tableVars -> catchErr handlers $
-          WrapTable <$> Class.unions (fmap (unwrapTable . lookUp') tableVars)
+        DeleteSnapshot name ->
+          runRealWithInjectedErrors "DeleteSnapshot" env merrs
+            (Class.deleteSnapshot session name)
+            (\_ -> pure ()) -- TODO(err)
+        ListSnapshots ->
+          runRealWithInjectedErrors "ListSnapshots" env merrs
+            (Class.listSnapshots session)
+            (\_ -> pure ()) -- TODO(err)
+        Duplicate tableVar ->
+          runRealWithInjectedErrors "Duplicate" env merrs
+            (WrapTable <$> Class.duplicate (unwrapTable $ lookUp' tableVar))
+            (\_ -> pure ()) -- TODO(err)
+        Union table1Var table2Var ->
+          runRealWithInjectedErrors "Union" env merrs
+            (WrapTable <$> Class.union (unwrapTable $ lookUp' table1Var) (unwrapTable $ lookUp' table2Var))
+            (\_ -> pure ()) -- TODO(err)
+        Unions tableVars ->
+          runRealWithInjectedErrors "Unions" env merrs
+            (WrapTable <$> Class.unions (fmap (unwrapTable . lookUp') tableVars))
+            (\_ -> pure ()) -- TODO(err)
       where
         session = envSession env
-        handlers = envHandlers env
 
     lookUp' :: Var h x -> Realized IO x
     lookUp' = lookUpGVar (Proxy @(RealMonad h IO)) lookUp
@@ -1330,59 +1440,87 @@ runIOSim action lookUp = ReaderT $ \ !env -> do
          RealEnv h (IOSim s)
       -> LockstepAction (ModelState h) a
       -> IOSim s (Realized (IOSim s) a)
-    aux env = \case
-        New _ cfg -> catchErr handlers $
-          WrapTable <$> Class.new session cfg
-        Close tableVar -> catchErr handlers $
-          Class.close (unwrapTable $ lookUp' tableVar)
-        Lookups ks tableVar -> catchErr handlers $
-          fmap (fmap WrapBlobRef) <$> Class.lookups (unwrapTable $ lookUp' tableVar) ks
-        RangeLookup range tableVar -> catchErr handlers $
-          fmap (fmap WrapBlobRef) <$> Class.rangeLookup (unwrapTable $ lookUp' tableVar) range
-        NewCursor offset tableVar -> catchErr handlers $
-          WrapCursor <$> Class.newCursor offset (unwrapTable $ lookUp' tableVar)
-        CloseCursor cursorVar -> catchErr handlers $
-          Class.closeCursor (Proxy @h) (unwrapCursor $ lookUp' cursorVar)
-        ReadCursor n cursorVar -> catchErr handlers $
-          fmap (fmap WrapBlobRef) <$> Class.readCursor (Proxy @h) n (unwrapCursor $ lookUp' cursorVar)
-        Updates kups tableVar -> catchErr handlers $
-          Class.updates (unwrapTable $ lookUp' tableVar) kups
-        Inserts kins tableVar -> catchErr handlers $
-          Class.inserts (unwrapTable $ lookUp' tableVar) kins
-        Deletes kdels tableVar -> catchErr handlers $
-          Class.deletes (unwrapTable $ lookUp' tableVar) kdels
-        Mupserts kmups tableVar -> catchErr handlers $
-          Class.mupserts (unwrapTable $ lookUp' tableVar) kmups
-        RetrieveBlobs blobRefsVar -> catchErr handlers $
-          fmap WrapBlob <$> Class.retrieveBlobs (Proxy @h) session (unwrapBlobRef <$> lookUp' blobRefsVar)
-        CreateSnapshot mcorrOrErrs label name tableVar ->
-          let rCreateSnapshot = Class.createSnapshot label name (unwrapTable $ lookUp' tableVar) in
-          case sequence mcorrOrErrs of
-            Left corr -> do
-              rCreateSnapshot
-              Class.corruptSnapshot (bitChoice corr) name (unwrapTable $ lookUp' tableVar)
-              pure (Right ())
-            Right merrs ->
-              runRealWithInjectedErrors "CreateSnapshot" env merrs
-                rCreateSnapshot
-                (\() -> Class.deleteSnapshot session name)
-        OpenSnapshot _ merrs label name ->
+    aux env (Action merrs action') = case action' of
+        New _ cfg ->
+          runRealWithInjectedErrors "New" env merrs
+            (WrapTable <$> Class.new session cfg)
+            (\_ -> pure ()) -- TODO(err)
+        Close tableVar ->
+          runRealWithInjectedErrors "Close" env merrs
+            (Class.close (unwrapTable $ lookUp' tableVar))
+            (\_ -> pure ()) -- TODO(err)
+        Lookups ks tableVar ->
+          runRealWithInjectedErrors "Lookups" env merrs
+            (fmap (fmap WrapBlobRef) <$> Class.lookups (unwrapTable $ lookUp' tableVar) ks)
+            (\_ -> pure ()) -- TODO(err)
+        RangeLookup range tableVar ->
+          runRealWithInjectedErrors "RangeLookup" env merrs
+            (fmap (fmap WrapBlobRef) <$> Class.rangeLookup (unwrapTable $ lookUp' tableVar) range)
+            (\_ -> pure ()) -- TODO(err)
+        NewCursor offset tableVar ->
+          runRealWithInjectedErrors "NewCursor" env merrs
+            (WrapCursor <$> Class.newCursor offset (unwrapTable $ lookUp' tableVar))
+            (\_ -> pure ()) -- TODO(err)
+        CloseCursor cursorVar ->
+          runRealWithInjectedErrors "CloseCursor" env merrs
+            (Class.closeCursor (Proxy @h) (unwrapCursor $ lookUp' cursorVar))
+            (\_ -> pure ()) -- TODO(err)
+        ReadCursor n cursorVar ->
+          runRealWithInjectedErrors "ReadCursor" env merrs
+            (fmap (fmap WrapBlobRef) <$> Class.readCursor (Proxy @h) n (unwrapCursor $ lookUp' cursorVar))
+            (\_ -> pure ()) -- TODO(err)
+        Updates kups tableVar ->
+          runRealWithInjectedErrors "Updates" env merrs
+            (Class.updates (unwrapTable $ lookUp' tableVar) kups)
+            (\_ -> pure ()) -- TODO(err)
+        Inserts kins tableVar ->
+          runRealWithInjectedErrors "Inserts" env merrs
+            (Class.inserts (unwrapTable $ lookUp' tableVar) kins)
+            (\_ -> pure ()) -- TODO(err)
+        Deletes kdels tableVar ->
+          runRealWithInjectedErrors "Deletes" env merrs
+            (Class.deletes (unwrapTable $ lookUp' tableVar) kdels)
+            (\_ -> pure ()) -- TODO(err)
+        Mupserts kmups tableVar ->
+          runRealWithInjectedErrors "Mupserts" env merrs
+            (Class.mupserts (unwrapTable $ lookUp' tableVar) kmups)
+            (\_ -> pure ()) -- TODO(err)
+        RetrieveBlobs blobRefsVar ->
+          runRealWithInjectedErrors "RetrieveBlobs" env merrs
+            (fmap WrapBlob <$> Class.retrieveBlobs (Proxy @h) session (unwrapBlobRef <$> lookUp' blobRefsVar))
+            (\_ -> pure ()) -- TODO(err)
+        CreateSnapshot mcorr label name tableVar ->
+          let table = unwrapTable $ lookUp' tableVar in
+          runRealWithInjectedErrors "CreateSnapshot" env merrs
+            (do Class.createSnapshot label name table
+                forM_ mcorr $ \corr -> Class.corruptSnapshot (bitChoice corr) name table)
+            (\() -> Class.deleteSnapshot session name) -- TODO(err)
+        OpenSnapshot _ label name ->
           runRealWithInjectedErrors "OpenSnapshot" env merrs
             (WrapTable <$> Class.openSnapshot session label name)
             (\(WrapTable t) -> Class.close t)
-        DeleteSnapshot name -> catchErr handlers $
-          Class.deleteSnapshot session name
-        ListSnapshots -> catchErr handlers $
-          Class.listSnapshots session
-        Duplicate tableVar -> catchErr handlers $
-          WrapTable <$> Class.duplicate (unwrapTable $ lookUp' tableVar)
-        Union table1Var table2Var -> catchErr handlers $
-          WrapTable <$> Class.union (unwrapTable $ lookUp' table1Var) (unwrapTable $ lookUp' table2Var)
-        Unions tableVars -> catchErr handlers $
-          WrapTable <$> Class.unions (fmap (unwrapTable . lookUp') tableVars)
+        DeleteSnapshot name ->
+          runRealWithInjectedErrors "DeleteSnapshot" env merrs
+            (Class.deleteSnapshot session name)
+            (\_ -> pure ()) -- TODO(err)
+        ListSnapshots ->
+          runRealWithInjectedErrors "ListSnapshots" env merrs
+            (Class.listSnapshots session)
+            (\_ -> pure ()) -- TODO(err)
+        Duplicate tableVar ->
+          runRealWithInjectedErrors "Duplicate" env merrs
+            (WrapTable <$> Class.duplicate (unwrapTable $ lookUp' tableVar))
+            (\_ -> pure ()) -- TODO(err)
+        Union table1Var table2Var ->
+          runRealWithInjectedErrors "Union" env merrs
+            (WrapTable <$> Class.union (unwrapTable $ lookUp' table1Var) (unwrapTable $ lookUp' table2Var))
+            (\_ -> pure ()) -- TODO(err)
+        Unions tableVars ->
+          runRealWithInjectedErrors "Unions" env merrs
+            (WrapTable <$> Class.unions (fmap (unwrapTable . lookUp') tableVars))
+            (\_ -> pure ()) -- TODO(err)
       where
         session = envSession env
-        handlers = envHandlers env
 
     lookUp' :: Var h x -> Realized (IOSim s) x
     lookUp' = lookUpGVar (Proxy @(RealMonad h (IOSim s))) lookUp
@@ -1462,7 +1600,10 @@ arbitraryActionWithVars _ label ctx (ModelState st _stats) =
         ]
   where
     _coveredAllCases :: LockstepAction (ModelState h) a -> ()
-    _coveredAllCases = \case
+    _coveredAllCases (Action _ action') = _coveredAllCases' action'
+
+    _coveredAllCases' :: Action' h a -> ()
+    _coveredAllCases' = \case
         New{} -> ()
         Close{} -> ()
         Lookups{} -> ()
@@ -1534,11 +1675,14 @@ arbitraryActionWithVars _ label ctx (ModelState st _stats) =
 
     genActionsSession :: [(Int, Gen (Any (LockstepAction (ModelState h))))]
     genActionsSession =
-        [ (1, fmap Some $ New @k @v @b PrettyProxy <$> QC.arbitrary)
-        | length tableVars <= 5 ] -- no more than 5 tables at once
+        [ (1, fmap Some $ (Action <$> genErrors <*>) $
+            New @k @v @b <$> pure PrettyProxy <*> QC.arbitrary)
+        | length tableVars <= 5 -- no more than 5 tables at once
+        , let genErrors = pure Nothing -- TODO: generate errors
+        ]
 
-     ++ [ (2, fmap Some $ OpenSnapshot @k @v @b PrettyProxy <$>
-                genErrors <*> pure label <*> genUsedSnapshotName)
+     ++ [ (2, fmap Some $ (Action <$> genErrors <*>) $
+            OpenSnapshot @k @v @b PrettyProxy <$> pure label <*> genUsedSnapshotName)
         | length tableVars <= 5 -- no more than 5 tables at once
         , not (null usedSnapshotNames)
         , let genErrors = QC.frequency [
@@ -1547,46 +1691,81 @@ arbitraryActionWithVars _ label ctx (ModelState st _stats) =
                 ]
         ]
 
-     ++ [ (1, fmap Some $ DeleteSnapshot <$> genUsedSnapshotName)
-        | not (null usedSnapshotNames) ]
+     ++ [ (1, fmap Some $ (Action <$> genErrors <*>) $
+            DeleteSnapshot <$> genUsedSnapshotName)
+        | not (null usedSnapshotNames)
+        , let genErrors = pure Nothing -- TODO: generate errors
+        ]
 
-     ++ [ (1, fmap Some $ pure ListSnapshots)
-        | not (null tableVars) ] -- otherwise boring!
+     ++ [ (1, fmap Some $ (Action <$> genErrors <*>) $
+            pure ListSnapshots)
+        | not (null tableVars) -- otherwise boring!
+        , let genErrors = pure Nothing -- TODO: generate errors
+        ]
 
     genActionsTables :: [(Int, Gen (Any (LockstepAction (ModelState h))))]
     genActionsTables
       | null tableVars = []
       | otherwise      =
-        [ (1,  fmap Some $ Close <$> genTableVar)
-        , (10, fmap Some $ Lookups <$> genLookupKeys <*> genTableVar)
-        , (5,  fmap Some $ RangeLookup <$> genRange <*> genTableVar)
-        , (10, fmap Some $ Updates <$> genUpdates <*> genTableVar)
-        , (10, fmap Some $ Inserts <$> genInserts <*> genTableVar)
-        , (10, fmap Some $ Deletes <$> genDeletes <*> genTableVar)
-        , (10, fmap Some $ Mupserts <$> genMupserts <*> genTableVar)
+        [ (1,  fmap Some $ (Action <$> genErrors <*>) $
+            Close <$> genTableVar)
+        | let genErrors = pure Nothing
         ]
-     ++ [ (3,  fmap Some $ NewCursor <$> QC.arbitrary <*> genTableVar)
+     ++ [ (10, fmap Some $ (Action <$> genErrors <*>) $
+            Lookups <$> genLookupKeys <*> genTableVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
+        ]
+     ++ [ (5,  fmap Some $ (Action <$> genErrors <*>) $
+            RangeLookup <$> genRange <*> genTableVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
+        ]
+     ++ [ (10, fmap Some $ (Action <$> genErrors <*>) $
+            Updates <$> genUpdates <*> genTableVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
+        ]
+     ++ [ (10, fmap Some $ (Action <$> genErrors <*>) $
+            Inserts <$> genInserts <*> genTableVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
+        ]
+     ++ [ (10, fmap Some $ (Action <$> genErrors <*>) $
+            Deletes <$> genDeletes <*> genTableVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
+        ]
+     ++ [ (10, fmap Some $ (Action <$> genErrors <*>) $
+            Mupserts <$> genMupserts <*> genTableVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
+        ]
+     ++ [ (3,  fmap Some $ (Action <$> genErrors <*>) $
+            NewCursor <$> QC.arbitrary <*> genTableVar)
         | length cursorVars <= 5 -- no more than 5 cursors at once
+        , let genErrors = pure Nothing -- TODO: generate errors
         ]
-     ++ [ (2,  fmap Some $ CreateSnapshot <$>
-                genErrors <*> pure label <*> genUnusedSnapshotName <*> genTableVar)
+     ++ [ (2,  fmap Some $ (Action <$> genErrors <*>) $
+            CreateSnapshot <$> genCorruption <*> pure label <*> genUnusedSnapshotName <*> genTableVar)
         | not (null unusedSnapshotNames)
-        , let genErrors = QC.frequency [
+          -- TODO: should errors and corruption be generated at the same time,
+          -- or should they be mutually exclusive?
+        , let genErrors = pure Nothing -- TODO: generate errors
+        , let genCorruption = QC.frequency [
                   (3, pure Nothing)
-                , (1, Just . Left <$> QC.arbitrary)
-                  -- TODO: generate errors, e.g., @Just . Right <$>
-                  -- QC.arbitrary@
+                , (1, Just <$> QC.arbitrary)
                 ]
         ]
-     ++ [ (5,  fmap Some $ Duplicate <$> genTableVar)
+     ++ [ (5,  fmap Some $ (Action <$> genErrors <*>) $
+            Duplicate <$> genTableVar)
         | length tableVars <= 5 -- no more than 5 tables at once
+        , let genErrors = pure Nothing -- TODO: generate errors
         ]
-     ++ [ (2,  fmap Some $ Union <$> genTableVar <*> genTableVar)
+     ++ [ (2,  fmap Some $ (Action <$> genErrors <*>) $
+            Union <$> genTableVar <*> genTableVar)
         | length tableVars <= 5 -- no more than 5 tables at once
+        , let genErrors = pure Nothing -- TODO: generate errors
         , False -- TODO: enable once table union is implemented
         ]
-     ++ [ (2,  fmap Some $ Unions <$> genUnionsTableVars)
+     ++ [ (2,  fmap Some $ (Action <$> genErrors <*>) $
+            Unions <$> genUnionsTableVars)
         | length tableVars <= 5 -- no more than 5 tables at once
+        , let genErrors = pure Nothing -- TODO: generate errors
         , False -- TODO: enable once table unions is implemented
         ]
 
@@ -1594,15 +1773,21 @@ arbitraryActionWithVars _ label ctx (ModelState st _stats) =
     genActionsCursor
       | null cursorVars = []
       | otherwise       =
-        [ (2,  fmap Some $ CloseCursor <$> genCursorVar)
-        , (10, fmap Some $ ReadCursor <$> (QC.getNonNegative <$> QC.arbitrary)
-                                      <*> genCursorVar)
+        [ (2,  fmap Some $ (Action <$> genErrors <*>) $
+            CloseCursor <$> genCursorVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
+        ]
+     ++ [ (10, fmap Some $ (Action <$> genErrors <*>) $
+            ReadCursor <$> (QC.getNonNegative <$> QC.arbitrary) <*> genCursorVar)
+        | let genErrors = pure Nothing -- TODO: generate errors
         ]
 
     genActionsBlobRef :: [(Int, Gen (Any (LockstepAction (ModelState h))))]
     genActionsBlobRef =
-        [ (5, fmap Some $ RetrieveBlobs <$> genBlobRefsVar)
+        [ (5, fmap Some $ (Action <$> genErrors <*>) $
+            RetrieveBlobs <$> genBlobRefsVar)
         | not (null blobRefsVars)
+        , let genErrors = pure Nothing -- TODO: generate errors
         ]
 
     fromRight ::
@@ -1665,8 +1850,57 @@ shrinkActionWithVars ::
   -> ModelState h
   -> LockstepAction (ModelState h) a
   -> [Any (LockstepAction (ModelState h))]
-shrinkActionWithVars _ctx _st = \case
-    New p conf -> [ Some $ New p conf' | conf' <- QC.shrink conf ]
+shrinkActionWithVars _ctx _st (Action merrs action') =
+        [ -- TODO: it's somewhat unfortunate, but we have to dynamically
+          -- construct evidence that @a@ is typeable, which is a requirement
+          -- coming from the @Some@ existential. Could we find a different way
+          -- to solve this using just regular constraints?
+          case dictIsTypeable action' of
+            Dict -> Some $ Action merrs' action'
+        | merrs' <- QC.shrink merrs ]
+     ++ [ Some $ Action merrs action''
+        | Some action'' <- shrinkAction'WithVars _ctx _st action'
+        ]
+
+-- | Dynamically construct evidence that the result type @a@ of an action is
+-- typeable.
+dictIsTypeable :: Typeable h => Action' h a -> Dict (Typeable a)
+dictIsTypeable = \case
+      New{}            -> Dict
+      Close{}          -> Dict
+      Lookups{}        -> Dict
+      RangeLookup{}    -> Dict
+      NewCursor{}      -> Dict
+      CloseCursor{}    -> Dict
+      ReadCursor{}     -> Dict
+      Updates{}        -> Dict
+      Inserts{}        -> Dict
+      Deletes{}        -> Dict
+      Mupserts{}       -> Dict
+      RetrieveBlobs{}  -> Dict
+      CreateSnapshot{} -> Dict
+      OpenSnapshot{}   -> Dict
+      DeleteSnapshot{} -> Dict
+      ListSnapshots{}  -> Dict
+      Duplicate{}      -> Dict
+      Union{}          -> Dict
+      Unions{}         -> Dict
+
+shrinkAction'WithVars ::
+     forall h a. (
+       Eq (Class.TableConfig h)
+     , Arbitrary (Class.TableConfig h)
+     , Typeable h
+     )
+  => ModelVarContext (ModelState h)
+  -> ModelState h
+  -> Action' h a
+  -> [Any (Action' h)]
+shrinkAction'WithVars _ctx _st a = case a of
+    New p conf -> [
+        Some $ New p conf'
+      | conf' <- QC.shrink conf
+      ]
 
     -- Shrink inserts and deletes towards updates.
     Updates upds tableVar -> [
@@ -1701,17 +1935,9 @@ shrinkActionWithVars _ctx _st = \case
       | tableVars' <- QC.liftShrink (const []) tableVars
       ]
 
-    Lookups ks tableVar -> [ Some $ Lookups ks' tableVar | ks' <- QC.shrink ks ]
-
-    -- Snapshots
-
-    CreateSnapshot merrs label name tableVar -> [
-        Some $ CreateSnapshot merrs' label name tableVar
-      | merrs' <- QC.shrink merrs
-      ]
-    OpenSnapshot pp merrs label name -> [
-        Some $ OpenSnapshot pp merrs' label name
-      | merrs' <- QC.shrink merrs
+    Lookups ks tableVar -> [
+        Some $ Lookups ks' tableVar
+      | ks' <- QC.shrink ks
       ]
 
     _ -> []
@@ -1803,7 +2029,7 @@ updateStats ::
   -> Val h a
   -> Stats
   -> Stats
-updateStats action lookUp modelBefore _modelAfter result =
+updateStats action@(Action _merrs action') lookUp modelBefore _modelAfter result =
       -- === Tags
       updSnapshotted
       -- === Final tags
@@ -1818,7 +2044,7 @@ updateStats action lookUp modelBefore _modelAfter result =
   where
     -- === Tags
 
-    updSnapshotted stats = case (action, result) of
+    updSnapshotted stats = case (action', result) of
       (CreateSnapshot _ _ name _, MEither (Right (MUnit ()))) -> stats {
           snapshotted = Set.insert name (snapshotted stats)
         }
@@ -1829,7 +2055,7 @@ updateStats action lookUp modelBefore _modelAfter result =
 
     -- === Final tags
 
-    updNumLookupsResults stats = case (action, result) of
+    updNumLookupsResults stats = case (action', result) of
       (Lookups _ _, MEither (Right (MVector lrs))) -> stats {
           numLookupsResults =
             let count :: (Int, Int, Int)
@@ -1843,7 +2069,7 @@ updateStats action lookUp modelBefore _modelAfter result =
         }
       _ -> stats
 
-    updNumUpdates stats = case (action, result) of
+    updNumUpdates stats = case (action', result) of
         (Updates upds _, MEither (Right (MUnit ()))) -> stats {
             numUpdates = countAll upds
           }
@@ -1880,7 +2106,7 @@ updateStats action lookUp modelBefore _modelAfter result =
         _ -> stats
 
     updNumActionsPerTable :: Stats -> Stats
-    updNumActionsPerTable stats = case action of
+    updNumActionsPerTable stats = case action' of
         New{}
           | MEither (Right (MTable table)) <- result -> initCount table
           | otherwise                                      -> stats
@@ -1941,7 +2167,7 @@ updateStats action lookUp modelBefore _modelAfter result =
                                                     (numActionsPerTable stats)
               }
 
-    updClosedTableSizes stats = case action of
+    updClosedTableSizes stats = case action' of
         Close tableVar
           | MTable t <- lookUp tableVar
           , let tid          = Model.tableID t
@@ -1953,7 +2179,7 @@ updateStats action lookUp modelBefore _modelAfter result =
              }
         _ -> stats
 
-    updParentTable stats = case (action, result) of
+    updParentTable stats = case (action', result) of
         (New{}, MEither (Right (MTable tbl))) ->
           stats {
             parentTable = Map.insert (Model.tableID tbl)
@@ -1983,7 +2209,7 @@ updateStats action lookUp modelBefore _modelAfter result =
         _ -> stats
 
     updDupTableActionLog stats | MEither (Right _) <- result =
-      case action of
+      case action' of
         Lookups     ks   tableVar
           | not (null ks)         -> updateLastActionLog tableVar
         RangeLookup r    tableVar
@@ -2059,7 +2285,7 @@ tagStep' ::
   -> [Tag]
 tagStep' (ModelState _stateBefore statsBefore,
           ModelState _stateAfter _statsAfter)
-          action result =
+          (Action _ action') result =
     catMaybes [
       tagSnapshotTwice
     , tagOpenExistingSnapshot
@@ -2072,51 +2298,51 @@ tagStep' (ModelState _stateBefore statsBefore,
     ]
   where
     tagSnapshotTwice
-      | CreateSnapshot _ _ name _ <- action
+      | CreateSnapshot _ _ name _ <- action'
       , name `Set.member` snapshotted statsBefore
       = Just SnapshotTwice
       | otherwise
       = Nothing
 
     tagOpenExistingSnapshot
-      | OpenSnapshot _ _ _ name <- action
+      | OpenSnapshot _ _ name <- action'
       , name `Set.member` snapshotted statsBefore
       = Just OpenExistingSnapshot
       | otherwise
       = Nothing
 
     tagOpenMissingSnapshot
-      | OpenSnapshot _ _ _ name <- action
+      | OpenSnapshot _ _ name <- action'
       , not (name `Set.member` snapshotted statsBefore)
       = Just OpenMissingSnapshot
       | otherwise
       = Nothing
 
     tagDeleteExistingSnapshot
-      | DeleteSnapshot name <- action
+      | DeleteSnapshot name <- action'
       , name `Set.member` snapshotted statsBefore
       = Just DeleteExistingSnapshot
       | otherwise
       = Nothing
 
     tagDeleteMissingSnapshot
-      | DeleteSnapshot name <- action
+      | DeleteSnapshot name <- action'
       , not (name `Set.member` snapshotted statsBefore)
       = Just DeleteMissingSnapshot
       | otherwise
       = Nothing
 
     tagCreateSnapshotCorruptedOrUncorrupted
-      | CreateSnapshot mcorrOrErrs _ name _ <- action
+      | CreateSnapshot mcorr _ name _ <- action'
       , MEither (Right (MUnit ())) <- result
-      = Just $ case mcorrOrErrs of
-          Just (Left (_ :: SilentCorruption)) -> CreateSnapshotCorrupted name
-          _                                   -> CreateSnapshotUncorrupted name
+      = Just $ case mcorr of
+          Just (_ :: SilentCorruption) -> CreateSnapshotCorrupted name
+          _                            -> CreateSnapshotUncorrupted name
       | otherwise
       = Nothing
 
     tagOpenSnapshotDetectsCorruption
-      | OpenSnapshot  _ _ _ name <- action
+      | OpenSnapshot _ _ name <- action'
       , MEither (Left (MErr (Model.ErrSnapshotCorrupted _))) <- result
       = Just (OpenSnapshotDetectsCorruption name)
       | otherwise

--- a/test/Test/Database/LSMTree/StateMachine/DL.hs
+++ b/test/Test/Database/LSMTree/StateMachine/DL.hs
@@ -54,7 +54,7 @@ prop_example =
 dl_example :: DL (Lockstep (ModelState R.Table)) ()
 dl_example = do
     -- Create an initial table and fill it with some inserts
-    var3 <- action $ New (PrettyProxy @((Key, Value, Blob))) (TableConfig {
+    var3 <- action $ Action Nothing $ New (PrettyProxy @((Key, Value, Blob))) (TableConfig {
           confMergePolicy = MergePolicyLazyLevelling
         , confSizeRatio = Four
         , confWriteBufferAlloc = AllocNumEntries (NumEntries 4)
@@ -70,7 +70,7 @@ dl_example = do
         ups = V.fromList
             . map (\(k,v) -> (k, Insert v Nothing))
             . Map.toList $ kvs
-    action $ Updates ups (unsafeMkGVar var3 (OpFromRight `OpComp` OpId))
+    action $ Action Nothing $ Updates ups (unsafeMkGVar var3 (OpFromRight `OpComp` OpId))
     -- This is a rather ugly assertion, and could be improved using some helper
     -- function(s). However, it does serve its purpose as checking that the
     -- insertions we just did were successful.


### PR DESCRIPTION
Instead of adding `Maybe Errors` to each constructor, which would probably lead to quite a bit of duplicated code, I opted to add a single top-level constructor that contains a `Maybe Errors` and an `Action'`. This `Action'` is a new data type that contains the interesting constructors, like `New` and `Updates`.

As a result of this change, there quite a few mechanical changes, but not much of it is interesting. However, having made this change, we are now ready to enable fault injection for all the actions whenever we want to.

