### PR TITLE
Update fs-sim dependency

### DIFF
--- a/cabal.project.release
+++ b/cabal.project.release
@@ -34,11 +34,11 @@ if (impl(ghc < 9.0) && os(windows))
   package text
     flags: -simdutf
 
--- ghc-9.12.1
+-- bugfix hGetBufExactly and hGetBufExactlyAt
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/fs-sim
-  tag: 12dae42a78b95bf290c90b6ce7d30a8a7aa0fb45
+  tag: 55efd82e10c2b2d339bdfdc29d8d4bd8484150ba
   subdir:
     fs-api
     fs-sim

--- a/test/Test/Database/LSMTree/Internal/BlobFile/FS.hs
+++ b/test/Test/Database/LSMTree/Internal/BlobFile/FS.hs
@@ -59,6 +59,9 @@ prop_fault_openRelease doCreateFile om
               propNoDirEntries root fs .||. propNumDirEntries root 1 fs
             MustBeNew ->
               propNumDirEntries root 1 fs
+            MustExist ->
+              -- TODO: fix, see the TODO on openBlobFile
+              propNoDirEntries root fs .||. propNumDirEntries root 1 fs
         else
           propNoDirEntries root fs
 

--- a/test/Test/Database/LSMTree/Internal/WriteBufferBlobs/FS.hs
+++ b/test/Test/Database/LSMTree/Internal/WriteBufferBlobs/FS.hs
@@ -80,5 +80,8 @@ prop_fault_WriteBufferBlobs doCreateFile ae
               propNoDirEntries root fs .||. propNumDirEntries root 1 fs
             MustBeNew ->
               propNumDirEntries root 1 fs
+            MustExist ->
+              -- TODO: fix, see the TODO on openBlobFile
+              propNoDirEntries root fs .||. propNumDirEntries root 1 fs
         else
           propNoDirEntries root fs

--- a/test/Test/Util/FS.hs
+++ b/test/Test/Util/FS.hs
@@ -611,12 +611,15 @@ genAllowExisting :: Gen AllowExisting
 genAllowExisting = elements [
       AllowExisting
     , MustBeNew
+    , MustExist
     ]
   where
     _coveredAllCases x = case x of
         AllowExisting -> ()
         MustBeNew     -> ()
+        MustExist     -> ()
 
 shrinkAllowExisting :: AllowExisting -> [AllowExisting]
 shrinkAllowExisting AllowExisting = []
 shrinkAllowExisting MustBeNew     = [AllowExisting]
+shrinkAllowExisting MustExist     = [AllowExisting, MustBeNew]


### PR DESCRIPTION
In the updated dependency, a bug in `hGetBufExaclty` and `hGetBufExactlyAt` is fixed.