### PR TITLE
Loosen the size constraints on serialized keys

### DIFF
--- a/src/Database/LSMTree/Internal/Index.hs
+++ b/src/Database/LSMTree/Internal/Index.hs
@@ -2,6 +2,11 @@
     Provides support for working with fence pointer indexes of different types
     and their accumulators.
 
+    Keys used with an index are subject to the key size constraints of the
+    concrete type of the index. These constraints are stated in the descriptions
+    of the modules "Database.LSMTree.Internal.Index.Compact" and
+    "Database.LSMTree.Internal.Index.Ordinary", respectively.
+
     Part of the functionality that this module provides is the construction of
     serialised indexes in a mostly incremental fashion. The incremental part of
     serialisation is provided through index accumulators, while the
@@ -138,13 +143,7 @@ fromSBS Ordinary input = second OrdinaryIndex <$> Ordinary.fromSBS input
     an index under incremental construction.
 
     Incremental index construction is only guaranteed to work correctly when the
-    following conditions are met:
-
-      * The supplied key ranges do not overlap and are given in ascending order.
-
-      * Each supplied key is at least 8 and at most 65535 bytes long.
-        (Currently, construction of compact indexes needs the former and
-        construction of ordinary indexes needs the latter bound.)
+    supplied key ranges do not overlap and are given in ascending order.
 -}
 data IndexAcc s = CompactIndexAcc  (IndexCompactAcc  s)
                 | OrdinaryIndexAcc (IndexOrdinaryAcc s)

--- a/src/Database/LSMTree/Internal/Index/Compact.hs
+++ b/src/Database/LSMTree/Internal/Index/Compact.hs
@@ -1,5 +1,7 @@
 -- | A compact fence-pointer index for uniformly distributed keys.
 --
+-- Keys used with a compact index must be at least 8 bytes long.
+--
 -- TODO: add utility functions for clash probability calculations
 --
 module Database.LSMTree.Internal.Index.Compact (

--- a/src/Database/LSMTree/Internal/Index/Ordinary.hs
+++ b/src/Database/LSMTree/Internal/Index/Ordinary.hs
@@ -1,6 +1,10 @@
 {- HLINT ignore "Avoid restricted alias" -}
 
--- | A general-purpose fence pointer index.
+{-|
+    A general-purpose fence pointer index.
+
+    Keys used with an ordinary index must be smaller than 64 KiB.
+-}
 module Database.LSMTree.Internal.Index.Ordinary
 (
     IndexOrdinary (IndexOrdinary),


### PR DESCRIPTION
Currently, the documentation of the general index interface requires serialized keys to satisfy the key size constraints of compact and ordinary indexes. This pull request changes the documentation such that it requires only the key size constraint of the actually used index type to be satisfied.
