### PR TITLE
Change credit scaling, using nominal vs merge credit

### DIFF
--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -331,6 +331,12 @@ deriving anyclass instance
 deriving stock instance Generic MergePolicyForLevel
 deriving anyclass instance NoThunks MergePolicyForLevel
 
+deriving stock instance Generic NominalDebt
+deriving anyclass instance NoThunks NominalDebt
+
+deriving stock instance Generic NominalCredits
+deriving anyclass instance NoThunks NominalCredits
+
 {-------------------------------------------------------------------------------
   MergingRun
 -------------------------------------------------------------------------------}

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -354,6 +354,12 @@ deriving anyclass instance ( Typeable m, Typeable (PrimState m), Typeable h
 deriving stock instance Generic NumRuns
 deriving anyclass instance NoThunks NumRuns
 
+deriving stock instance Generic MergeDebt
+deriving anyclass instance NoThunks MergeDebt
+
+deriving stock instance Generic MergeCredits
+deriving anyclass instance NoThunks MergeCredits
+
 deriving stock instance Generic (CreditsVar s)
 deriving anyclass instance Typeable s => NoThunks (CreditsVar s)
 

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -28,6 +28,7 @@ module Database.LSMTree.Internal.MergeSchedule (
     -- * Exported for cabal-docspec
   , maxRunSize
     -- * Credits
+  , MergeDebt (..)
   , MergeCredits (..)
   , supplyCredits
   , creditThresholdForLevel
@@ -58,7 +59,7 @@ import           Database.LSMTree.Internal.Entry (Entry, NumEntries (..),
 import           Database.LSMTree.Internal.Index (Index)
 import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.MergingRun (MergeCredits (..),
-                     MergingRun, NumRuns (..))
+                     MergeDebt, MergingRun, NumRuns (..))
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.MergingTree (MergingTree)
 import           Database.LSMTree.Internal.Paths (ActiveDir, RunFsPaths (..),
@@ -411,7 +412,7 @@ newIncomingSingleRun tr ln r = do
   -> LevelNo
   -> MergePolicyForLevel
   -> NumRuns
-  -> NumEntries
+  -> MergeDebt
   -> Ref (Run IO h)
   -> IO (IncomingRun IO h) #-}
 newIncomingCompletedMergingRun ::
@@ -421,7 +422,7 @@ newIncomingCompletedMergingRun ::
   -> LevelNo
   -> MergePolicyForLevel
   -> NumRuns
-  -> NumEntries
+  -> MergeDebt
   -> Ref (Run m h)
   -> m (IncomingRun m h)
 newIncomingCompletedMergingRun tr reg ln mergePolicy nr ne r = do

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -117,14 +117,17 @@ data MergeTrace =
       RunBloomFilterAlloc
       MergePolicyForLevel
       MR.LevelMergeType
+  | TraceNewMergeSingleRun
+      NumEntries -- ^ Size of run
+      RunNumber
+  | TraceNewMergeCompletedRun
+      NumEntries -- ^ Size of run
+      RunNumber
   | TraceCompletedMerge  -- TODO: currently not traced for Incremental merges
       NumEntries -- ^ Size of output run
       RunNumber
     -- | This is traced at the latest point the merge could complete.
   | TraceExpectCompletedMerge
-      RunNumber
-  | TraceNewMergeSingleRun
-      NumEntries -- ^ Size of run
       RunNumber
   deriving stock Show
 
@@ -450,7 +453,7 @@ newIncomingCompletedMergingRun ::
   -> m (IncomingRun m h)
 newIncomingCompletedMergingRun tr conf reg ln mergePolicy nr mergeDebt r = do
     traceWith tr $ AtLevel ln $
-      TraceNewMergeSingleRun (Run.size r) (Run.runFsPathsNumber r)
+      TraceNewMergeCompletedRun (Run.size r) (Run.runFsPathsNumber r)
     mr <- withRollback reg (MR.newCompleted nr mergeDebt r) releaseRef
     let nominalDebt    = nominalDebtForLevel conf ln
         nominalCredits = nominalDebtAsCredits nominalDebt

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -198,6 +198,7 @@ unsafeNew _ mergeNumEntries _ _
   = throwIO (ErrorCall "MergingRun.new: run size exceeds maximum of 2^40")
 
 unsafeNew mergeNumRuns mergeNumEntries knownCompleted state = do
+    --TODO: make sure we have the right physical credits for a completed merge.
     mergeCreditsVar <- CreditsVar <$> newPrimVar 0
     case state of
       OngoingMerge{}   -> assert (knownCompleted == MergeMaybeCompleted) (pure ())

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -14,6 +14,7 @@ module Database.LSMTree.Internal.MergingRun (
   , expectCompleted
   , snapshot
   , numRuns
+  , totalMergeDebt
 
     -- * Merge types
   , IsMergeType (..)

--- a/src/Database/LSMTree/Internal/Paths.hs
+++ b/src/Database/LSMTree/Internal/Paths.hs
@@ -79,8 +79,8 @@ newtype ActiveDir = ActiveDir { getActiveDir :: FsPath }
 activeDir :: SessionRoot -> ActiveDir
 activeDir (SessionRoot dir) = ActiveDir (dir </> mkFsPath ["active"])
 
-runPath :: SessionRoot -> RunNumber -> RunFsPaths
-runPath root = RunFsPaths (getActiveDir (activeDir root))
+runPath :: ActiveDir -> RunNumber -> RunFsPaths
+runPath (ActiveDir dir) = RunFsPaths dir
 
 snapshotsDir :: SessionRoot -> FsPath
 snapshotsDir (SessionRoot dir) = dir </> mkFsPath ["snapshots"]

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -463,10 +463,10 @@ fromSnapLevels reg hfs hbio conf uc resolve dir (SnapLevels levels) =
     fromSnapIncomingRun ln (SnapSingleRun run) =
         newIncomingSingleRun tr ln =<< dupRun run
 
-    fromSnapIncomingRun ln (SnapMergingRun mpfl nr md mc smrs) = do
+    fromSnapIncomingRun ln (SnapMergingRun mpfl nr md nc smrs) = do
       case smrs of
         SnapCompletedMerge r ->
-          newIncomingCompletedMergingRun tr reg ln mpfl nr md r
+          newIncomingCompletedMergingRun tr conf reg ln mpfl nr md r
 
         SnapOngoingMerge rs mt -> do
           ir <- newIncomingMergingRun tr hfs hbio dir uc
@@ -475,7 +475,7 @@ fromSnapLevels reg hfs hbio conf uc resolve dir (SnapLevels levels) =
           -- When a snapshot is created, merge progress is lost, so we have to
           -- redo merging work here. The MergeCredits in SnapMergingRun tracks
           -- how many credits were supplied before the snapshot was taken.
-          supplyCreditsIncomingRun conf ln ir mc
+          supplyCreditsIncomingRun conf ln ir nc
           return ir
 
     dupRun r = withRollback reg (dupRef r) releaseRef

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -27,7 +27,6 @@ import           Control.ActionRegistry
 import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.Concurrent.Class.MonadSTM (MonadSTM)
 import           Control.DeepSeq (NFData (..))
-import           Control.Exception (assert)
 import           Control.Monad (void)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow (MonadMask)
@@ -472,8 +471,7 @@ fromSnapLevels reg hfs hbio conf uc resolve dir (SnapLevels levels) =
           -- When a snapshot is created, merge progress is lost, so we have to
           -- redo merging work here. The MergeCredits in SnapMergingRun tracks
           -- how many credits were supplied before the snapshot was taken.
-          leftoverCredits <- supplyCreditsIncomingRun conf ln ir mc
-          assert (leftoverCredits == 0) $ return ()
+          supplyCreditsIncomingRun conf ln ir mc
           return ir
 
     dupRun r = withRollback reg (dupRef r) releaseRef

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -115,7 +115,7 @@ data SnapshotMetaData = SnapshotMetaData {
     -- | The shape of the levels of the LSM tree.
   , snapMetaLevels    :: !(SnapLevels RunNumber)
   }
-  deriving stock (Show, Eq)
+  deriving stock Eq
 
 instance NFData SnapshotMetaData where
   rnf (SnapshotMetaData a b c d e) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e
@@ -125,14 +125,14 @@ instance NFData SnapshotMetaData where
 -------------------------------------------------------------------------------}
 
 newtype SnapLevels r = SnapLevels { getSnapLevels :: V.Vector (SnapLevel r) }
-  deriving stock (Show, Eq, Functor, Foldable, Traversable)
+  deriving stock (Eq, Functor, Foldable, Traversable)
   deriving newtype NFData
 
 data SnapLevel r = SnapLevel {
     snapIncoming     :: !(SnapIncomingRun r)
   , snapResidentRuns :: !(V.Vector r)
   }
-  deriving stock (Show, Eq, Functor, Foldable, Traversable)
+  deriving stock (Eq, Functor, Foldable, Traversable)
 
 instance NFData r => NFData (SnapLevel r) where
   rnf (SnapLevel a b) = rnf a `seq` rnf b
@@ -144,7 +144,7 @@ data SnapIncomingRun r =
                    !SuppliedCredits
                    !(SnapMergingRunState MR.LevelMergeType r)
   | SnapSingleRun !r
-  deriving stock (Show, Eq, Functor, Foldable, Traversable)
+  deriving stock (Eq, Functor, Foldable, Traversable)
 
 instance NFData r => NFData (SnapIncomingRun r) where
   rnf (SnapMergingRun a b c d e) =
@@ -154,13 +154,13 @@ instance NFData r => NFData (SnapIncomingRun r) where
 -- | The total number of supplied credits. This total is used on snapshot load
 -- to restore merging work that was lost when the snapshot was created.
 newtype SuppliedCredits = SuppliedCredits { getSuppliedCredits :: Int }
-  deriving stock (Show, Eq, Read)
+  deriving stock (Eq, Read)
   deriving newtype NFData
 
 data SnapMergingRunState t r =
     SnapCompletedMerge !r
   | SnapOngoingMerge !(V.Vector r) !t
-  deriving stock (Show, Eq, Functor, Foldable, Traversable)
+  deriving stock (Eq, Functor, Foldable, Traversable)
 
 instance (NFData t, NFData r) => NFData (SnapMergingRunState t r) where
   rnf (SnapCompletedMerge a) = rnf a

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -199,7 +199,8 @@ toSnapIncomingRun ::
   => IncomingRun m h
   -> m (SnapIncomingRun (Ref (Run m h)))
 toSnapIncomingRun (Single r) = pure (SnapSingleRun r)
-toSnapIncomingRun (Merging mergePolicy mergingRun) = do
+toSnapIncomingRun (Merging mergePolicy _mergeNominalDebt _mergeNominalCreditVar
+                           mergingRun) = do
     -- We need to know how many credits were supplied so we can restore merge
     -- work on snapshot load.
     (mergingRunState,

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -204,7 +204,7 @@ toSnapIncomingRun (Merging mergePolicy _mergeNominalDebt _mergeNominalCreditVar
     -- We need to know how many credits were supplied so we can restore merge
     -- work on snapshot load.
     (mergingRunState,
-     MR.SuppliedCredits (MR.Credits suppliedCredits),
+     MR.SuppliedCredits (MergeCredits suppliedCredits),
      mergeNumRuns,
      mergeNumEntries) <- MR.snapshot mergingRun
     -- TODO: MR.snapshot needs to return duplicated run references, and we
@@ -473,7 +473,7 @@ fromSnapLevels reg hfs hbio conf uc resolve dir (SnapLevels levels) =
           -- When a snapshot is created, merge progress is lost, so we
           -- have to redo merging work here. SuppliedCredits tracks how
           -- many credits were supplied before the snapshot was taken.
-          leftoverCredits <- supplyCreditsIncomingRun conf ln ir (MR.Credits sc)
+          leftoverCredits <- supplyCreditsIncomingRun conf ln ir (MergeCredits sc)
           assert (leftoverCredits == 0) $ return ()
           return ir
 

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -542,13 +542,13 @@ instance DecodeVersioned t => DecodeVersioned (SnapMergingRunState t RunNumber) 
         (3, 1) -> SnapOngoingMerge <$> decodeVersioned v <*> decodeVersioned v
         _ -> fail ("[SnapMergingRunState] Unexpected combination of list length and tag: " <> show (n, tag))
 
--- SuppliedCredits
+-- MergeCredits and MergeDebt
 
-instance Encode SuppliedCredits where
-  encode (SuppliedCredits x) = encodeInt x
+instance Encode MergeCredits where
+  encode (MergeCredits x) = encodeInt x
 
-instance DecodeVersioned SuppliedCredits where
-  decodeVersioned V0 = SuppliedCredits <$> decodeInt
+instance DecodeVersioned MergeCredits where
+  decodeVersioned V0 = MergeCredits <$> decodeInt
 
 instance Encode MergeDebt where
   encode (MergeDebt (MergeCredits x)) = encodeInt x

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -474,13 +474,13 @@ instance DecodeVersioned RunNumber where
 -- SnapIncomingRun
 
 instance Encode (SnapIncomingRun RunNumber) where
-  encode (SnapMergingRun mpfl nr ne sc smrs) =
+  encode (SnapMergingRun mpfl nr md nc smrs) =
        encodeListLen 6
     <> encodeWord 0
     <> encode mpfl
     <> encode nr
-    <> encode ne
-    <> encode sc
+    <> encode md
+    <> encode nc
     <> encode smrs
   encode (SnapSingleRun x) =
        encodeListLen 2
@@ -542,13 +542,13 @@ instance DecodeVersioned t => DecodeVersioned (SnapMergingRunState t RunNumber) 
         (3, 1) -> SnapOngoingMerge <$> decodeVersioned v <*> decodeVersioned v
         _ -> fail ("[SnapMergingRunState] Unexpected combination of list length and tag: " <> show (n, tag))
 
--- MergeCredits and MergeDebt
+-- NominalCredits and MergeDebt
 
-instance Encode MergeCredits where
-  encode (MergeCredits x) = encodeInt x
+instance Encode NominalCredits where
+  encode (NominalCredits x) = encodeInt x
 
-instance DecodeVersioned MergeCredits where
-  decodeVersioned V0 = MergeCredits <$> decodeInt
+instance DecodeVersioned NominalCredits where
+  decodeVersioned V0 = NominalCredits <$> decodeInt
 
 instance Encode MergeDebt where
   encode (MergeDebt (MergeCredits x)) = encodeInt x

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -550,6 +550,12 @@ instance Encode SuppliedCredits where
 instance DecodeVersioned SuppliedCredits where
   decodeVersioned V0 = SuppliedCredits <$> decodeInt
 
+instance Encode MergeDebt where
+  encode (MergeDebt (MergeCredits x)) = encodeInt x
+
+instance DecodeVersioned MergeDebt where
+  decodeVersioned V0 = (MergeDebt . MergeCredits) <$> decodeInt
+
 -- MergeType
 
 instance Encode MR.LevelMergeType  where

--- a/test/Test/Database/LSMTree/Internal/MergingRun.hs
+++ b/test/Test/Database/LSMTree/Internal/MergingRun.hs
@@ -37,7 +37,7 @@ prop_CreditsPair spentCredits unspentCredits =
 deriving newtype instance Enum SpentCredits
 deriving newtype instance Enum UnspentCredits
 
-deriving stock instance Show Credits
+deriving stock instance Show MergeCredits
 deriving stock instance Show SpentCredits
 deriving stock instance Show UnspentCredits
 

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -171,8 +171,8 @@ testAll test = [
     , test (Proxy @NumRuns)
     , test (Proxy @MergePolicyForLevel)
     , test (Proxy @(SnapMergingRunState LevelMergeType RunNumber))
-    , test (Proxy @MergeCredits)
     , test (Proxy @MergeDebt)
+    , test (Proxy @NominalCredits)
     , test (Proxy @LevelMergeType)
     , test (Proxy @TreeMergeType)
     ]
@@ -303,6 +303,7 @@ instance Arbitrary t => Arbitrary (SnapMergingRunState t RunNumber) where
 
 deriving newtype instance Arbitrary MergeDebt
 deriving newtype instance Arbitrary MergeCredits
+deriving newtype instance Arbitrary NominalCredits
 
 {-------------------------------------------------------------------------------
   Show
@@ -315,3 +316,4 @@ deriving stock instance Show r => Show (SnapIncomingRun r)
 deriving stock instance (Show t, Show r) => Show (SnapMergingRunState t r)
 deriving stock instance Show MergeDebt
 deriving stock instance Show MergeCredits
+deriving stock instance Show NominalCredits

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -16,7 +16,7 @@ import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.MergeSchedule
-import           Database.LSMTree.Internal.MergingRun hiding (SuppliedCredits)
+import           Database.LSMTree.Internal.MergingRun
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.Snapshot.Codec
@@ -171,7 +171,7 @@ testAll test = [
     , test (Proxy @NumRuns)
     , test (Proxy @MergePolicyForLevel)
     , test (Proxy @(SnapMergingRunState LevelMergeType RunNumber))
-    , test (Proxy @SuppliedCredits)
+    , test (Proxy @MergeCredits)
     , test (Proxy @MergeDebt)
     , test (Proxy @LevelMergeType)
     , test (Proxy @TreeMergeType)
@@ -301,7 +301,6 @@ instance Arbitrary t => Arbitrary (SnapMergingRunState t RunNumber) where
   shrink (SnapOngoingMerge x y) =
       [ SnapOngoingMerge x' y' | (x', y') <- shrink (x, y) ]
 
-deriving newtype instance Arbitrary SuppliedCredits
 deriving newtype instance Arbitrary MergeDebt
 deriving newtype instance Arbitrary MergeCredits
 
@@ -314,7 +313,5 @@ deriving stock instance Show r => Show (SnapLevels r)
 deriving stock instance Show r => Show (SnapLevel r)
 deriving stock instance Show r => Show (SnapIncomingRun r)
 deriving stock instance (Show t, Show r) => Show (SnapMergingRunState t r)
-deriving stock instance Show SuppliedCredits
 deriving stock instance Show MergeDebt
 deriving stock instance Show MergeCredits
-

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -172,6 +172,7 @@ testAll test = [
     , test (Proxy @MergePolicyForLevel)
     , test (Proxy @(SnapMergingRunState LevelMergeType RunNumber))
     , test (Proxy @SuppliedCredits)
+    , test (Proxy @MergeDebt)
     , test (Proxy @LevelMergeType)
     , test (Proxy @TreeMergeType)
     ]
@@ -301,6 +302,8 @@ instance Arbitrary t => Arbitrary (SnapMergingRunState t RunNumber) where
       [ SnapOngoingMerge x' y' | (x', y') <- shrink (x, y) ]
 
 deriving newtype instance Arbitrary SuppliedCredits
+deriving newtype instance Arbitrary MergeDebt
+deriving newtype instance Arbitrary MergeCredits
 
 {-------------------------------------------------------------------------------
   Show
@@ -312,4 +315,6 @@ deriving stock instance Show r => Show (SnapLevel r)
 deriving stock instance Show r => Show (SnapIncomingRun r)
 deriving stock instance (Show t, Show r) => Show (SnapMergingRunState t r)
 deriving stock instance Show SuppliedCredits
+deriving stock instance Show MergeDebt
+deriving stock instance Show MergeCredits
 

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -302,3 +302,14 @@ instance Arbitrary t => Arbitrary (SnapMergingRunState t RunNumber) where
 
 deriving newtype instance Arbitrary SuppliedCredits
 
+{-------------------------------------------------------------------------------
+  Show
+-------------------------------------------------------------------------------}
+
+deriving stock instance Show SnapshotMetaData
+deriving stock instance Show r => Show (SnapLevels r)
+deriving stock instance Show r => Show (SnapLevel r)
+deriving stock instance Show r => Show (SnapIncomingRun r)
+deriving stock instance (Show t, Show r) => Show (SnapMergingRunState t r)
+deriving stock instance Show SuppliedCredits
+

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
@@ -15,7 +15,7 @@ import           Database.LSMTree.Common (BloomFilterAlloc (..),
 import           Database.LSMTree.Internal.Config (FencePointerIndex (..),
                      MergePolicy (..), MergeSchedule (..), SizeRatio (..))
 import           Database.LSMTree.Internal.MergeSchedule
-                     (MergePolicyForLevel (..))
+                     (MergePolicyForLevel (..), NominalCredits (..))
 import           Database.LSMTree.Internal.MergingRun (NumRuns (..))
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.RunNumber (RunNumber (..))
@@ -212,11 +212,12 @@ enumerateSnapIncomingRun :: [(ComponentAnnotation, SnapIncomingRun RunNumber)]
 enumerateSnapIncomingRun =
   let
       inSnaps =
-        [ (fuseAnnotations ["R1", a, b], SnapMergingRun policy numRuns entries credits sState)
+        [ (fuseAnnotations ["R1", a, b],
+           SnapMergingRun policy numRuns mergeDebt nominalCredits sState)
         | (a, policy ) <- [("P0", LevelTiering), ("P1", LevelLevelling)]
         , numRuns <- NumRuns <$> [ magicNumber1 ]
-        , entries <- MR.MergeDebt    <$> [ magicNumber2 ]
-        , credits <- MR.MergeCredits <$> [ magicNumber1 ]
+        , mergeDebt      <- MR.MergeDebt    <$> [ magicNumber2 ]
+        , nominalCredits <- NominalCredits <$>  [ magicNumber1 ]
         , (b, sState ) <- enumerateSnapMergingRunState enumerateLevelMergeType
         ]
   in  fold

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
@@ -215,7 +215,7 @@ enumerateSnapIncomingRun =
         [ (fuseAnnotations ["R1", a, b], SnapMergingRun policy numRuns entries credits sState)
         | (a, policy ) <- [("P0", LevelTiering), ("P1", LevelLevelling)]
         , numRuns <- NumRuns <$> [ magicNumber1 ]
-        , entries <- NumEntries  <$> [ magicNumber2 ]
+        , entries <- MR.MergeDebt  <$> [ magicNumber2 ]
         , credits <- SuppliedCredits <$> [ magicNumber1 ]
         , (b, sState ) <- enumerateSnapMergingRunState enumerateLevelMergeType
         ]

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
@@ -215,8 +215,8 @@ enumerateSnapIncomingRun =
         [ (fuseAnnotations ["R1", a, b], SnapMergingRun policy numRuns entries credits sState)
         | (a, policy ) <- [("P0", LevelTiering), ("P1", LevelLevelling)]
         , numRuns <- NumRuns <$> [ magicNumber1 ]
-        , entries <- MR.MergeDebt  <$> [ magicNumber2 ]
-        , credits <- SuppliedCredits <$> [ magicNumber1 ]
+        , entries <- MR.MergeDebt    <$> [ magicNumber2 ]
+        , credits <- MR.MergeCredits <$> [ magicNumber1 ]
         , (b, sState ) <- enumerateSnapMergingRunState enumerateLevelMergeType
         ]
   in  fold


### PR DESCRIPTION
This is the equivalent of #571 but for the real implementation. There's quite a few small refactoring steps.

Previously we would scale each contribution of credits by scaling the
credit delta, rounded up. The scaling itself also depended on the
merging policy. The scaling was done to to work for the worst case size
of merge input runs, irrespective of the acutal input run sizes.

This approach would supply more credit than needed (thus finishing the
merge unnecessarily early) for two reasons: 1. assuming worst case
number of input runs and run sizes and 2 accumulation of rounding
errors over a sequence of small credit contributions. The approach also
meant that credit contributions to the same merge from different tables
would cause credit over-supply, and finishing the merge earlier than
either table needed.

The new approach is to separately track nominal and merge credit. The
merge debt is the merge steps of the actual merge at hand (based on
its actual not worst case input sizes) while the nominal debt is the
worst case of table updates that will be performed before the merge will
need to be completed.

We make relative contributions to the nominal credit. We then scale
linearly to convert the new (absolute) nominal credit to the new
(absolute) merge credit, and we try to set the merging runs credits to
this new (absolute) value.

This approach means we supply merge credits based on the actual not
worst case merge debt, and we never get compounding rounding errors. By
taking advantage of supplying merge credits in absolute terms, we can
avoid separate tables that share a merge from over-supplying credits
since the absolute contribution uses maximum rather than summation to
combine multiple contributions.

We also have to update the snapshot representation to store nominal
credits instead of merge credits.