### PR TITLE
Propagate MergingRun's type parameter to Merge

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
@@ -95,7 +95,7 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
         , randomKey    = -- each run uses half of the possible keys
                          randomWord64OutOf (totalEntries `div` 2)
         , mergeMappend = Just (onDeserialisedValues ((+) @Word64))
-        , mergeType    = MergeMidLevel
+        , mergeType    = MergeTypeMidLevel
         }
     , benchMerge configWord64
         { name         = "word64-mix-collisions-x4-lastlevel"
@@ -106,7 +106,7 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
         , randomKey    = -- each run uses half of the possible keys
                          randomWord64OutOf (totalEntries `div` 2)
         , mergeMappend = Just (onDeserialisedValues ((+) @Word64))
-        , mergeType    = MergeLastLevel
+        , mergeType    = MergeTypeLastLevel
         }
     , benchMerge configWord64
         { name         = "word64-mix-collisions-x4-union"
@@ -117,14 +117,14 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
         , randomKey    = -- each run uses half of the possible keys
                          randomWord64OutOf (totalEntries `div` 2)
         , mergeMappend = Just (onDeserialisedValues ((+) @Word64))
-        , mergeType    = MergeUnion
+        , mergeType    = MergeTypeUnion
         }
       -- not writing anything at all
     , benchMerge configWord64
         { name         = "word64-delete-x4-lastlevel"
         , nentries     = totalEntries `splitInto` 4
         , fdeletes     = 1
-        , mergeType    = MergeLastLevel
+        , mergeType    = MergeTypeLastLevel
         }
       -- different key and value sizes
     , benchMerge configWord64
@@ -175,26 +175,26 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
         , nentries     = totalEntries `splitInto` 4
         , finserts     = 1
         , fdeletes     = 1
-        , mergeType    = MergeLastLevel
+        , mergeType    = MergeTypeLastLevel
         }
     , benchMerge configUTxO
         { name         = "utxo-x4+1-min-skewed-lastlevel"  -- live levelling merge
         , nentries     = totalEntries `distributed` [1, 1, 1, 1, 4]
         , finserts     = 1
         , fdeletes     = 1
-        , mergeType    = MergeLastLevel
+        , mergeType    = MergeTypeLastLevel
         }
     , benchMerge configUTxO
         { name         = "utxo-x4+1-max-skewed-lastlevel"  -- live levelling merge
         , nentries     = totalEntries `distributed` [1, 1, 1, 1, 16]
         , finserts     = 1
         , fdeletes     = 1
-        , mergeType    = MergeLastLevel
+        , mergeType    = MergeTypeLastLevel
         }
     , benchMerge configUTxOStaking
         { name         = "utxo-x2-tree-union"  -- binary union merge
         , nentries     = totalEntries `distributed` [4, 1]
-        , mergeType    = MergeUnion
+        , mergeType    = MergeTypeUnion
         }
     , benchMerge configUTxOStaking
         { name         = "utxo-x10-tree-level"  -- merge a whole table (for union)
@@ -203,7 +203,7 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
                                                     , 16, 16, 16
                                                     , 100  -- last level
                                                     ]
-        , mergeType    = MergeLastLevel
+        , mergeType    = MergeTypeLastLevel
         }
     ]
   where
@@ -323,7 +323,7 @@ defaultConfig = Config {
   , randomKey    = error "randomKey not implemented"
   , randomValue  = error "randomValue not implemented"
   , randomBlob   = error "randomBlob not implemented"
-  , mergeType    = MergeMidLevel
+  , mergeType    = MergeTypeMidLevel
   , mergeMappend = Nothing
   , stepSize     = maxBound  -- by default, just do in one go
   }

--- a/src-extras/Database/LSMTree/Extras/Generators.hs
+++ b/src-extras/Database/LSMTree/Extras/Generators.hs
@@ -55,7 +55,6 @@ import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
 import qualified Database.LSMTree.Internal.Merge as Merge
-import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.Page (PageNo (..))
 import           Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Serialise
@@ -564,17 +563,17 @@ instance Arbitrary BlobSpan where
 
 instance Arbitrary Merge.MergeType where
   arbitrary = QC.elements
-      [Merge.MergeMidLevel, Merge.MergeLastLevel, Merge.MergeUnion]
+      [Merge.MergeTypeMidLevel, Merge.MergeTypeLastLevel, Merge.MergeTypeUnion]
+  shrink Merge.MergeTypeMidLevel  = []
+  shrink Merge.MergeTypeLastLevel = [Merge.MergeTypeMidLevel]
+  shrink Merge.MergeTypeUnion     = [Merge.MergeTypeLastLevel]
+
+instance Arbitrary Merge.LevelMergeType where
+  arbitrary = QC.elements [Merge.MergeMidLevel, Merge.MergeLastLevel]
   shrink Merge.MergeMidLevel  = []
   shrink Merge.MergeLastLevel = [Merge.MergeMidLevel]
-  shrink Merge.MergeUnion     = [Merge.MergeLastLevel]
 
-instance Arbitrary MR.LevelMergeType where
-  arbitrary = QC.elements [MR.MergeMidLevel, MR.MergeLastLevel]
-  shrink MR.MergeMidLevel  = []
-  shrink MR.MergeLastLevel = [MR.MergeMidLevel]
-
-instance Arbitrary MR.TreeMergeType where
-  arbitrary = QC.elements [MR.MergeLevel, MR.MergeUnion]
-  shrink MR.MergeLevel = []
-  shrink MR.MergeUnion = [MR.MergeLevel]
+instance Arbitrary Merge.TreeMergeType where
+  arbitrary = QC.elements [Merge.MergeLevel, Merge.MergeUnion]
+  shrink Merge.MergeLevel = []
+  shrink Merge.MergeUnion = [Merge.MergeLevel]

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -299,33 +299,51 @@ deriving anyclass instance NoThunks Index
 -------------------------------------------------------------------------------}
 
 deriving stock instance Generic (TableContent m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           , NoThunks (StrictMVar m (MergingTreeState m h))
-                           ) => NoThunks (TableContent m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingRunState LevelMergeType m h))
+  , NoThunks (StrictMVar m (MergingTreeState m h))
+  ) => NoThunks (TableContent m h)
 
 deriving stock instance Generic (LevelsCache m h)
-deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
-                        => NoThunks (LevelsCache m h)
+deriving anyclass instance
+  (Typeable m, Typeable (PrimState m), Typeable h)
+  => NoThunks (LevelsCache m h)
 
 deriving stock instance Generic (Level m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           ) => NoThunks (Level m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingRunState LevelMergeType m h))
+  ) => NoThunks (Level m h)
 
 deriving stock instance Generic (IncomingRun m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           ) => NoThunks (IncomingRun m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingRunState LevelMergeType m h))
+  ) => NoThunks (IncomingRun m h)
 
 deriving stock instance Generic (UnionLevel m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           , NoThunks (StrictMVar m (MergingTreeState m h))
-                           ) => NoThunks (UnionLevel m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingTreeState m h))
+  ) => NoThunks (UnionLevel m h)
 
 deriving stock instance Generic MergePolicyForLevel
 deriving anyclass instance NoThunks MergePolicyForLevel
+
+{-------------------------------------------------------------------------------
+  MergingRun
+-------------------------------------------------------------------------------}
+
+deriving stock instance Generic (MergingRun t m h)
+deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
+                           , NoThunks (StrictMVar m (MergingRunState t m h))
+                           ) => NoThunks (MergingRun t m h)
+
+deriving stock instance Generic (MergingRunState t m h)
+deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
+                           , NoThunks t
+                           ) => NoThunks (MergingRunState t m h)
 
 deriving stock instance Generic NumRuns
 deriving anyclass instance NoThunks NumRuns
@@ -337,44 +355,35 @@ deriving stock instance Generic MergeKnownCompleted
 deriving anyclass instance NoThunks MergeKnownCompleted
 
 {-------------------------------------------------------------------------------
-  MergingRun
--------------------------------------------------------------------------------}
-
-deriving stock instance Generic (MergingRun t m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           ) => NoThunks (MergingRun t m h)
-
-deriving stock instance Generic (MergingRunState m h)
-deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
-                        => NoThunks (MergingRunState m h)
-
-{-------------------------------------------------------------------------------
   MergingTree
 -------------------------------------------------------------------------------}
 
 deriving stock instance Generic (MergingTree m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           , NoThunks (StrictMVar m (MergingTreeState m h))
-                           ) => NoThunks (MergingTree m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingTreeState m h))
+  ) => NoThunks (MergingTree m h)
 
 deriving stock instance Generic (MergingTreeState m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           , NoThunks (StrictMVar m (MergingTreeState m h))
-                           ) => NoThunks (MergingTreeState m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingRunState LevelMergeType m h))
+  , NoThunks (StrictMVar m (MergingRunState TreeMergeType m h))
+  , NoThunks (StrictMVar m (MergingTreeState m h))
+  ) => NoThunks (MergingTreeState m h)
 
 deriving stock instance Generic (PendingMerge m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           , NoThunks (StrictMVar m (MergingTreeState m h))
-                           ) => NoThunks (PendingMerge m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingRunState LevelMergeType m h))
+  , NoThunks (StrictMVar m (MergingTreeState m h))
+  ) => NoThunks (PendingMerge m h)
 
 deriving stock instance Generic (PreExistingRun m h)
-deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
-                           , NoThunks (StrictMVar m (MergingRunState m h))
-                           ) => NoThunks (PreExistingRun m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  , NoThunks (StrictMVar m (MergingRunState LevelMergeType m h))
+  ) => NoThunks (PreExistingRun m h)
 
 {-------------------------------------------------------------------------------
   Entry
@@ -454,12 +463,19 @@ deriving anyclass instance Typeable s
   Merge
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (Merge m h)
-deriving anyclass instance (Typeable m, Typeable (PrimState m), Typeable h)
-                        => NoThunks (Merge m h)
+deriving stock instance Generic (Merge t m h)
+deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
+                           , NoThunks t
+                           ) => NoThunks (Merge t m h)
 
 deriving stock instance Generic MergeType
 deriving anyclass instance NoThunks MergeType
+
+deriving stock instance Generic LevelMergeType
+deriving anyclass instance NoThunks LevelMergeType
+
+deriving stock instance Generic TreeMergeType
+deriving anyclass instance NoThunks TreeMergeType
 
 deriving stock instance Generic Merge.StepResult
 deriving anyclass instance NoThunks Merge.StepResult
@@ -673,10 +689,17 @@ instance (NoThunks a, Typeable a) => NoThunks (StrictTVar IO a) where
 instance (NoThunks a, Typeable a) => NoThunks (StrictMVar IO a) where
   showTypeOf (p :: Proxy (StrictMVar IO a)) = show $ typeRep p
   wNoThunks ctx var
-    | Just (Proxy :: Proxy (MergingRunState IO HandleIO))
+    -- TODO: Revisit which of these cases are still needed.
+    | Just (Proxy :: Proxy (MergingRunState LevelMergeType IO HandleIO))
         <- gcast (Proxy @a)
     = workAroundCheck
-    | Just (Proxy :: Proxy (MergingRunState IO HandleMock))
+    | Just (Proxy :: Proxy (MergingRunState TreeMergeType IO HandleIO))
+        <- gcast (Proxy @a)
+    = workAroundCheck
+    | Just (Proxy :: Proxy (MergingRunState LevelMergeType IO HandleMock))
+        <- gcast (Proxy @a)
+    = workAroundCheck
+    | Just (Proxy :: Proxy (MergingRunState TreeMergeType IO HandleMock))
         <- gcast (Proxy @a)
     = workAroundCheck
     | otherwise

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -104,12 +104,9 @@ class IsMergeType t where
   -- TODO: have @isLastLevel :: t -> Bool@ and @isUnion :: t -> Bool@ instead,
   -- like in the the prototype?
   toMergeType :: t -> MergeType
-  -- | Needed for deserialisation when opening snapshots.
-  fromMergeType :: MergeType -> Maybe t
 
 instance IsMergeType MergeType where
   toMergeType = id
-  fromMergeType = Just
 
 -- | Different types of merges created as part of a regular (non-union) level.
 --
@@ -127,10 +124,6 @@ instance IsMergeType LevelMergeType where
   toMergeType = \case
       MergeMidLevel  -> MergeTypeMidLevel
       MergeLastLevel -> MergeTypeLastLevel
-  fromMergeType = \case
-      MergeTypeMidLevel  -> Just MergeMidLevel
-      MergeTypeLastLevel -> Just MergeLastLevel
-      MergeTypeUnion     -> Nothing
 
 -- | Different types of merges created as part of the merging tree.
 data TreeMergeType = MergeLevel | MergeUnion
@@ -144,10 +137,6 @@ instance IsMergeType TreeMergeType where
   toMergeType = \case
       MergeLevel -> MergeTypeLastLevel  -- node merges are always last level
       MergeUnion -> MergeTypeUnion
-  fromMergeType = \case
-      MergeTypeMidLevel  -> Nothing
-      MergeTypeLastLevel -> Just MergeLevel
-      MergeTypeUnion     -> Just MergeUnion
 
 type Mappend = SerialisedValue -> SerialisedValue -> SerialisedValue
 

--- a/src/Database/LSMTree/Internal/MergingTree.hs
+++ b/src/Database/LSMTree/Internal/MergingTree.hs
@@ -30,7 +30,7 @@ import           Database.LSMTree.Internal.Run (Run)
 -- Looking at the implementation, tables are not just key-value pairs, but
 -- consist of runs. If each table was just a single run, unioning would involve
 -- a run merge similar to the one used for compaction (when a level is full),
--- but with a different merge type 'MergeUnion' that differs semantically:
+-- but with a different merge type 'MR.MergeUnion' that differs semantically:
 -- Here, runs don't represent updates (overwriting each other), but they each
 -- represent the full state of a table. There is no distinction between no
 -- entry and a 'Delete', between an 'Insert' and a 'Mupsert'.

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -160,14 +160,6 @@ newtype SuppliedCredits = SuppliedCredits { getSuppliedCredits :: Int }
 data SnapMergingRunState t r =
     SnapCompletedMerge !r
   | SnapOngoingMerge !(V.Vector r) !t
-    -- ^ While we use a specific, more restrictive merge type @t@ here (see
-    -- 'MR.IsMergeType'), we should always serialise it as a 'MergeType'.
-    -- Otherwise, if we for example accidentally deserialised a
-    -- @SnapMergingRunState LevelMergeType@ with @MergeLastLevel@ as a
-    -- @SnapMergingRunState TreeMergeType@, it would succeed with @MergeUnion@.
-    -- If we go via 'MergeType', the error will be detected. We could even
-    -- change the invariant about which merge type can occur in which part of
-    -- the table without having to change the serialisation format itself.
   deriving stock (Show, Eq, Functor, Foldable, Traversable)
 
 instance (NFData t, NFData r) => NFData (SnapMergingRunState t r) where

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -224,26 +224,12 @@ toSnapIncomingRun (Merging mergePolicy mergingRun) = do
         (SuppliedCredits suppliedCredits)
         smrs
 
--- | Only to be used for incoming runs! Merging runs inside a merging tree need
--- to use MR.TreeMergeType.
---
--- We could offer a more general type if 'Mr.MergingRunState' also had a type
--- parameter 't', but that adds quite a bit of noise.
 toSnapMergingRunState ::
-     MR.MergingRunState m h
-  -> SnapMergingRunState MR.LevelMergeType (Ref (Run m h))
-toSnapMergingRunState (MR.CompletedMerge r)  = SnapCompletedMerge r
-toSnapMergingRunState (MR.OngoingMerge rs m) =
-    -- The merge type conversion should never fail, since the Merge was
-    -- constructed based on the restricted LevelMergeType.
-    -- To make the types align, we could either:
-    -- * store the restricted type inside MergingRun itself, but this would
-    --   just duplicate information, not provide any safety.
-    -- * Also add the type parameter to Merge, adding complexity there.
-    let mt = Merge.mergeType m
-    in case MR.fromMergeType mt of
-      Just t  -> SnapOngoingMerge rs t
-      Nothing -> error ("invalid MergeType: " <> show mt)
+     MR.MergingRunState t m h
+  -> SnapMergingRunState t (Ref (Run m h))
+toSnapMergingRunState = \case
+    MR.CompletedMerge r  -> SnapCompletedMerge r
+    MR.OngoingMerge rs m -> SnapOngoingMerge rs (Merge.narrowMergeType m)
 
 {-------------------------------------------------------------------------------
   Write Buffer

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -221,7 +221,7 @@ toSnapMergingRunState ::
   -> SnapMergingRunState t (Ref (Run m h))
 toSnapMergingRunState = \case
     MR.CompletedMerge r  -> SnapCompletedMerge r
-    MR.OngoingMerge rs m -> SnapOngoingMerge rs (Merge.narrowMergeType m)
+    MR.OngoingMerge rs m -> SnapOngoingMerge rs (Merge.mergeType m)
 
 {-------------------------------------------------------------------------------
   Write Buffer

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -560,15 +560,15 @@ instance DecodeVersioned SuppliedCredits where
 -- MergeType
 
 instance Encode MergeType  where
-  encode MergeMidLevel  = encodeWord 0
-  encode MergeLastLevel = encodeWord 1
-  encode MergeUnion     = encodeWord 2
+  encode MergeTypeMidLevel  = encodeWord 0
+  encode MergeTypeLastLevel = encodeWord 1
+  encode MergeTypeUnion     = encodeWord 2
 
 instance DecodeVersioned MergeType where
   decodeVersioned V0 = do
       tag <- decodeWord
       case tag of
-        0 -> pure MergeMidLevel
-        1 -> pure MergeLastLevel
-        2 -> pure MergeUnion
+        0 -> pure MergeTypeMidLevel
+        1 -> pure MergeTypeLastLevel
+        2 -> pure MergeTypeUnion
         _ -> fail ("[MergeType] Unexpected tag: " <> show tag)

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -31,7 +31,6 @@ import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.CRC32C
 import qualified Database.LSMTree.Internal.CRC32C as FS
 import           Database.LSMTree.Internal.Entry
-import           Database.LSMTree.Internal.Merge (MergeType (..))
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun (NumRuns (..))
 import qualified Database.LSMTree.Internal.MergingRun as MR
@@ -523,7 +522,7 @@ instance DecodeVersioned MergePolicyForLevel where
 
 -- SnapMergingRunState
 
-instance MR.IsMergeType t => Encode (SnapMergingRunState t RunNumber) where
+instance Encode t => Encode (SnapMergingRunState t RunNumber) where
   encode (SnapCompletedMerge x) =
          encodeListLen 2
       <> encodeWord 0
@@ -532,21 +531,15 @@ instance MR.IsMergeType t => Encode (SnapMergingRunState t RunNumber) where
          encodeListLen 3
       <> encodeWord 1
       <> encode rs
-         -- always encode the full MergeType, see SnapOngoingMerge
-      <> encode @MergeType (MR.toMergeType mt)
+      <> encode mt
 
-instance MR.IsMergeType t => DecodeVersioned (SnapMergingRunState t RunNumber) where
+instance DecodeVersioned t => DecodeVersioned (SnapMergingRunState t RunNumber) where
   decodeVersioned v@V0 = do
       n <- decodeListLen
       tag <- decodeWord
       case (n, tag) of
         (2, 0) -> SnapCompletedMerge <$> decodeVersioned v
-        (3, 1) -> do
-          rs <- decodeVersioned v
-          mt <- decodeVersioned @MergeType v
-          case MR.fromMergeType mt of
-            Just t  -> return (SnapOngoingMerge rs t)
-            Nothing -> fail ("[SnapMergingRunState] Invalid merge type: " <> show mt)
+        (3, 1) -> SnapOngoingMerge <$> decodeVersioned v <*> decodeVersioned v
         _ -> fail ("[SnapMergingRunState] Unexpected combination of list length and tag: " <> show (n, tag))
 
 -- SuppliedCredits
@@ -559,16 +552,36 @@ instance DecodeVersioned SuppliedCredits where
 
 -- MergeType
 
-instance Encode MergeType  where
-  encode MergeTypeMidLevel  = encodeWord 0
-  encode MergeTypeLastLevel = encodeWord 1
-  encode MergeTypeUnion     = encodeWord 2
+instance Encode MR.LevelMergeType  where
+  encode MR.MergeMidLevel  = encodeWord 0
+  encode MR.MergeLastLevel = encodeWord 1
 
-instance DecodeVersioned MergeType where
+instance DecodeVersioned MR.LevelMergeType where
   decodeVersioned V0 = do
       tag <- decodeWord
       case tag of
-        0 -> pure MergeTypeMidLevel
-        1 -> pure MergeTypeLastLevel
-        2 -> pure MergeTypeUnion
-        _ -> fail ("[MergeType] Unexpected tag: " <> show tag)
+        0 -> pure MR.MergeMidLevel
+        1 -> pure MR.MergeLastLevel
+        _ -> fail ("[LevelMergeType] Unexpected tag: " <> show tag)
+
+-- | We start the tags for these merge types at an offset. This way, if we
+-- serialise @MR.MergeMidLevel :: MR.LevelMergeType@ as 0 and then accidentally
+-- try deserialising it as a @MR.TreeMergeType@, that will fail.
+--
+-- However, 'MR.LevelMergeType' and 'MR.TreeMergeType' are only different
+-- (overlapping) subsets of 'MR.MergeType'. In particular, 'MR.MergeLastLevel'
+-- and 'MR.MergeLevel' are semantically the same. Encoding them as the same
+-- number leaves the door open to relaxing the restrictions on which merge types
+-- can occur where, e.g. decoding them as a general 'MR.MergeType', without
+-- having to change the file format.
+instance Encode MR.TreeMergeType  where
+  encode MR.MergeLevel = encodeWord 1
+  encode MR.MergeUnion = encodeWord 2
+
+instance DecodeVersioned MR.TreeMergeType where
+  decodeVersioned V0 = do
+      tag <- decodeWord
+      case tag of
+        1 -> pure MR.MergeLevel
+        2 -> pure MR.MergeUnion
+        _ -> fail ("[TreeMergeType] Unexpected tag: " <> show tag)

--- a/test/Test/Database/LSMTree/Internal/Merge.hs
+++ b/test/Test/Database/LSMTree/Internal/Merge.hs
@@ -196,11 +196,11 @@ mergeWriteBuffers :: MergeType
                   -> [Map SerialisedKey SerialisedEntry]
                   ->  Map SerialisedKey SerialisedEntry
 mergeWriteBuffers = \case
-    MergeMidLevel  -> Map.unionsWith (Entry.combine mappendValues)
-    MergeLastLevel -> Map.filter (not . isDelete)
-                    . Map.unionsWith (Entry.combine mappendValues)
-    MergeUnion     -> Map.filter (not . isDelete)
-                    . Map.unionsWith (Entry.combineUnion mappendValues)
+    MergeTypeMidLevel  -> Map.unionsWith (Entry.combine mappendValues)
+    MergeTypeLastLevel -> Map.filter (not . isDelete)
+                        . Map.unionsWith (Entry.combine mappendValues)
+    MergeTypeUnion     -> Map.filter (not . isDelete)
+                        . Map.unionsWith (Entry.combineUnion mappendValues)
   where
     isDelete Entry.Delete = True
     isDelete _            = False

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -15,7 +15,6 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry
-import           Database.LSMTree.Internal.Merge (MergeType (..))
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun hiding (SuppliedCredits)
 import           Database.LSMTree.Internal.RunNumber
@@ -173,7 +172,8 @@ testAll test = [
     , test (Proxy @MergePolicyForLevel)
     , test (Proxy @(SnapMergingRunState LevelMergeType RunNumber))
     , test (Proxy @SuppliedCredits)
-    , test (Proxy @MergeType)
+    , test (Proxy @LevelMergeType)
+    , test (Proxy @TreeMergeType)
     ]
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Follow-up to https://github.com/IntersectMBO/lsm-tree/pull/573#discussion_r1956126412

This makes `MergingRun`'s `t` parameter not just phantom, but actually stores the merge type as `:: t` internally. As a result, we also have to move the `IsMergeType` class further up in the module hierarchy.

