### PR TITLE
QLS: test that we do not swallow exceptions

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -401,6 +401,7 @@ test-suite lsm-tree-test
     Test.System.Posix.Fcntl.NoCache
     Test.Util.Arbitrary
     Test.Util.FS
+    Test.Util.FS.Error
     Test.Util.Orphans
     Test.Util.PrettyProxy
     Test.Util.QC
@@ -410,6 +411,7 @@ test-suite lsm-tree-test
 
   build-depends:
     , ansi-terminal
+    , barbies
     , base
     , bitvec
     , bytestring

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -447,6 +447,7 @@ test-suite lsm-tree-test
     , quickcheck-instances
     , quickcheck-lockstep
     , random
+    , safe-wild-cards
     , semialign
     , split
     , stm

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -119,7 +119,6 @@ import           System.Directory (removeDirectoryRecursive)
 import           System.FS.API (FsError (..), HasFS, MountPoint (..), mkFsPath)
 import           System.FS.BlockIO.API (HasBlockIO, defaultIOCtxParams)
 import           System.FS.BlockIO.IO (ioHasBlockIO)
-import           System.FS.BlockIO.Sim (simErrorHasBlockIO)
 import           System.FS.IO (HandleIO, ioHasFS)
 import qualified System.FS.Sim.Error as FSSim
 import           System.FS.Sim.Error (Errors)
@@ -144,6 +143,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 import           Test.Util.FS (approximateEqStream, noRemoveDirectoryRecursiveE,
                      propNoOpenHandles, propNumOpenHandles)
+import           Test.Util.FS.Error
 import           Test.Util.PrettyProxy
 import           Test.Util.QC (Choice)
 import qualified Test.Util.QLS as QLS
@@ -191,7 +191,7 @@ propLockstep_ModelIOImpl =
       (Proxy @(ModelState ModelIO.Table))
       acquire
       release
-      (\r (session, errsVar) -> do
+      (\r (session, errsVar, logVar) -> do
             faultsVar <- newMutVar []
             let
               env :: RealEnv ModelIO.Table IO
@@ -199,6 +199,7 @@ propLockstep_ModelIOImpl =
                   envSession = session
                 , envHandlers = [handler]
                 , envErrors = errsVar
+                , envErrorsLog = logVar
                 , envInjectFaultResults = faultsVar
                 }
             prop <- runReaderT r env
@@ -207,14 +208,15 @@ propLockstep_ModelIOImpl =
         )
       tagFinalState'
   where
-    acquire :: IO (Class.Session ModelIO.Table IO, StrictTVar IO Errors)
+    acquire :: IO (Class.Session ModelIO.Table IO, StrictTVar IO Errors, StrictTVar IO ErrorsLog)
     acquire = do
       session <- Class.openSession ModelIO.NoSessionArgs
       errsVar <- newTVarIO FSSim.emptyErrors
-      pure (session, errsVar)
+      logVar <- newTVarIO emptyLog
+      pure (session, errsVar, logVar)
 
-    release :: (Class.Session ModelIO.Table IO, StrictTVar IO Errors) -> IO ()
-    release (session, _) = Class.closeSession session
+    release :: (Class.Session ModelIO.Table IO, StrictTVar IO Errors, StrictTVar IO ErrorsLog) -> IO ()
+    release (session, _, _) = Class.closeSession session
 
     handler :: Handler IO (Maybe Model.Err)
     handler = Handler $ pure . handler'
@@ -292,7 +294,7 @@ propLockstep_RealImpl_RealFS_IO tr =
       (Proxy @(ModelState R.Table))
       acquire
       release
-      (\r (_, session, errsVar) -> do
+      (\r (_, session, errsVar, logVar) -> do
             faultsVar <- newMutVar []
             let
               env :: RealEnv R.Table IO
@@ -300,6 +302,7 @@ propLockstep_RealImpl_RealFS_IO tr =
                   envSession = session
                 , envHandlers = realErrorHandlers @IO
                 , envErrors = errsVar
+                , envErrorsLog = logVar
                 , envInjectFaultResults = faultsVar
                 }
             prop <- runReaderT r env
@@ -308,15 +311,16 @@ propLockstep_RealImpl_RealFS_IO tr =
         )
       tagFinalState'
   where
-    acquire :: IO (FilePath, Class.Session R.Table IO, StrictTVar IO Errors)
+    acquire :: IO (FilePath, Class.Session R.Table IO, StrictTVar IO Errors, StrictTVar IO ErrorsLog)
     acquire = do
         (tmpDir, hasFS, hasBlockIO) <- createSystemTempDirectory "prop_lockstepIO_RealImpl_RealFS"
         session <- R.openSession tr hasFS hasBlockIO (mkFsPath [])
         errsVar <- newTVarIO FSSim.emptyErrors
-        pure (tmpDir, session, errsVar)
+        logVar <- newTVarIO emptyLog
+        pure (tmpDir, session, errsVar, logVar)
 
-    release :: (FilePath, Class.Session R.Table IO, StrictTVar IO Errors) -> IO Property
-    release (tmpDir, !session, _) = do
+    release :: (FilePath, Class.Session R.Table IO, StrictTVar IO Errors, StrictTVar IO ErrorsLog) -> IO Property
+    release (tmpDir, !session, _, _) = do
         !prop <- propNoThunks session
         R.closeSession session
         removeDirectoryRecursive tmpDir
@@ -331,7 +335,7 @@ propLockstep_RealImpl_MockFS_IO tr =
       (Proxy @(ModelState R.Table))
       (acquire_RealImpl_MockFS tr)
       release_RealImpl_MockFS
-      (\r (_, session, errsVar) -> do
+      (\r (_, session, errsVar, logVar) -> do
             faultsVar <- newMutVar []
             let
               env :: RealEnv R.Table IO
@@ -339,6 +343,7 @@ propLockstep_RealImpl_MockFS_IO tr =
                   envSession = session
                 , envHandlers = realErrorHandlers @IO
                 , envErrors = errsVar
+                , envErrorsLog = logVar
                 , envInjectFaultResults = faultsVar
                 }
             prop <- runReaderT r env
@@ -364,7 +369,7 @@ propLockstep_RealImpl_MockFS_IOSim tr actions =
   where
     prop :: forall s. PropertyM (IOSim s) Property
     prop = do
-        (fsVar, session, errsVar) <- QC.run (acquire_RealImpl_MockFS tr)
+        (fsVar, session, errsVar, logVar) <- QC.run (acquire_RealImpl_MockFS tr)
         faultsVar <- QC.run $ newMutVar []
         let
           env :: RealEnv R.Table (IOSim s)
@@ -372,13 +377,14 @@ propLockstep_RealImpl_MockFS_IOSim tr actions =
               envSession = session
             , envHandlers = realErrorHandlers @(IOSim s)
             , envErrors = errsVar
+            , envErrorsLog = logVar
             , envInjectFaultResults = faultsVar
             }
         void $ QD.runPropertyReaderT
                 (QD.runActions @(Lockstep (ModelState R.Table)) actions)
                 env
         faults <- QC.run $ readMutVar faultsVar
-        p <- QC.run $ release_RealImpl_MockFS (fsVar, session, errsVar)
+        p <- QC.run $ release_RealImpl_MockFS (fsVar, session, errsVar, logVar)
         pure
           $ tagFinalState actions tagFinalState'
           $ QC.tabulate "Fault results" (fmap show faults)
@@ -387,19 +393,20 @@ propLockstep_RealImpl_MockFS_IOSim tr actions =
 acquire_RealImpl_MockFS ::
      R.IOLike m
   => Tracer m R.LSMTreeTrace
-  -> m (StrictTMVar m MockFS, Class.Session R.Table m, StrictTVar m Errors)
+  -> m (StrictTMVar m MockFS, Class.Session R.Table m, StrictTVar m Errors, StrictTVar m ErrorsLog)
 acquire_RealImpl_MockFS tr = do
     fsVar <- newTMVarIO MockFS.empty
     errsVar <- newTVarIO FSSim.emptyErrors
-    (hfs, hbio) <- simErrorHasBlockIO fsVar errsVar
+    logVar <- newTVarIO emptyLog
+    (hfs, hbio) <- simErrorHasBlockIOLogged fsVar errsVar logVar
     session <- R.openSession tr hfs hbio (mkFsPath [])
-    pure (fsVar, session, errsVar)
+    pure (fsVar, session, errsVar, logVar)
 
 release_RealImpl_MockFS ::
      R.IOLike m
-  => (StrictTMVar m MockFS, Class.Session R.Table m, StrictTVar m Errors)
+  => (StrictTMVar m MockFS, Class.Session R.Table m, StrictTVar m Errors, StrictTVar m ErrorsLog)
   -> m Property
-release_RealImpl_MockFS (fsVar, session, _) = do
+release_RealImpl_MockFS (fsVar, session, _, _) = do
     sts <- getAllSessionTables session
     forM_ sts $ \(SomeTable t) -> R.close t
     scs <- getAllSessionCursors session
@@ -1088,6 +1095,11 @@ data RealEnv h m = RealEnv {
     -- variable can be used to enable/disable errors locally, for example on a
     -- per-action basis.
   , envErrors             :: !(StrictTVar m Errors)
+    -- | A variable holding a log of simulated disk faults.
+    --
+    -- Errors that are injected into the simulated file system using 'envErrors'
+    -- are logged here.
+  , envErrorsLog          :: !(StrictTVar m ErrorsLog)
     -- | The results of fault injection
   , envInjectFaultResults :: !(MutVar (PrimState m) [InjectFaultResult])
   }
@@ -1670,19 +1682,26 @@ runRealWithInjectedErrors s env merrs k rollback =
       modifyMutVar faultsVar (InjectFaultNone s :)
       catchErr handlers k
     Just errs -> do
+      atomically $ writeTVar logVar emptyLog
       eith <- catchErr handlers $ FSSim.withErrors errsVar errs k
+      errsLog <- readTVarIO logVar
+      -- TODO: turn assertions on @errsLog@ into 'Property's
       case eith of
         Left (Model.ErrDiskFault _) -> do
           modifyMutVar faultsVar (InjectFaultInducedError s :)
+          assert (countNoisyErrors errsLog >= 1) $ pure ()
           pure eith
-        Left _ ->
+        Left _ -> do
+          assert (countNoisyErrors errsLog == 0) $ pure ()
           pure eith
         Right x -> do
           modifyMutVar faultsVar (InjectFaultAccidentalSuccess s :)
           rollback x
+          assert (countNoisyErrors errsLog == 0) $ pure ()
           pure $ Left $ Model.ErrDiskFault ("dummy: " <> s)
   where
     errsVar = envErrors env
+    logVar = envErrorsLog env
     faultsVar = envInjectFaultResults env
     handlers = envHandlers env
 

--- a/test/Test/Database/LSMTree/StateMachine/DL.hs
+++ b/test/Test/Database/LSMTree/StateMachine/DL.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 {-# OPTIONS_GHC -Wno-unused-do-bind #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -5,6 +7,8 @@ module Test.Database.LSMTree.StateMachine.DL (
     tests
   ) where
 
+import           Control.Monad (void)
+import           Control.RefCount
 import           Control.Tracer
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
@@ -12,20 +16,28 @@ import           Database.LSMTree as R
 import qualified Database.LSMTree.Model.Session as Model (fromSomeTable, tables)
 import qualified Database.LSMTree.Model.Table as Model (values)
 import           Prelude
+import           SafeWildCards
+import           System.FS.API.Types
+import           System.FS.Sim.Error hiding (Blob)
+import qualified System.FS.Sim.Stream as Stream
+import           System.FS.Sim.Stream (Stream)
 import           Test.Database.LSMTree.StateMachine hiding (tests)
 import           Test.Database.LSMTree.StateMachine.Op
-import           Test.QuickCheck as QC
+import           Test.QuickCheck as QC hiding (label)
 import           Test.QuickCheck.DynamicLogic
 import qualified Test.QuickCheck.Gen as QC
 import qualified Test.QuickCheck.Random as QC
 import           Test.QuickCheck.StateModel.Lockstep
-import           Test.Tasty (TestTree, testGroup)
+import qualified Test.QuickCheck.StateModel.Lockstep.Defaults as QLS
+import           Test.QuickCheck.StateModel.Variables
+import           Test.Tasty (TestTree, testGroup, withResource)
 import qualified Test.Tasty.QuickCheck as QC
 import           Test.Util.PrettyProxy
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.StateMachine.DL" [
       QC.testProperty "prop_example" prop_example
+    , test_noSwallowedExceptions
     ]
 
 instance DynLogicModel (Lockstep (ModelState R.Table))
@@ -80,3 +92,203 @@ dl_example = do
             | Just tbl <- (Model.fromSomeTable @Key @Value @Blob smTbl)
             -> Map.size (Model.values tbl) == Map.size kvs
           _ -> False
+
+{-------------------------------------------------------------------------------
+  Swallowed exceptions
+-------------------------------------------------------------------------------}
+
+-- | See 'prop_noSwallowedExceptions'.
+--
+-- Forgotten reference checks are disabled completely, because we allow bugs
+-- (like forgotten references) in exception unsafe code where we inject disk
+-- faults.
+test_noSwallowedExceptions :: TestTree
+test_noSwallowedExceptions =
+    withResource
+      (checkForgottenRefs >> disableForgottenRefChecks)
+      (\_ -> enableForgottenRefChecks) $ \ !_ ->
+      QC.testProperty "prop_noSwallowedExceptions" prop_noSwallowedExceptions
+
+-- | Test that the @lsm-tree@ library does not swallow exceptions.
+--
+-- A functional requirement for the @lsm-tree@ library is that all exceptions
+-- are properly communicated to the user. An alternative way of stating this
+-- requirement is that no exceptions should be /swallowed/ by the library. We
+-- test this requirement by running the state machine test with injected disk
+-- errors using @fs-sim@, and asserting that no exceptions are swallowed.
+--
+-- The state machine test compares the SUT against a model by checking that
+-- their responses to @lsm-tree@ actions are the same. As of writing this
+-- property, not all of these actions on the SUT are guaranteed to be fully
+-- exception safe. As a result, an exception might leave the database (i.e.,
+-- session, tables, cursors) in an inconsistent state. The results of subsequent
+-- operations on the inconsistent database should be considered undefined. As
+-- such, it is highly likely that the SUT and model will thereafter disagree,
+-- leading to a failing property.
+--
+-- Still, we want to run the swallowed error assertion on /all/ operations,
+-- regardless of whether they are exception safe. We overcome this problem by
+-- /definitely/ injecting errors (and running a swallowed error assertion) for
+-- the last action in a sequence of actions. This may leave the final database
+-- state inconsistent, but that is okay. However, we'll also have to disable
+-- sanity checks like 'NoCheckCleanup', 'NoCheckFS', and 'NoCheckRefs', because
+-- they are likely to fail if the database is an inconsistent state.
+--
+-- TODO: running only one swallowed exception assertion per action sequence is
+-- restrictive, but this automatically improves as we make more actions
+-- exceptions safe. When we generate injected errors for these errors by default
+-- (in @arbitraryWithVars@), the swallowed exception assertion automatically
+-- runs for those actions as well.
+prop_noSwallowedExceptions :: Property
+prop_noSwallowedExceptions = forAllDL dl_noSwallowExceptions runner
+  where
+    -- disable all file system and reference checks
+    runner = propLockstep_RealImpl_MockFS_IO tr NoCheckCleanup NoCheckFS NoCheckRefs
+    tr = nullTracer
+
+-- | Run any number of actions using the default actions generator, and finally
+-- run a single action with errors *definitely* enabled.
+dl_noSwallowExceptions :: DL (Lockstep (ModelState R.Table)) ()
+dl_noSwallowExceptions = do
+    -- Run any number of actions as normal
+    anyActions_
+
+    -- Generate a single action as normal
+    varCtx <- getVarContextDL
+    st <- getModelStateDL
+    let
+      gen = QLS.arbitraryAction varCtx st
+      predicate (Some a) = QLS.precondition st a
+      shr (Some a) = QLS.shrinkAction varCtx st a
+    Some a <- forAllQ $ withGenQ gen predicate shr
+
+    -- Overwrite the maybe errors of the generated action with *definitely* just
+    -- errors.
+    case a of
+      Action _merrs a' -> do
+        HasNoVariables errs <-
+          forAllQ $ hasNoVariablesQ $ withGenQ arbitraryErrors (\_ -> True) shrinkErrors
+        -- Run the modified action
+        void $ action $ Action (Just errs) a'
+
+-- | Generate an 'Errors' with arbitrary probabilities of exceptions.
+--
+-- The default 'genErrors' from @fs-sim@ generates streams of 'Maybe' exceptions
+-- with a fixed probability for a 'Just' or 'Nothing'. The version here
+-- generates an arbitrary probability for each stream, which should generate a
+-- larger variety of 'Errors' structures.
+--
+-- TODO: upstream to @fs-sim@ to replase the default 'genErrors'?
+arbitraryErrors :: Gen Errors
+arbitraryErrors = do
+    dumpStateE                <- genStream arbitrary
+    hCloseE                   <- genStream arbitrary
+    hTruncateE                <- genStream arbitrary
+    doesDirectoryExistE       <- genStream arbitrary
+    doesFileExistE            <- genStream arbitrary
+    hOpenE                    <- genStream arbitrary
+    hSeekE                    <- genStream arbitrary
+    hGetSomeE                 <- genErrorStreamGetSome
+    hGetSomeAtE               <- genErrorStreamGetSome
+    hPutSomeE                 <- genErrorStreamPutSome
+    hGetSizeE                 <- genStream arbitrary
+    createDirectoryE          <- genStream arbitrary
+    createDirectoryIfMissingE <- genStream arbitrary
+    listDirectoryE            <- genStream arbitrary
+    removeDirectoryRecursiveE <- genStream arbitrary
+    removeFileE               <- genStream arbitrary
+    renameFileE               <- genStream arbitrary
+    hGetBufSomeE              <- genErrorStreamGetSome
+    hGetBufSomeAtE            <- genErrorStreamGetSome
+    hPutBufSomeE              <- genErrorStreamPutSome
+    hPutBufSomeAtE            <- genErrorStreamPutSome
+    return $ filterErrors Errors {..}
+  where
+    -- Generate a stream using 'genLikelihoods' for its 'Maybe' elements.
+    genStream :: forall a. Gen a -> Gen (Stream a)
+    genStream genA = do
+        (pNothing, pJust) <- genLikelihoods
+        Stream.genInfinite $ Stream.genMaybe pNothing pJust genA
+
+    -- Generate two integer likelihoods for 'Nothing' and 'Just' constructors.
+    genLikelihoods :: Gen (Int, Int)
+    genLikelihoods = do
+      NonNegative pNothing <- arbitrary
+      NonNegative pJust <- arbitrary
+      if pNothing == 0 then
+        pure (0, 1)
+      else if pJust == 0 then
+        pure (1, 0)
+      else
+        pure (pNothing, pJust)
+
+    genErrorStreamGetSome :: Gen ErrorStreamGetSome
+    genErrorStreamGetSome = genStream $ liftArbitrary2 arbitrary arbitrary
+
+    genErrorStreamPutSome :: Gen ErrorStreamPutSome
+    genErrorStreamPutSome = genStream $ flip liftArbitrary2 arbitrary $ do
+        errorType <- arbitrary
+        maybePutCorruption <- liftArbitrary genPutCorruption
+        pure (errorType, maybePutCorruption)
+
+    genPutCorruption :: Gen PutCorruption
+    genPutCorruption = oneof [
+          PartialWrite <$> arbitrary
+        , SubstituteWithJunk <$> arbitrary
+        ]
+      where
+        _coveredAllCases x = case x of
+          PartialWrite{}       -> pure ()
+          SubstituteWithJunk{} -> pure ()
+
+    -- TODO: there is one case where an 'FsReachEOF' error is swallowed. Is that
+    -- valid behaviour, or should we change it?
+    filterErrors errs = errs {
+          hGetBufSomeE = Stream.filter (not . isFsReachedEOF) (hGetBufSomeE errs)
+        }
+
+    isFsReachedEOF Nothing = False
+    isFsReachedEOF (Just (Left e)) = case e of
+        FsReachedEOF -> True
+        _            -> False
+    isFsReachedEOF (Just (Right _)) = False
+
+-- | Shrink each error stream and all error stream elements.
+--
+-- The default 'shrink' from @fs-sim@ shrinks only the stream structure, but not
+-- the elements contained in those streams.
+--
+-- TODO: upstream to @fs-sim@ to replace the default 'shrink'?
+shrinkErrors :: Errors -> [Errors]
+shrinkErrors err@($(fields 'Errors))
+    | allNull err = []
+    | otherwise = emptyErrors : concatMap (filter (not . allNull))
+        [ (\s' -> err { dumpStateE = s' })                <$> Stream.liftShrinkStream shrink dumpStateE
+        , (\s' -> err { hOpenE = s' })                    <$> Stream.liftShrinkStream shrink hOpenE
+        , (\s' -> err { hCloseE = s' })                   <$> Stream.liftShrinkStream shrink hCloseE
+        , (\s' -> err { hSeekE = s' })                    <$> Stream.liftShrinkStream shrink hSeekE
+        , (\s' -> err { hGetSomeE = s' })                 <$> Stream.liftShrinkStream shrink hGetSomeE
+        , (\s' -> err { hGetSomeAtE = s' })               <$> Stream.liftShrinkStream shrink hGetSomeAtE
+        , (\s' -> err { hPutSomeE = s' })                 <$> Stream.liftShrinkStream shrink hPutSomeE
+        , (\s' -> err { hTruncateE = s' })                <$> Stream.liftShrinkStream shrink hTruncateE
+        , (\s' -> err { hGetSizeE = s' })                 <$> Stream.liftShrinkStream shrink hGetSizeE
+        , (\s' -> err { createDirectoryE = s' })          <$> Stream.liftShrinkStream shrink createDirectoryE
+        , (\s' -> err { createDirectoryIfMissingE = s' }) <$> Stream.liftShrinkStream shrink createDirectoryIfMissingE
+        , (\s' -> err { listDirectoryE = s' })            <$> Stream.liftShrinkStream shrink listDirectoryE
+        , (\s' -> err { doesDirectoryExistE = s' })       <$> Stream.liftShrinkStream shrink doesDirectoryExistE
+        , (\s' -> err { doesFileExistE = s' })            <$> Stream.liftShrinkStream shrink doesFileExistE
+        , (\s' -> err { removeDirectoryRecursiveE = s' }) <$> Stream.liftShrinkStream shrink removeDirectoryRecursiveE
+        , (\s' -> err { removeFileE = s' })               <$> Stream.liftShrinkStream shrink removeFileE
+        , (\s' -> err { renameFileE = s' })               <$> Stream.liftShrinkStream shrink renameFileE
+        , (\s' -> err { hGetBufSomeE = s' })              <$> Stream.liftShrinkStream shrink hGetBufSomeE
+        , (\s' -> err { hGetBufSomeAtE = s' })            <$> Stream.liftShrinkStream shrink hGetBufSomeAtE
+        , (\s' -> err { hPutBufSomeE = s' })              <$> Stream.liftShrinkStream shrink hPutBufSomeE
+        , (\s' -> err { hPutBufSomeAtE = s' })            <$> Stream.liftShrinkStream shrink hPutBufSomeAtE
+        ]
+
+deriving stock instance Enum FsErrorType
+deriving stock instance Bounded FsErrorType
+
+instance Arbitrary FsErrorType where
+  arbitrary = arbitraryBoundedEnum
+  shrink = shrinkBoundedEnum

--- a/test/Test/Database/LSMTree/StateMachine/DL.hs
+++ b/test/Test/Database/LSMTree/StateMachine/DL.hs
@@ -25,7 +25,6 @@ import           Test.Util.PrettyProxy
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.StateMachine.DL" [
-
       QC.testProperty "prop_example" prop_example
     ]
 
@@ -44,7 +43,7 @@ prop_example =
     -- Run the example ...
     forAllDL dl_example $
     -- ... with the given lockstep property
-    propLockstep_RealImpl_MockFS_IO tr
+    propLockstep_RealImpl_MockFS_IO tr CheckCleanup CheckFS CheckRefs
   where
     -- To enable tracing, use something like @show `contramap` stdoutTracer@
     -- instead

--- a/test/Test/Util/FS/Error.hs
+++ b/test/Test/Util/FS/Error.hs
@@ -1,0 +1,226 @@
+module Test.Util.FS.Error (
+    -- * Errors log
+    ErrorsLog
+  , emptyLog
+  , countNoisyErrors
+    -- * Logged HasFS and HasBlockIO
+  , simErrorHasBlockIOLogged
+  , simErrorHasFS
+  ) where
+
+import           Control.Concurrent.Class.MonadMVar (MonadMVar)
+import           Control.Concurrent.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Primitive
+import           Data.Functor.Barbie
+import           Data.Monoid
+import           GHC.Generics
+import           System.FS.API
+import           System.FS.BlockIO.API
+import           System.FS.BlockIO.Sim
+import           System.FS.Sim.Error
+import           System.FS.Sim.MockFS (HandleMock, MockFS)
+import           System.FS.Sim.Stream
+
+{-------------------------------------------------------------------------------
+  Higher-kinded datatype
+-------------------------------------------------------------------------------}
+
+-- | A higher-kinded datatype (HKD) version of the 'Errors' type. 'Errors' is
+-- equivalent to @'HKD' 'Stream'@.
+--
+-- 'HKD' has instances for @barbies@ classes, which lets us manipulate 'HKD'
+-- with a small set of combinators like 'bpure' and 'bmap'. This makes writing
+-- functions operating on 'HKD' less arduous than writing the functions out
+-- fully.
+--
+-- TODO: admittedly, we are not getting the full benefis from higher-kinded
+-- datatypes because 'Errors' and 'HasFS' are not HKDs, meaning we still have to
+-- write some stuff out manually, like in 'simErrorHasFSLogged'. We could take
+-- the HKD approach even further, but it is likely going to require quite a bit
+-- of boilerplate to set up before we can start programming with HKDs. At that
+-- point one might ask whether the costs of defining the HKD boilerplate
+-- outweighs the benefits of programming with HKDs.
+data HKD f = HKD {
+    dumpStateHKD               :: f FsErrorType
+  , hOpenHKD                   :: f FsErrorType
+  , hCloseHKD                  :: f FsErrorType
+  , hSeekHKD                   :: f FsErrorType
+  , hGetSomeHKD                :: f (Either FsErrorType Partial)
+  , hGetSomeAtHKD              :: f (Either FsErrorType Partial)
+  , hPutSomeHKD                :: f (Either (FsErrorType, Maybe PutCorruption) Partial)
+  , hTruncateHKD               :: f FsErrorType
+  , hGetSizeHKD                :: f FsErrorType
+  , createDirectoryHKD         :: f FsErrorType
+  , createDirectoryIfMissingHKD:: f FsErrorType
+  , listDirectoryHKD           :: f FsErrorType
+  , doesDirectoryExistHKD      :: f FsErrorType
+  , doesFileExistHKD           :: f FsErrorType
+  , removeDirectoryRecursiveHKD:: f FsErrorType
+  , removeFileHKD              :: f FsErrorType
+  , renameFileHKD              :: f FsErrorType
+  , hGetBufSomeHKD             :: f (Either FsErrorType Partial)
+  , hGetBufSomeAtHKD           :: f (Either FsErrorType Partial)
+  , hPutBufSomeHKD             :: f (Either (FsErrorType, Maybe PutCorruption) Partial)
+  , hPutBufSomeAtHKD           :: f (Either (FsErrorType, Maybe PutCorruption) Partial)
+  }
+  deriving stock Generic
+
+deriving anyclass instance FunctorB HKD
+deriving anyclass instance ApplicativeB HKD
+deriving anyclass instance TraversableB HKD
+deriving anyclass instance ConstraintsB HKD
+
+{-------------------------------------------------------------------------------
+  Errors log
+-------------------------------------------------------------------------------}
+
+type ErrorsLog = HKD []
+
+emptyLog :: ErrorsLog
+emptyLog = bpure []
+
+{-------------------------------------------------------------------------------
+  Count noisy errors in the log
+-------------------------------------------------------------------------------}
+
+class IsNoisy a where
+  isNoisy :: a -> Bool
+
+instance IsNoisy FsErrorType where
+  isNoisy _ = True
+
+instance IsNoisy (Either FsErrorType b) where
+  isNoisy (Left x)  = isNoisy x
+  isNoisy (Right _) = False
+
+instance IsNoisy (Either (FsErrorType, b) c) where
+  isNoisy (Left (x, _)) = isNoisy x
+  isNoisy (Right _)     = False
+
+countNoisyErrors :: ErrorsLog -> Int
+countNoisyErrors = getSum . bfoldMapC @IsNoisy (Sum . length . Prelude.filter isNoisy)
+
+{-------------------------------------------------------------------------------
+  Logged HasFS and HasBlockIO
+-------------------------------------------------------------------------------}
+
+-- | Like 'simErrorHasFSLogged', but also produces a simulated 'HasBlockIO'.
+simErrorHasBlockIOLogged ::
+     forall m. (MonadCatch m, MonadMVar m, PrimMonad m, MonadSTM m)
+  => StrictTMVar m MockFS
+  -> StrictTVar m Errors
+  -> StrictTVar m (HKD [])
+  -> m (HasFS m HandleMock, HasBlockIO m HandleMock)
+simErrorHasBlockIOLogged fsVar errorsVar logVar = do
+    let hfs = simErrorHasFSLogged fsVar errorsVar logVar
+    hbio <- fromHasFS hfs
+    pure (hfs, hbio)
+
+-- | Produce a simulated file system with injected errors and a logger for those
+-- errors.
+--
+-- Every time a 'HasFS' primitive is used and an error from 'Errors' is used, it
+-- will be logged in 'ErrorsLog'.
+simErrorHasFSLogged ::
+     forall m. (MonadSTM m, MonadThrow m, PrimMonad m)
+  => StrictTMVar m MockFS
+  -> StrictTVar m Errors
+  -> StrictTVar m ErrorsLog
+  -> HasFS m HandleMock
+simErrorHasFSLogged fsVar errorsVar logVar =
+    HasFS {
+        dumpState = do
+          addToLog dumpStateE dumpStateHKD (\l x -> l { dumpStateHKD = x} )
+          dumpState hfs
+      , hOpen = \a b -> do
+          addToLog hOpenE hOpenHKD (\l x -> l { hOpenHKD = x} )
+          hOpen hfs a b
+      , hClose = \a -> do
+          addToLog hCloseE hCloseHKD (\l x -> l { hCloseHKD = x} )
+          hClose hfs a
+      , hIsOpen = \a ->
+          hIsOpen hfs a
+      , hSeek = \a b c -> do
+          addToLog hSeekE hSeekHKD (\l x -> l { hSeekHKD = x} )
+          hSeek hfs a b c
+      , hGetSome = \a b -> do
+          addToLog hGetSomeE hGetSomeHKD (\l x -> l { hGetSomeHKD = x} )
+          hGetSome hfs a b
+      , hGetSomeAt = \a b c -> do
+          addToLog hGetSomeAtE hGetSomeAtHKD (\l x -> l { hGetSomeAtHKD = x} )
+          hGetSomeAt hfs a b c
+      , hPutSome = \a b -> do
+          addToLog hPutSomeE hPutSomeHKD (\l x -> l { hPutSomeHKD = x} )
+          hPutSome hfs a b
+      , hTruncate = \a b -> do
+          addToLog hTruncateE hTruncateHKD (\l x -> l { hTruncateHKD = x} )
+          hTruncate hfs a b
+      , hGetSize = \a -> do
+          addToLog hGetSizeE hGetSizeHKD (\l x -> l { hGetSizeHKD = x} )
+          hGetSize hfs a
+      , createDirectory = \a -> do
+          addToLog createDirectoryE createDirectoryHKD (\l x -> l { createDirectoryHKD = x} )
+          createDirectory hfs a
+      , createDirectoryIfMissing = \a b -> do
+          addToLog createDirectoryIfMissingE createDirectoryIfMissingHKD (\l x -> l { createDirectoryIfMissingHKD = x} )
+          createDirectoryIfMissing hfs a b
+      , listDirectory = \a -> do
+          addToLog listDirectoryE listDirectoryHKD (\l x -> l { listDirectoryHKD = x} )
+          listDirectory hfs a
+      , doesDirectoryExist = \a -> do
+          addToLog doesDirectoryExistE doesDirectoryExistHKD (\l x -> l { doesDirectoryExistHKD = x} )
+          doesDirectoryExist hfs a
+      , doesFileExist = \a -> do
+          addToLog doesFileExistE doesFileExistHKD (\l x -> l { doesFileExistHKD = x} )
+          doesFileExist hfs a
+      , removeDirectoryRecursive = \a -> do
+          addToLog removeDirectoryRecursiveE removeDirectoryRecursiveHKD (\l x -> l { removeDirectoryRecursiveHKD = x} )
+          removeDirectoryRecursive hfs a
+      , removeFile = \a -> do
+          addToLog removeFileE removeFileHKD (\l x -> l { removeFileHKD = x} )
+          removeFile hfs a
+      , renameFile = \a b -> do
+          addToLog renameFileE renameFileHKD (\l x -> l { renameFileHKD = x} )
+          renameFile hfs a b
+      , mkFsErrorPath = mkFsErrorPath hfs
+      , unsafeToFilePath = unsafeToFilePath hfs
+      , hGetBufSome = \a b c d -> do
+          addToLog hGetBufSomeE hGetBufSomeHKD (\l x -> l { hGetBufSomeHKD = x} )
+          hGetBufSome hfs a b c d
+      , hGetBufSomeAt = \a b c d e -> do
+          addToLog hGetBufSomeAtE hGetBufSomeAtHKD (\l x -> l { hGetBufSomeAtHKD = x} )
+          hGetBufSomeAt hfs a b c d e
+      , hPutBufSome = \a b c d -> do
+          addToLog hPutBufSomeE hPutBufSomeHKD (\l x -> l { hPutBufSomeHKD = x} )
+          hPutBufSome hfs a b c d
+      , hPutBufSomeAt = \a b c d e -> do
+          addToLog hPutBufSomeAtE hPutBufSomeAtHKD (\l x -> l { hPutBufSomeAtHKD = x} )
+          hPutBufSomeAt hfs a b c d e
+      }
+  where
+    hfs = simErrorHasFS fsVar errorsVar
+
+    -- Peek at the first element from an error stream and add it to the errors
+    -- log if it is 'Just' an error.
+    addToLog ::
+         (Errors -> Stream e)
+      -> (ErrorsLog -> [e])
+      -> (ErrorsLog -> [e] -> ErrorsLog)
+      -> m ()
+    addToLog getE getL setL = do
+        errors <- readTVarIO errorsVar
+        logs <- readTVarIO logVar
+        let s = getE errors
+        let x = peek s
+        case x of
+          Nothing -> pure ()
+          Just y ->
+            atomically $ writeTVar logVar $
+              setL logs $ (++ [y]) $ getL logs
+
+    -- Peek at the first element from an error stream.
+    peek :: Stream a -> Maybe a
+    peek (UnsafeStream _ xs) = case xs of
+      []    -> Nothing
+      (x:_) -> x


### PR DESCRIPTION
This PR adds
* Functionality to log errors injected by `fs-sim`
* Assertions in the state machine to check that always see disk errors if we inject *noisy* errors through `fs-sim`. That is, the assertion checks that no noisy errors are swallowed.
* Finally, we add and test a dynamic logic (`DL`) formula that injects errors into *all* `lsm-tree` actions and runs the swallow error assertion afterwards.