### PR TITLE
Introduce MergingRunData and MergingTreeData

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -26,6 +26,7 @@
 - ignore: {name: "Redundant $!"}
 - ignore: {name: "Use shows"}
 - ignore: {name: "Use fmap"}
+- ignore: {name: "Use <=<"}
 
 # Specify additional command line arguments
 #

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -309,6 +309,8 @@ library extras
     Database.LSMTree.Extras
     Database.LSMTree.Extras.Generators
     Database.LSMTree.Extras.Index
+    Database.LSMTree.Extras.MergingRunData
+    Database.LSMTree.Extras.MergingTreeData
     Database.LSMTree.Extras.NoThunks
     Database.LSMTree.Extras.Orphans
     Database.LSMTree.Extras.Random
@@ -333,6 +335,7 @@ library extras
     , lsm-tree:control
     , lsm-tree:kmerge
     , lsm-tree:prototypes
+    , nonempty-containers
     , nothunks
     , primitive
     , QuickCheck

--- a/src-extras/Database/LSMTree/Extras/MergingRunData.hs
+++ b/src-extras/Database/LSMTree/Extras/MergingRunData.hs
@@ -1,0 +1,222 @@
+-- | Utilities for generating 'MergingRun's. Tests and benchmarks should
+-- preferably use these utilities instead of (re-)defining their own.
+module Database.LSMTree.Extras.MergingRunData (
+    -- * Create merging runs
+    withMergingRun
+  , unsafeCreateMergingRun
+    -- * MergingRunData
+  , MergingRunData (..)
+  , mergingRunDataMergeType
+  , mergingRunDataInvariant
+  , mapMergingRunData
+  , SerialisedMergingRunData
+  , serialiseMergingRunData
+    -- * QuickCheck
+  , labelMergingRunData
+  , genMergingRunData
+  , shrinkMergingRunData
+  ) where
+
+import           Control.Exception (bracket)
+import           Control.RefCount
+import qualified Data.Vector as V
+import           Database.LSMTree.Extras (showPowersOf)
+import           Database.LSMTree.Extras.Generators ()
+import           Database.LSMTree.Extras.RunData
+import           Database.LSMTree.Internal.Index (IndexType)
+import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
+import           Database.LSMTree.Internal.MergingRun (MergingRun)
+import qualified Database.LSMTree.Internal.MergingRun as MR
+import           Database.LSMTree.Internal.Paths
+import           Database.LSMTree.Internal.Run (RunDataCaching (..))
+import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..))
+import           Database.LSMTree.Internal.RunNumber
+import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.UniqCounter
+import qualified System.FS.API as FS
+import           System.FS.API (HasFS)
+import           System.FS.BlockIO.API (HasBlockIO)
+import           Test.QuickCheck as QC
+
+{-------------------------------------------------------------------------------
+  Create merging runs
+-------------------------------------------------------------------------------}
+
+-- | Create a temporary 'MergingRun' using 'unsafeCreateMergingRun'.
+withMergingRun ::
+     MR.IsMergeType t
+  => HasFS IO h
+  -> HasBlockIO IO h
+  -> ResolveSerialisedValue
+  -> IndexType
+  -> FS.FsPath
+  -> UniqCounter IO
+  -> SerialisedMergingRunData t
+  -> (Ref (MergingRun t IO h) -> IO a)
+  -> IO a
+withMergingRun hfs hbio resolve indexType path counter mrd = do
+    bracket
+      (unsafeCreateMergingRun hfs hbio resolve indexType path counter mrd)
+      releaseRef
+
+-- | Flush serialised merging run data to disk.
+--
+-- This might leak resources if not run with asynchronous exceptions masked.
+-- Consider using 'withMergingRun' instead.
+--
+-- Use of this function should be paired with a 'releaseRef'.
+unsafeCreateMergingRun ::
+     MR.IsMergeType t
+  => HasFS IO h
+  -> HasBlockIO IO h
+  -> ResolveSerialisedValue
+  -> IndexType
+  -> FS.FsPath
+  -> UniqCounter IO
+  -> SerialisedMergingRunData t
+  -> IO (Ref (MergingRun t IO h))
+unsafeCreateMergingRun hfs hbio resolve indexType path counter = \case
+    CompletedMergeData _ numRuns rd -> do
+      withRun hfs hbio indexType path counter rd $ \run -> do
+        -- slightly hacky, generally it's larger
+        let totalDebt = MR.numEntriesToMergeDebt (Run.size run)
+        MR.newCompleted numRuns totalDebt run
+
+    OngoingMergeData mergeType rds -> do
+      withRuns hfs hbio indexType path counter (toRunData <$> rds)
+        $ \runs -> do
+          n <- incrUniqCounter counter
+          let fsPaths = RunFsPaths path (RunNumber (uniqueToInt n))
+          MR.new hfs hbio resolve CacheRunData (RunAllocFixed 10) indexType
+            mergeType fsPaths (V.fromList runs)
+
+{-------------------------------------------------------------------------------
+  MergingRunData
+-------------------------------------------------------------------------------}
+
+-- | A data structure suitable for creating arbitrary 'MergingRun's.
+--
+-- Note: 'b ~ Void' should rule out blobs.
+--
+-- Currently, ongoing merges are always \"fresh\", i.e. there is no merge work
+-- already performed.
+--
+-- TODO: Generate merge credits and supply them in 'unsafeCreateMergingRun',
+-- similarly to how @ScheduledMergesTest@ does it.
+data MergingRunData t k v b =
+    CompletedMergeData t MR.NumRuns (RunData k v b)
+  | OngoingMergeData t [NonEmptyRunData k v b]  -- ^ at least 2 inputs
+  deriving stock (Show, Eq)
+
+mergingRunDataMergeType :: MergingRunData t k v b -> t
+mergingRunDataMergeType = \case
+    CompletedMergeData mt _ _ -> mt
+    OngoingMergeData mt _     -> mt
+
+-- | See @mergeInvariant@ in the prototype.
+mergingRunDataInvariant :: MergingRunData t k v b -> Either String ()
+mergingRunDataInvariant = \case
+    CompletedMergeData _ (MR.NumRuns n) _ ->
+      assertI "completed merges are non-trivial (at least two inputs)" $
+        n >= 2
+    OngoingMergeData _ rds -> do
+      assertI "ongoing merges are non-trivial (at least two inputs)" $
+        length rds >= 2
+  where
+    assertI msg False = Left msg
+    assertI _   True  = Right ()
+
+mapMergingRunData ::
+     Ord k'
+  => (k -> k') -> (v -> v') -> (b -> b')
+  -> MergingRunData t k v b -> MergingRunData t k' v' b'
+mapMergingRunData f g h = \case
+    CompletedMergeData t n r ->
+      CompletedMergeData t n $ mapRunData f g h r
+    OngoingMergeData t rs ->
+      OngoingMergeData t $ map (mapNonEmptyRunData f g h) rs
+
+type SerialisedMergingRunData t =
+    MergingRunData t SerialisedKey SerialisedValue SerialisedBlob
+
+serialiseMergingRunData ::
+     (SerialiseKey k, SerialiseValue v, SerialiseValue b)
+  => MergingRunData t k v b -> SerialisedMergingRunData t
+serialiseMergingRunData =
+    mapMergingRunData serialiseKey serialiseValue serialiseBlob
+
+{-------------------------------------------------------------------------------
+  QuickCheck
+-------------------------------------------------------------------------------}
+
+labelMergingRunData ::
+     Show t => SerialisedMergingRunData t -> Property -> Property
+labelMergingRunData (CompletedMergeData mt _ rd) =
+      tabulate "merging run state" ["CompletedMerge"]
+    . tabulate "merge type" [show mt]
+    . labelRunData rd
+labelMergingRunData (OngoingMergeData mt rds) =
+      tabulate "merging run state" ["OngoingMerge"]
+    . tabulate "merge type" [show mt]
+    . tabulate "merging run inputs" [showPowersOf 2 (length rds)]
+    . foldr ((.) . labelNonEmptyRunData) id rds
+
+instance ( Arbitrary t, Ord k, Arbitrary k, Arbitrary v, Arbitrary b
+         ) => Arbitrary (MergingRunData t k v b) where
+  arbitrary = genMergingRunData arbitrary arbitrary arbitrary arbitrary
+  shrink = shrinkMergingRunData shrink shrink shrink
+
+genMergingRunData ::
+     Ord k
+  => Gen t
+  -> Gen k
+  -> Gen v
+  -> Gen b
+  -> Gen (MergingRunData t k v b)
+genMergingRunData genMergeType genKey genVal genBlob =
+    QC.oneof
+      [ do
+          mt <- genMergeType
+          numRuns <- MR.NumRuns <$> QC.chooseInt (2, 8)
+          rd <- genRunData genKey genVal genBlob
+          pure (CompletedMergeData mt numRuns rd)
+      , do
+          s  <- QC.getSize
+          mt <- genMergeType
+          n  <- QC.chooseInt (2, max 2 (s * 8 `div` 100))  -- 2 to 8
+          rs <- QC.vectorOf n $
+            -- Scaled, so overall number of entries is similar to a completed
+            -- merge. However, the entries themselves should not be smaller.
+            QC.scale (`div` n) $
+              genNonEmptyRunData
+                (resize s genKey)
+                (resize s genVal)
+                (resize s genBlob)
+          pure (OngoingMergeData mt rs)
+      ]
+
+shrinkMergingRunData ::
+     Ord k
+  => (k -> [k])
+  -> (v -> [v])
+  -> (b -> [b])
+  -> MergingRunData t k v b
+  -> [MergingRunData t k v b]
+shrinkMergingRunData shrinkKey shrinkVal shrinkBlob = \case
+    CompletedMergeData mt numRuns rd ->
+      [ CompletedMergeData mt numRuns' rd'
+      | (numRuns', rd') <-
+          liftShrink2
+            (fmap MR.NumRuns . filter (>= 2) . shrink . MR.unNumRuns)
+            (shrinkRunData shrinkKey shrinkVal shrinkBlob)
+            (numRuns, rd)
+      ]
+    OngoingMergeData mt rds ->
+      [ OngoingMergeData mt rds'
+      | rds' <-
+          liftShrink
+            (shrinkNonEmptyRunData shrinkKey shrinkVal shrinkBlob)
+            rds
+      , length rds' >= 2
+      ]

--- a/src-extras/Database/LSMTree/Extras/MergingTreeData.hs
+++ b/src-extras/Database/LSMTree/Extras/MergingTreeData.hs
@@ -1,0 +1,401 @@
+-- | Utilities for generating 'MergingTree's. Tests and benchmarks should
+-- preferably use these utilities instead of (re-)defining their own.
+module Database.LSMTree.Extras.MergingTreeData (
+    -- * Create merging trees
+    withMergingTree
+  , unsafeCreateMergingTree
+    -- * MergingTreeData
+  , MergingTreeData (..)
+  , PreExistingRunData (..)
+  , mergingTreeDataInvariant
+  , mapMergingTreeData
+  , SerialisedMergingTreeData
+  , serialiseMergingTreeData
+    -- * QuickCheck
+  , labelMergingTreeData
+  , genMergingTreeData
+  , shrinkMergingTreeData
+  ) where
+
+import           Control.Exception (assert, bracket)
+import           Control.RefCount
+import           Data.Foldable (for_, toList)
+import           Database.LSMTree.Extras (showPowersOf)
+import           Database.LSMTree.Extras.Generators ()
+import           Database.LSMTree.Extras.MergingRunData
+import           Database.LSMTree.Extras.RunData
+import           Database.LSMTree.Internal.Index (IndexType)
+import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
+import qualified Database.LSMTree.Internal.MergingRun as MR
+import           Database.LSMTree.Internal.MergingTree (MergingTree)
+import qualified Database.LSMTree.Internal.MergingTree as MT
+import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.UniqCounter
+import qualified System.FS.API as FS
+import           System.FS.API (HasFS)
+import           System.FS.BlockIO.API (HasBlockIO)
+import           Test.QuickCheck as QC
+
+{-------------------------------------------------------------------------------
+  Create merging tree
+-------------------------------------------------------------------------------}
+
+-- | Create a temporary 'MergingTree' using 'unsafeCreateMergingTree'.
+withMergingTree ::
+     HasFS IO h
+  -> HasBlockIO IO h
+  -> ResolveSerialisedValue
+  -> IndexType
+  -> FS.FsPath
+  -> UniqCounter IO
+  -> SerialisedMergingTreeData
+  -> (Ref (MergingTree IO h) -> IO a)
+  -> IO a
+withMergingTree hfs hbio resolve indexType path counter mrd = do
+    bracket
+      (unsafeCreateMergingTree hfs hbio resolve indexType path counter mrd)
+      releaseRef
+
+-- | Flush serialised merging tree data to disk.
+--
+-- This might leak resources if not run with asynchronous exceptions masked.
+-- Consider using 'withMergingTree' instead.
+--
+-- Use of this function should be paired with a 'releaseRef'.
+unsafeCreateMergingTree ::
+     HasFS IO h
+  -> HasBlockIO IO h
+  -> ResolveSerialisedValue
+  -> IndexType
+  -> FS.FsPath
+  -> UniqCounter IO
+  -> SerialisedMergingTreeData
+  -> IO (Ref (MergingTree IO h))
+unsafeCreateMergingTree hfs hbio resolve indexType path counter = go
+  where
+    go = \case
+      CompletedTreeMergeData rd -> do
+        withRun hfs hbio indexType path counter rd $ \run ->
+          MT.mkMergingTree . MT.CompletedTreeMerge =<< dupRef run
+      OngoingTreeMergeData mrd -> do
+        withMergingRun hfs hbio resolve indexType path counter mrd $ \mr ->
+          MT.mkMergingTree . MT.OngoingTreeMerge =<< dupRef mr
+      PendingLevelMergeData prds mtd -> do
+        withPreExistingRuns prds $ \prs ->
+          withMaybeTree mtd $ \mt ->
+            MT.newPendingLevelMerge prs mt
+      PendingUnionMergeData mtds -> do
+        withTrees mtds $ \mts ->
+          MT.newPendingUnionMerge mts
+
+    withTrees []         act = act []
+    withTrees (mtd:rest) act =
+        bracket (go mtd) releaseRef $ \t ->
+          withTrees rest $ \ts ->
+            act (t:ts)
+
+    withMaybeTree Nothing    act = act Nothing
+    withMaybeTree (Just mtd) act =
+        bracket (go mtd) releaseRef $ \t ->
+          act (Just t)
+
+    withPreExistingRuns [] act = act []
+    withPreExistingRuns (PreExistingRunData rd : rest) act =
+        withRun hfs hbio indexType path counter rd $ \r ->
+          withPreExistingRuns rest $ \prs ->
+            act (MT.PreExistingRun r : prs)
+    withPreExistingRuns (PreExistingMergingRunData mrd : rest) act =
+        withMergingRun hfs hbio resolve indexType path counter mrd $ \mr ->
+          withPreExistingRuns rest $ \prs ->
+            act (MT.PreExistingMergingRun mr : prs)
+
+{-------------------------------------------------------------------------------
+  MergingTreeData
+-------------------------------------------------------------------------------}
+
+-- TODO: This module has quite a lot duplication with the prototype's
+-- ScheduledMergesTest module. Maybe we can share some code?
+
+-- | A data structure suitable for creating arbitrary 'MergingTree's.
+--
+-- Note: 'b ~ Void' should rule out blobs.
+data MergingTreeData k v b =
+    CompletedTreeMergeData (RunData k v b)
+  | OngoingTreeMergeData (MergingRunData MR.TreeMergeType k v b)
+  | PendingLevelMergeData
+      [PreExistingRunData k v b]
+      (Maybe (MergingTreeData k v b))  -- ^ not both empty!
+  | PendingUnionMergeData [MergingTreeData k v b]  -- ^ at least 2 children
+  deriving stock (Show, Eq)
+
+data PreExistingRunData k v b =
+    PreExistingRunData (RunData k v b)
+  | PreExistingMergingRunData (MergingRunData MR.LevelMergeType k v b)
+  deriving stock (Show, Eq)
+
+-- | See @treeInvariant@ in prototype.
+mergingTreeDataInvariant :: MergingTreeData k v b -> Either String ()
+mergingTreeDataInvariant = \case
+    CompletedTreeMergeData _rd ->
+      Right ()
+    OngoingTreeMergeData mr ->
+      mergingRunDataInvariant mr
+    PendingLevelMergeData prs t -> do
+      assertI "pending level merges have at least one input" $
+        length prs + length t > 0
+      for_ prs $ \case
+        PreExistingRunData        _r -> Right ()
+        PreExistingMergingRunData mr -> mergingRunDataInvariant mr
+      for_ (drop 1 (reverse prs)) $ \case
+        PreExistingRunData        _r -> Right ()
+        PreExistingMergingRunData mr ->
+          assertI "only the last pre-existing run can be a last level merge" $
+            mergingRunDataMergeType mr == MR.MergeMidLevel
+      for_ t mergingTreeDataInvariant
+    PendingUnionMergeData ts -> do
+      assertI "pending union merges are non-trivial (at least two inputs)" $
+        length ts >= 2
+      for_ ts mergingTreeDataInvariant
+  where
+    assertI msg False = Left msg
+    assertI _   True  = Right ()
+
+mapMergingTreeData ::
+     Ord k'
+  => (k -> k') -> (v -> v') -> (b -> b')
+  -> MergingTreeData k v b -> MergingTreeData k' v' b'
+mapMergingTreeData f g h = \case
+    CompletedTreeMergeData r ->
+      CompletedTreeMergeData $ mapRunData f g h r
+    OngoingTreeMergeData mr ->
+      OngoingTreeMergeData $ mapMergingRunData f g h mr
+    PendingLevelMergeData prs t ->
+      PendingLevelMergeData
+        (map (mapPreExistingRunData f g h) prs)
+        (fmap (mapMergingTreeData f g h) t)
+    PendingUnionMergeData ts ->
+      PendingUnionMergeData $ fmap (mapMergingTreeData f g h) ts
+
+mapPreExistingRunData ::
+     Ord k'
+  => (k -> k') -> (v -> v') -> (b -> b')
+  -> PreExistingRunData k v b -> PreExistingRunData k' v' b'
+mapPreExistingRunData f g h = \case
+    PreExistingRunData r ->
+      PreExistingRunData (mapRunData f g h r)
+    PreExistingMergingRunData mr ->
+      PreExistingMergingRunData (mapMergingRunData f g h mr)
+
+type SerialisedMergingTreeData =
+    MergingTreeData SerialisedKey SerialisedValue SerialisedBlob
+
+type SerialisedPreExistingRunData =
+    PreExistingRunData SerialisedKey SerialisedValue SerialisedBlob
+
+serialiseMergingTreeData ::
+     (SerialiseKey k, SerialiseValue v, SerialiseValue b)
+  => MergingTreeData k v b -> SerialisedMergingTreeData
+serialiseMergingTreeData =
+    mapMergingTreeData serialiseKey serialiseValue serialiseBlob
+
+{-------------------------------------------------------------------------------
+  QuickCheck
+-------------------------------------------------------------------------------}
+
+labelMergingTreeData :: SerialisedMergingTreeData -> Property -> Property
+labelMergingTreeData = \rd ->
+    tabulate "tree depth" [showPowersOf 2 (depthTree rd)] . go rd
+  where
+    go (CompletedTreeMergeData rd) =
+          tabulate "merging tree state" ["CompletedTreeMerge"]
+        . labelRunData rd
+    go (OngoingTreeMergeData mrd) =
+          tabulate "merging tree state" ["OngoingTreeMerge"]
+        . labelMergingRunData mrd
+    go (PendingLevelMergeData prds mtd) =
+          tabulate "merging tree state" ["PendingLevelMerge"]
+        . foldr ((.) . labelPreExistingRunData) id prds
+        . maybe id go mtd
+    go (PendingUnionMergeData mtds) =
+          tabulate "merging tree state" ["PendingUnionMerge"]
+        . foldr ((.) . go) id mtds
+
+    -- the longest path from the root to a run
+    depthTree = (+1) . \case  -- maximum depth of children
+        CompletedTreeMergeData _ -> 0
+        OngoingTreeMergeData _   -> 0
+        PendingLevelMergeData prds mtds ->
+          maximum (0 : fmap (const 1) prds ++ map depthTree (toList mtds))
+        PendingUnionMergeData mtds ->
+          maximum (0 : map depthTree mtds)
+
+
+labelPreExistingRunData :: SerialisedPreExistingRunData -> Property -> Property
+labelPreExistingRunData (PreExistingRunData rd)         = labelRunData rd
+labelPreExistingRunData (PreExistingMergingRunData mrd) = labelMergingRunData mrd
+
+instance ( Ord k, Arbitrary k, Arbitrary v, Arbitrary b
+         ) => Arbitrary (MergingTreeData k v b) where
+  arbitrary = genMergingTreeData arbitrary arbitrary arbitrary
+  shrink = shrinkMergingTreeData shrink shrink shrink
+
+genMergingTreeData ::
+     Ord k => Gen k -> Gen v -> Gen b -> Gen (MergingTreeData k v b)
+genMergingTreeData genKey genVal genBlob = QC.sized $ \s -> do
+    treeSize <- QC.chooseInt (1, 1 + (s `div` 4)) -- up to 26
+    genMergingTreeDataOfSize genKey genVal genBlob treeSize
+
+-- | Minimal returned size will be 1. Doesn't generate structurally empty trees!
+--
+-- The size is measured by the number of MergingTreeData constructors.
+genMergingTreeDataOfSize ::
+     Ord k => Gen k -> Gen v -> Gen b -> Int -> Gen (MergingTreeData k v b)
+genMergingTreeDataOfSize genKey genVal genBlob = \n0 -> do
+    tree <- genMergingTree n0
+    assert (mergingTreeDataSize tree == n0) $
+      return tree
+  where
+    genMergingTree n
+      | n < 1
+      = error ("arbitrary T: n == " <> show n)
+
+      | n == 1
+      = QC.oneof
+          [ CompletedTreeMergeData <$> genRunData genKey genVal genBlob
+          , OngoingTreeMergeData <$> genMergingRunData arbitrary genKey genVal genBlob
+          , genPendingLevelMergeNoChild
+          ]
+
+      | n == 2
+      = genPendingLevelMergeWithChild n
+
+      | otherwise
+      = QC.oneof [genPendingLevelMergeWithChild n, genPendingUnionMerge n]
+
+    -- n == 1
+    genPendingLevelMergeNoChild = do
+        numPreExisting <- chooseIntSkewed (0, 5)
+        initPreExisting <- QC.vectorOf numPreExisting $
+          -- these can't be last level. we generate the last input below.
+          genPreExistingRunData (pure MR.MergeMidLevel) genKey genVal genBlob
+        -- there must be at least one (last) input to the pending merge.
+        lastPreExisting <- genPreExistingRunData arbitrary genKey genVal genBlob
+        let preExisting = initPreExisting ++ [lastPreExisting]
+        return (PendingLevelMergeData preExisting Nothing)
+
+    -- n >= 2
+    genPendingLevelMergeWithChild n = do
+        numPreExisting <- chooseIntSkewed (0, 6)
+        preExisting <- QC.vectorOf numPreExisting $
+          -- there can't be a last level merge, child is last
+          genPreExistingRunData (pure MR.MergeMidLevel) genKey genVal genBlob
+        tree <- genMergingTree (n - 1)
+        return (PendingLevelMergeData preExisting (Just tree))
+
+    -- n >= 3, needs 1 constructor + 2 children
+    genPendingUnionMerge n = do
+        ns <- QC.shuffle =<< arbitraryPartition2 (n - 1)
+        PendingUnionMergeData <$> traverse genMergingTree ns
+
+    -- skewed towards smaller values
+    chooseIntSkewed (lb, ub) = do
+        ub' <- QC.chooseInt (lb, ub)
+        QC.chooseInt (lb, ub')
+
+mergingTreeDataSize :: MergingTreeData k v b -> Int
+mergingTreeDataSize = \case
+    CompletedTreeMergeData _ -> 1
+    OngoingTreeMergeData _ -> 1
+    PendingLevelMergeData _ tree -> 1 + maybe 0 mergingTreeDataSize tree
+    PendingUnionMergeData trees -> 1 + sum (map mergingTreeDataSize trees)
+
+-- Split into at least two smaller positive numbers. The input needs to be
+-- greater than or equal to 2.
+arbitraryPartition2 :: Int -> QC.Gen [Int]
+arbitraryPartition2 n = assert (n >= 2) $ do
+    first <- QC.chooseInt (1, n-1)
+    (first :) <$> arbitraryPartition (n - first)
+
+-- Split into smaller positive numbers.
+arbitraryPartition :: Int -> QC.Gen [Int]
+arbitraryPartition n
+      | n <  1 = return []
+      | n == 1 = return [1]
+      | otherwise = do
+        first <- QC.chooseInt (1, n)
+        (first :) <$> arbitraryPartition (n - first)
+
+-- TODO: Would it be useful to shrink by merging subtrees into a single run?
+-- This would simplify the tree while preserving many errors that depend on the
+-- specific content of the tree. See prototype tests.
+shrinkMergingTreeData ::
+     Ord k
+  => (k -> [k])
+  -> (v -> [v])
+  -> (b -> [b])
+  -> MergingTreeData k v b
+  -> [MergingTreeData k v b]
+shrinkMergingTreeData shrinkKey shrinkVal shrinkBlob = \case
+  CompletedTreeMergeData r ->
+    [ CompletedTreeMergeData r'
+    | r' <- shrinkRunData shrinkKey shrinkVal shrinkBlob r
+    ]
+  OngoingTreeMergeData mr ->
+    [ OngoingTreeMergeData mr'
+    | mr' <- shrinkMergingRunData shrinkKey shrinkVal shrinkBlob mr
+    ]
+  PendingLevelMergeData prs t ->
+    {- HLINT ignore "Use catMaybes" -}
+    -- just use the child tree, if present
+    [ t' | Just t' <- [t] ]
+    <>
+    -- move completed child tree into regular levels
+    [ PendingLevelMergeData (prs ++ [PreExistingRunData r]) Nothing
+    | Just (CompletedTreeMergeData r) <- [t]
+    ]
+    <>
+    [ PendingLevelMergeData prs' t'
+    | (prs', t') <-
+        liftShrink2
+          (liftShrink (shrinkPreExistingRunData shrinkKey shrinkVal shrinkBlob))
+          (liftShrink (shrinkMergingTreeData shrinkKey shrinkVal shrinkBlob))
+          (prs, t)
+    , length prs' + length t' > 0
+    ]
+  PendingUnionMergeData ts ->
+    ts
+    <>
+    [ PendingUnionMergeData ts'
+    | ts' <- liftShrink (shrinkMergingTreeData shrinkKey shrinkVal shrinkBlob) ts
+    , length ts' >= 2
+    ]
+
+genPreExistingRunData ::
+     Ord k
+  => Gen MR.LevelMergeType
+  -> Gen k
+  -> Gen v
+  -> Gen b
+  -> Gen (PreExistingRunData k v b)
+genPreExistingRunData genMergeType genKey genVal genBlob =
+    QC.oneof
+      [ PreExistingRunData <$> genRunData genKey genVal genBlob
+      , PreExistingMergingRunData <$> genMergingRunData genMergeType genKey genVal genBlob
+      ]
+
+shrinkPreExistingRunData ::
+     Ord k
+  => (k -> [k])
+  -> (v -> [v])
+  -> (b -> [b])
+  -> PreExistingRunData k v b
+  -> [PreExistingRunData k v b]
+shrinkPreExistingRunData shrinkKey shrinkVal shrinkBlob = \case
+    PreExistingRunData r ->
+      [ PreExistingRunData r'
+      | r' <- shrinkRunData shrinkKey shrinkVal shrinkBlob r
+      ]
+    PreExistingMergingRunData mr ->
+      [ PreExistingMergingRunData mr'
+      | mr' <- shrinkMergingRunData shrinkKey shrinkVal shrinkBlob mr
+      ]

--- a/src-extras/Database/LSMTree/Extras/RunData.hs
+++ b/src-extras/Database/LSMTree/Extras/RunData.hs
@@ -2,34 +2,46 @@
 -- from them. Tests and benchmarks should preferably use these utilities instead
 -- of (re-)defining their own.
 module Database.LSMTree.Extras.RunData (
-    -- * Flush runs
+    -- * Create runs
     withRun
+  , withRunAt
   , withRuns
-  , unsafeFlushAsWriteBuffer
+  , unsafeCreateRun
+  , unsafeCreateRunAt
+  , simplePath
+  , simplePaths
     -- * Serialise write buffers
   , withRunDataAsWriteBuffer
   , withSerialisedWriteBuffer
     -- * RunData
   , RunData (..)
+  , mapRunData
   , SerialisedRunData
   , serialiseRunData
-  , simplePath
-  , simplePaths
+    -- * NonEmptyRunData
+  , NonEmptyRunData (..)
+  , nonEmptyRunData
+  , toRunData
+  , mapNonEmptyRunData
+  , SerialisedNonEmptyRunData
     -- * QuickCheck
   , labelRunData
+  , labelNonEmptyRunData
   , genRunData
   , shrinkRunData
+  , genNonEmptyRunData
+  , shrinkNonEmptyRunData
   , liftArbitrary2Map
   , liftShrink2Map
   ) where
 
 import           Control.Exception (bracket, bracket_)
-import           Control.Monad
 import           Control.RefCount
 import           Data.Bifoldable (Bifoldable (bifoldMap))
 import           Data.Bifunctor
 import           Data.Foldable (for_)
-import qualified Data.Map as M
+import           Data.Map.NonEmpty (NEMap)
+import qualified Data.Map.NonEmpty as NEMap
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
@@ -47,21 +59,37 @@ import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..),
                      entryWouldFitInPage)
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.UniqCounter
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import qualified Database.LSMTree.Internal.WriteBufferBlobs as WBB
 import           Database.LSMTree.Internal.WriteBufferWriter (writeWriteBuffer)
 import qualified System.FS.API as FS
-import           System.FS.API
+import           System.FS.API (HasFS)
 import qualified System.FS.BlockIO.API as FS
-import           System.FS.BlockIO.API
+import           System.FS.BlockIO.API (HasBlockIO)
 import           Test.QuickCheck
 
 {-------------------------------------------------------------------------------
-  Flush runs
+  Create runs
 -------------------------------------------------------------------------------}
 
--- | Create a temporary 'Run' using 'unsafeFlushAsWriteBuffer'.
+-- | Create a temporary 'Run' using 'unsafeCreateRun'.
 withRun ::
+     HasFS IO h
+  -> HasBlockIO IO h
+  -> IndexType
+  -> FS.FsPath
+  -> UniqCounter IO
+  -> SerialisedRunData
+  -> (Ref (Run IO h) -> IO a)
+  -> IO a
+withRun hfs hbio indexType path counter rd = do
+    bracket
+      (unsafeCreateRun hfs hbio indexType path counter rd)
+      releaseRef
+
+-- | Create a temporary 'Run' using 'unsafeCreateRunAt'.
+withRunAt ::
      HasFS IO h
   -> HasBlockIO IO h
   -> IndexType
@@ -69,25 +97,44 @@ withRun ::
   -> SerialisedRunData
   -> (Ref (Run IO h) -> IO a)
   -> IO a
-withRun hfs hbio indexType path rd = do
+withRunAt hfs hbio indexType path rd = do
     bracket
-      (unsafeFlushAsWriteBuffer hfs hbio indexType path $ serialiseRunData rd)
+      (unsafeCreateRunAt hfs hbio indexType path rd)
       releaseRef
 
 {-# INLINABLE withRuns #-}
--- | Create temporary 'Run's using 'unsafeFlushAsWriteBuffer'.
+-- | Create temporary 'Run's using 'unsafeCreateRun'.
 withRuns ::
-     Traversable f
-  => HasFS IO h
+     HasFS IO h
   -> HasBlockIO IO h
   -> IndexType
-  -> f (RunFsPaths, SerialisedRunData)
-  -> (f (Ref (Run IO h)) -> IO a)
+  -> FS.FsPath
+  -> UniqCounter IO
+  -> [SerialisedRunData]
+  -> ([Ref (Run IO h)] -> IO a)
   -> IO a
-withRuns hfs hbio indexType xs = do
-    bracket
-      (forM xs $ \(path, rd) -> unsafeFlushAsWriteBuffer hfs hbio indexType path rd)
-      (mapM_ releaseRef)
+withRuns hfs hbio indexType path counter = go
+  where
+    go []       act = act []
+    go (rd:rds) act =
+      withRun hfs hbio indexType path counter rd $ \r ->
+        go rds $ \rs ->
+          act (r:rs)
+
+-- | Like 'unsafeCreateRunAt', but uses a 'UniqCounter' to determine
+-- the 'RunFsPaths', at a base file path.
+unsafeCreateRun ::
+     HasFS IO h
+  -> HasBlockIO IO h
+  -> IndexType
+  -> FS.FsPath
+  -> UniqCounter IO
+  -> SerialisedRunData
+  -> IO (Ref (Run IO h))
+unsafeCreateRun fs hbio indexType path counter rd = do
+    n <- incrUniqCounter counter
+    let fsPaths = RunFsPaths path (uniqueToRunNumber n)
+    unsafeCreateRunAt fs hbio indexType fsPaths rd
 
 -- | Flush serialised run data to disk as if it were a write buffer.
 --
@@ -95,21 +142,28 @@ withRuns hfs hbio indexType xs = do
 -- Use helper functions like 'withRun' or 'withRuns' instead.
 --
 -- Use of this function should be paired with a 'releaseRef'.
-unsafeFlushAsWriteBuffer ::
+unsafeCreateRunAt ::
      HasFS IO h
   -> HasBlockIO IO h
   -> IndexType
   -> RunFsPaths
   -> SerialisedRunData
   -> IO (Ref (Run IO h))
-unsafeFlushAsWriteBuffer fs hbio indexType fsPaths (RunData m) = do
-    let blobpath = addExtension (runBlobPath fsPaths) ".wb"
-    wbblobs <- WBB.new fs blobpath
-    wb <- WB.fromMap <$> traverse (traverse (WBB.addBlob fs wbblobs)) m
-    run <- Run.fromWriteBuffer fs hbio CacheRunData (RunAllocFixed 10) indexType
-                               fsPaths wb wbblobs
-    releaseRef wbblobs
-    return run
+unsafeCreateRunAt fs hbio indexType fsPaths (RunData m) = do
+    let blobpath = FS.addExtension (runBlobPath fsPaths) ".wb"
+    bracket (WBB.new fs blobpath) releaseRef $ \wbblobs -> do
+      wb <- WB.fromMap <$> traverse (traverse (WBB.addBlob fs wbblobs)) m
+      Run.fromWriteBuffer fs hbio CacheRunData (RunAllocFixed 10) indexType
+                          fsPaths wb wbblobs
+
+-- | Create a 'RunFsPaths' using an empty 'FsPath'. The empty path corresponds
+-- to the "root" or "mount point" of a 'HasFS' instance.
+simplePath :: Int -> RunFsPaths
+simplePath n = RunFsPaths (FS.mkFsPath []) (RunNumber n)
+
+-- | Like 'simplePath', but for a list.
+simplePaths :: [Int] -> [RunFsPaths]
+simplePaths ns = fmap simplePath ns
 
 {-------------------------------------------------------------------------------
   Serialise write buffers
@@ -124,14 +178,15 @@ withRunDataAsWriteBuffer ::
   -> (WB.WriteBuffer -> Ref (WBB.WriteBufferBlobs IO h) -> IO a)
   -> IO a
 withRunDataAsWriteBuffer hfs f fsPaths rd action = do
-  let es = V.fromList . M.toList $ unRunData rd
+  let es = V.fromList . Map.toList $ unRunData rd
   let maxn = NumEntries $ V.length es
   let wbbPath = Paths.writeBufferBlobPath fsPaths
   bracket (WBB.new hfs wbbPath) releaseRef $ \wbb -> do
     (wb, _) <- addWriteBufferEntries hfs f wbb maxn WB.empty es
     action wb wbb
 
--- | Serialise a 'WriteBuffer' and 'WriteBufferBlobs' to disk and perform an 'IO' action.
+-- | Serialise a 'WriteBuffer' and 'WriteBufferBlobs' to disk and perform an
+-- 'IO' action.
 withSerialisedWriteBuffer ::
      FS.HasFS IO h
   -> FS.HasBlockIO IO h
@@ -151,8 +206,6 @@ withSerialisedWriteBuffer hfs hbio wbPaths wb wbb =
   RunData
 -------------------------------------------------------------------------------}
 
-type SerialisedRunData = RunData SerialisedKey SerialisedValue SerialisedBlob
-
 -- | A collection of arbitrary key\/value pairs that are suitable for creating
 -- 'Run's.
 --
@@ -160,25 +213,48 @@ type SerialisedRunData = RunData SerialisedKey SerialisedValue SerialisedBlob
 newtype RunData k v b = RunData {
     unRunData :: Map k (Entry v b)
   }
-  deriving stock (Show, Eq)
+  deriving stock (Eq, Show)
+
+mapRunData ::
+     Ord k'
+  => (k -> k') -> (v -> v') -> (b -> b')
+  -> RunData k v b -> RunData k' v' b'
+mapRunData f g h = RunData . Map.mapKeys f . Map.map (bimap g h) . unRunData
+
+type SerialisedRunData = RunData SerialisedKey SerialisedValue SerialisedBlob
 
 serialiseRunData ::
      (SerialiseKey k, SerialiseValue v, SerialiseValue b)
   => RunData k v b -> SerialisedRunData
-serialiseRunData rd =
-    RunData $
-    Map.mapKeys (serialiseKey) $
-    Map.map (bimap serialiseValue serialiseBlob) $
-    unRunData rd
+serialiseRunData = mapRunData serialiseKey serialiseValue serialiseBlob
 
--- | Create a 'RunFsPaths' using an empty 'FsPath'. The empty path corresponds
--- to the "root" or "mount point" of a 'HasFS' instance.
-simplePath :: Int -> RunFsPaths
-simplePath n = RunFsPaths (mkFsPath []) (RunNumber n)
+{-------------------------------------------------------------------------------
+  NonEmptyRunData
+-------------------------------------------------------------------------------}
 
--- | Like 'simplePath', but for a list.
-simplePaths :: [Int] -> [RunFsPaths]
-simplePaths ns = fmap simplePath ns
+-- | A collection of arbitrary key\/value pairs that are suitable for creating
+-- 'Run's.
+--
+-- Note: 'b ~ Void' should rule out blobs.
+newtype NonEmptyRunData k v b =
+    NonEmptyRunData { unNonEmptyRunData :: NEMap k (Entry v b) }
+  deriving stock (Eq, Show)
+
+nonEmptyRunData :: RunData k v b -> Maybe (NonEmptyRunData k v b)
+nonEmptyRunData (RunData m) = NonEmptyRunData <$> NEMap.nonEmptyMap m
+
+toRunData :: NonEmptyRunData k v b -> RunData k v b
+toRunData (NonEmptyRunData m) = RunData (NEMap.toMap m)
+
+mapNonEmptyRunData ::
+     Ord k'
+  => (k -> k') -> (v -> v') -> (b -> b')
+  -> NonEmptyRunData k v b -> NonEmptyRunData k' v' b'
+mapNonEmptyRunData f g h =
+    NonEmptyRunData . NEMap.mapKeys f . NEMap.map (bimap g h) . unNonEmptyRunData
+
+type SerialisedNonEmptyRunData =
+    NonEmptyRunData SerialisedKey SerialisedValue SerialisedBlob
 
 {-------------------------------------------------------------------------------
   QuickCheck
@@ -186,26 +262,36 @@ simplePaths ns = fmap simplePath ns
 
 {- HLINT ignore "Hoist not" -}
 labelRunData :: SerialisedRunData -> Property -> Property
-labelRunData (RunData m) = tabulate "value size" size . label note
+labelRunData (RunData m) =
+      tabulate "value size" valSizes
+    . tabulate "run length" [runLength]
+      -- We use tabulate here, not label. Otherwise, if multiple RunDatas get
+      -- labelled in a test case, each leads to a separate entry in the
+      -- displayed statistics, which isn't that useful.
+    . tabulate "run has large k/ops" [note]
   where
     kops = Map.toList m
-    size = map (showPowersOf10 . sizeofValue) vals
+    valSizes = map (showPowersOf10 . sizeofValue) vals
+    runLength = showPowersOf10 (Map.size m)
     vals = concatMap (bifoldMap pure mempty . snd) kops
     note
       | any (not . uncurry entryWouldFitInPage) kops = "has large k/op"
       | otherwise = "no large k/op"
+
+labelNonEmptyRunData :: SerialisedNonEmptyRunData -> Property -> Property
+labelNonEmptyRunData = labelRunData . toRunData
 
 instance ( Ord k, Arbitrary k, Arbitrary v, Arbitrary b
          ) => Arbitrary (RunData k v b) where
   arbitrary = genRunData arbitrary arbitrary arbitrary
   shrink = shrinkRunData shrink shrink shrink
 
-genRunData ::
-     forall k v b. Ord k
-  => Gen k
-  -> Gen v
-  -> Gen b
-  -> Gen (RunData k v b)
+instance ( Ord k, Arbitrary k, Arbitrary v, Arbitrary b
+         ) => Arbitrary (NonEmptyRunData k v b) where
+  arbitrary = genNonEmptyRunData arbitrary arbitrary arbitrary
+  shrink = shrinkNonEmptyRunData shrink shrink shrink
+
+genRunData :: Ord k => Gen k -> Gen v -> Gen b -> Gen (RunData k v b)
 genRunData genKey genVal genBlob =
     RunData <$> liftArbitrary2Map genKey (liftArbitrary2 genVal genBlob)
 
@@ -223,9 +309,37 @@ shrinkRunData shrinkKey shrinkVal shrinkBlob =
 
 -- | We cannot implement 'Arbitrary2' since we have constraints on @k@.
 liftArbitrary2Map :: Ord k => Gen k -> Gen v -> Gen (Map k v)
-liftArbitrary2Map genk genv = Map.fromList <$> liftArbitrary (liftArbitrary2 genk genv)
+liftArbitrary2Map genk genv = Map.fromList <$>
+    liftArbitrary (liftArbitrary2 genk genv)
 
 -- | We cannot implement 'Arbitrary2' since we have constraints @k@.
 liftShrink2Map :: Ord k => (k -> [k]) -> (v -> [v]) -> Map k v -> [Map k v]
 liftShrink2Map shrinkk shrinkv m = Map.fromList <$>
     liftShrink (liftShrink2 shrinkk shrinkv) (Map.toList m)
+
+genNonEmptyRunData ::
+     Ord k => Gen k -> Gen v -> Gen b -> Gen (NonEmptyRunData k v b)
+genNonEmptyRunData genKey genVal genBlob = NonEmptyRunData <$>
+    liftArbitrary2NEMap genKey (liftArbitrary2 genVal genBlob)
+
+shrinkNonEmptyRunData ::
+     Ord k
+  => (k -> [k])
+  -> (v -> [v])
+  -> (b -> [b])
+  -> NonEmptyRunData k v b
+  -> [NonEmptyRunData k v b]
+shrinkNonEmptyRunData shrinkKey shrinkVal shrinkBlob =
+      fmap NonEmptyRunData
+    . liftShrink2NEMap shrinkKey (liftShrink2 shrinkVal shrinkBlob)
+    . unNonEmptyRunData
+
+-- | We cannot implement 'Arbitrary2' since we have constraints on @k@.
+liftArbitrary2NEMap :: Ord k => Gen k -> Gen v -> Gen (NEMap k v)
+liftArbitrary2NEMap genk genv = NEMap.fromList <$>
+    liftArbitrary (liftArbitrary2 genk genv)
+
+-- | We cannot implement 'Arbitrary2' since we have constraints @k@.
+liftShrink2NEMap :: Ord k => (k -> [k]) -> (v -> [v]) -> NEMap k v -> [NEMap k v]
+liftShrink2NEMap shrinkk shrinkv m = NEMap.fromList <$>
+    liftShrink (liftShrink2 shrinkk shrinkv) (NEMap.toList m)

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -24,6 +24,7 @@ module Database.LSMTree.Internal.MergingRun (
     -- * Credit tracking
     -- $credittracking
   , MergeDebt (..)
+  , numEntriesToMergeDebt
   , MergeCredits (..)
   , CreditThreshold (..)
   , SpentCredits (..)
@@ -184,7 +185,8 @@ new hfs hbio resolve caching alloc indexType mergeType runPaths inputRuns =
 -- failing after internal resources have already been created.
 newCompleted ::
      (MonadMVar m, MonadMask m, MonadSTM m, MonadST m)
-  => NumRuns
+  => NumRuns   -- ^ Since there are no longer any input runs, we need to be
+               -- told how many there were.
   -> MergeDebt -- ^ Since there are no longer any input runs, we need to be
                -- told what the merge debt was.
   -> Ref (Run m h)

--- a/test/Test/Database/LSMTree/Generators.hs
+++ b/test/Test/Database/LSMTree/Generators.hs
@@ -7,7 +7,6 @@ import           Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word64, Word8)
-
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators
 import           Database.LSMTree.Extras.MergingRunData
@@ -16,20 +15,24 @@ import           Database.LSMTree.Extras.ReferenceImpl
 import           Database.LSMTree.Extras.RunData
 import           Database.LSMTree.Internal.BlobRef (BlobSpan)
 import           Database.LSMTree.Internal.Entry
+import qualified Database.LSMTree.Internal.Index as Index
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.PageAcc (entryWouldFitInPage,
                      sizeofEntry)
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Serialise
-
-
+import           Database.LSMTree.Internal.UniqCounter
+import qualified System.FS.API as FS
+import qualified System.FS.BlockIO.API as FS
+import qualified System.FS.Sim.MockFS as MockFS
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck (Property)
 import           Test.Tasty (TestTree, localOption, testGroup)
 import           Test.Tasty.QuickCheck (QuickCheckMaxSize (..), testProperty,
                      (===))
 import           Test.Util.Arbitrary
+import           Test.Util.FS (propNoOpenHandles, withSimHasBlockIO)
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Generators" [
@@ -73,6 +76,11 @@ tests = testGroup "Test.Database.LSMTree.Generators" [
         prop_arbitraryAndShrinkPreserveInvariant
           labelRunData
           noInvariant
+     ++ [ testProperty "withRun doesn't leak resources" $ \rd ->
+            QC.ioProperty $
+              withSimHasBlockIO propNoOpenHandles MockFS.empty $ \hfs hbio _ ->
+                prop_withRunDoesntLeak hfs hbio rd
+        ]
     , testGroup "NonEmptyRunData" $
         prop_arbitraryAndShrinkPreserveInvariant
           labelNonEmptyRunData
@@ -82,10 +90,20 @@ tests = testGroup "Test.Database.LSMTree.Generators" [
           @(SerialisedMergingRunData MR.LevelMergeType)
           labelMergingRunData
           ((=== Right ()) . mergingRunDataInvariant)
+     ++ [ testProperty "withMergingRun doesn't leak resources" $ \mrd ->
+            QC.ioProperty $
+              withSimHasBlockIO propNoOpenHandles MockFS.empty $ \hfs hbio _ ->
+                prop_withMergingRunDoesntLeak hfs hbio mrd
+        ]
     , testGroup "MergingTreeData" $
         prop_arbitraryAndShrinkPreserveInvariant
           labelMergingTreeData
           ((=== Right ()) . mergingTreeDataInvariant)
+     ++ [ testProperty "withMergingTree doesn't leak resources" $ \mtd ->
+            QC.ioProperty $
+              withSimHasBlockIO propNoOpenHandles MockFS.empty $ \hfs hbio _ ->
+                prop_withMergingTreeDoesntLeak hfs hbio mtd
+        ]
     ]
 
 prop_packRawBytesPinnedOrUnpinned :: Bool -> [Word8] -> Bool
@@ -119,3 +137,42 @@ labelTestKOps kops' =
     values = foldMap (bifoldMap pure mempty . snd) kops
 
     isLarge = not . uncurry entryWouldFitInPage
+
+prop_withRunDoesntLeak ::
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> SerialisedRunData
+  -> IO Property
+prop_withRunDoesntLeak hfs hbio rd = do
+    let index = Index.Ordinary
+    withRunAt hfs hbio index (simplePath 0) rd $ \_run -> do
+      return (QC.property True)
+
+prop_withMergingRunDoesntLeak ::
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> SerialisedMergingRunData MR.LevelMergeType
+  -> IO Property
+prop_withMergingRunDoesntLeak hfs hbio mrd = do
+    let index = Index.Ordinary
+    let path = FS.mkFsPath []
+    counter <- newUniqCounter 0
+    withMergingRun hfs hbio resolveVal index path counter mrd $ \_mr -> do
+      return (QC.property True)
+
+-- TODO: This only tests the happy path. For everything else, we'd need to
+-- inject errors, e.g. with @simErrorHasBlockIO@.
+prop_withMergingTreeDoesntLeak ::
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> SerialisedMergingTreeData
+  -> IO Property
+prop_withMergingTreeDoesntLeak hfs hbio mrd = do
+    let index = Index.Ordinary
+    let path = FS.mkFsPath []
+    counter <- newUniqCounter 0
+    withMergingTree hfs hbio resolveVal index path counter mrd $ \_tree -> do
+      return (QC.property True)
+
+resolveVal :: SerialisedValue -> SerialisedValue -> SerialisedValue
+resolveVal (SerialisedValue x) (SerialisedValue y) = SerialisedValue (x <> y)

--- a/test/Test/Database/LSMTree/Internal/Merge.hs
+++ b/test/Test/Database/LSMTree/Internal/Merge.hs
@@ -24,6 +24,7 @@ import qualified Database.LSMTree.Internal.Run as Run
 import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..))
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.UniqCounter
 import qualified System.FS.API as FS
 import qualified System.FS.API.Lazy as FS
 import qualified System.FS.BlockIO.API as FS
@@ -69,12 +70,16 @@ prop_MergeDistributes ::
      StepSize ->
      SmallList (RunData KeyForIndexCompact SerialisedValue SerialisedBlob) ->
      IO Property
-prop_MergeDistributes fs hbio mergeType stepSize (SmallList rds) =
-    withRuns fs hbio Index.Compact (V.fromList (zip (simplePaths [10..]) rds')) $ \runs -> do
+prop_MergeDistributes fs hbio mergeType stepSize (SmallList rds) = do
+    let path = FS.mkFsPath []
+    counter <- newUniqCounter 0
+    withRuns fs hbio Index.Compact path counter rds' $ \runs -> do
       let stepsNeeded = sum (map (Map.size . unRunData) rds)
-      (stepsDone, lhs) <- mergeRuns fs hbio mergeType (RunNumber 0) runs stepSize
+
+      fsPathLhs <- RunFsPaths path . uniqueToRunNumber <$> incrUniqCounter counter
+      (stepsDone, lhs) <- mergeRuns fs hbio mergeType stepSize fsPathLhs runs
       let runData = RunData $ mergeWriteBuffers mergeType $ fmap unRunData rds'
-      withRun fs hbio Index.Compact (simplePath 1) runData $ \rhs -> do
+      withRun fs hbio Index.Compact path counter runData $ \rhs -> do
 
         (lhsSize, lhsFilter, lhsIndex, lhsKOps,
          lhsKOpsFileContent, lhsBlobFileContent) <- getRunContent lhs
@@ -141,13 +146,15 @@ prop_AbortMerge ::
      StepSize ->
      SmallList (RunData KeyForIndexCompact SerialisedValue SerialisedBlob) ->
      IO Property
-prop_AbortMerge fs hbio mergeType (Positive stepSize) (SmallList wbs) =
-    withRuns fs hbio Index.Compact (V.fromList (zip (simplePaths [10..]) wbs')) $ \runs -> do
-      let path0 = simplePath 0
-      mergeToClose <- makeInProgressMerge path0 runs
+prop_AbortMerge fs hbio mergeType (Positive stepSize) (SmallList wbs) = do
+    let path = FS.mkFsPath []
+    let pathOut = RunFsPaths path (RunNumber 0)
+    counter <- newUniqCounter 1
+    withRuns fs hbio Index.Compact path counter wbs' $ \runs -> do
+      mergeToClose <- makeInProgressMerge pathOut runs
       traverse_ Merge.abort mergeToClose
 
-      filesExist <- traverse (FS.doesFileExist fs) (pathsForRunFiles path0)
+      filesExist <- traverse (FS.doesFileExist fs) (pathsForRunFiles pathOut)
 
       return $
         counterexample ("run files exist: " <> show filesExist) $
@@ -157,7 +164,7 @@ prop_AbortMerge fs hbio mergeType (Positive stepSize) (SmallList wbs) =
 
     makeInProgressMerge path runs =
       Merge.new fs hbio Run.CacheRunData (RunAllocFixed 10) Index.Compact
-               mergeType mappendValues path runs >>= \case
+               mergeType mappendValues path (V.fromList runs) >>= \case
         Nothing -> return Nothing  -- not in progress
         Just merge -> do
           -- just do a few steps once, ideally not completing the merge
@@ -178,17 +185,17 @@ mergeRuns ::
      FS.HasFS IO h ->
      FS.HasBlockIO IO h ->
      MergeType ->
-     RunNumber ->
-     V.Vector (Ref (Run.Run IO h)) ->
      StepSize ->
+     RunFsPaths ->
+     [Ref (Run.Run IO h)] ->
      IO (Int, Ref (Run.Run IO h))
-mergeRuns fs hbio mergeType runNumber runs (Positive stepSize) = do
+mergeRuns fs hbio mergeType (Positive stepSize) fsPath runs = do
     Merge.new fs hbio Run.CacheRunData (RunAllocFixed 10) Index.Compact
-              mergeType mappendValues
-              (RunFsPaths (FS.mkFsPath []) runNumber) runs >>= \case
-      Nothing -> (,) 0 <$> unsafeFlushAsWriteBuffer fs hbio Index.Compact
-                             (RunFsPaths (FS.mkFsPath []) runNumber) (RunData Map.empty)
-      Just m  -> Merge.stepsToCompletionCounted m stepSize
+              mergeType mappendValues fsPath (V.fromList runs)
+      >>= \case
+        Just m  -> Merge.stepsToCompletionCounted m stepSize
+        Nothing -> (,) 0 <$> unsafeCreateRunAt fs hbio Index.Compact fsPath
+                               (RunData Map.empty)
 
 type SerialisedEntry = Entry.Entry SerialisedValue SerialisedBlob
 

--- a/test/Test/Database/LSMTree/Internal/Run.hs
+++ b/test/Test/Database/LSMTree/Internal/Run.hs
@@ -97,7 +97,7 @@ testSingleInsert sessionRoot key val mblob =
     -- flush write buffer
     let e = case mblob of Nothing -> Insert val; Just blob -> InsertWithBlob val blob
         wb = Map.singleton key e
-    withRun fs hbio Index.Compact (simplePath 42) (RunData wb) $ \_ -> do
+    withRunAt fs hbio Index.Compact (simplePath 42) (RunData wb) $ \_ -> do
       -- check all files have been written
       let activeDir = sessionRoot
       bsKOps <- BS.readFile (activeDir </> "42.keyops")
@@ -179,7 +179,7 @@ prop_WriteNumEntries ::
   -> RunData KeyForIndexCompact SerialisedValue SerialisedBlob
   -> IO Property
 prop_WriteNumEntries fs hbio wb@(RunData m) =
-    withRun fs hbio Index.Compact (simplePath 42) wb' $ \run -> do
+    withRunAt fs hbio Index.Compact (simplePath 42) wb' $ \run -> do
       let !runSize = Run.size run
 
       return . labelRunData wb' $
@@ -197,7 +197,7 @@ prop_WriteAndOpen ::
   -> RunData KeyForIndexCompact SerialisedValue SerialisedBlob
   -> IO Property
 prop_WriteAndOpen fs hbio wb =
-    withRun fs hbio Index.Compact (simplePath 1337) (serialiseRunData wb) $ \written ->
+    withRunAt fs hbio Index.Compact (simplePath 1337) (serialiseRunData wb) $ \written ->
     withActionRegistry $ \reg -> do
       let paths = Run.runFsPaths written
           paths' = paths { runNumber = RunNumber 17}
@@ -258,7 +258,7 @@ prop_WriteRunEqWriteWriteBuffer hfs hbio rd = do
   let rdPaths = simplePath 1337
   let rdKOpsFile = Paths.runKOpsPath rdPaths
   let rdBlobFile = Paths.runBlobPath rdPaths
-  withRun hfs hbio Index.Compact rdPaths srd $ \_run -> do
+  withRunAt hfs hbio Index.Compact rdPaths srd $ \_run -> do
     -- Serialise run data as write buffer:
     let f (SerialisedValue x) (SerialisedValue y) = SerialisedValue (x <> y)
     let inPaths = WrapRunFsPaths $ simplePath 1111

--- a/test/Test/Database/LSMTree/Internal/RunReader.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReader.hs
@@ -80,7 +80,7 @@ prop_readAtOffset ::
   -> Maybe BiasedKeyForIndexCompact
   -> IO Property
 prop_readAtOffset fs hbio rd offsetKey =
-    withRun fs hbio Index.Compact (simplePath 42) rd' $ \run -> do
+    withRunAt fs hbio Index.Compact (simplePath 42) rd' $ \run -> do
       rhs <- readKOps (coerce offsetKey) run
 
       return . labelRunData rd' $
@@ -124,7 +124,7 @@ prop_readAtOffsetIdempotence ::
   -> Maybe BiasedKeyForIndexCompact
   -> IO Property
 prop_readAtOffsetIdempotence fs hbio rd offsetKey =
-    withRun fs hbio Index.Compact (simplePath 42) rd' $ \run -> do
+    withRunAt fs hbio Index.Compact (simplePath 42) rd' $ \run -> do
     lhs <- readKOps (coerce offsetKey) run
     rhs <- readKOps (coerce offsetKey) run
 
@@ -148,7 +148,7 @@ prop_readAtOffsetReadHead ::
   -> RunData BiasedKeyForIndexCompact SerialisedValue SerialisedBlob
   -> IO Property
 prop_readAtOffsetReadHead fs hbio rd =
-    withRun fs hbio Index.Compact (simplePath 42) rd' $ \run -> do
+    withRunAt fs hbio Index.Compact (simplePath 42) rd' $ \run -> do
       lhs <- readKOps Nothing run
       rhs <- case lhs of
         []        -> return []

--- a/test/Test/Database/LSMTree/Internal/RunReaders.hs
+++ b/test/Test/Database/LSMTree/Internal/RunReaders.hs
@@ -337,7 +337,7 @@ runIO act lu = case act of
           wbs' = fmap serialiseRunData wbs
       runs <-
         zipWithM
-          (\p -> liftIO . unsafeFlushAsWriteBuffer hfs hbio Index.Compact p)
+          (\p -> liftIO . unsafeCreateRunAt hfs hbio Index.Compact p)
           (Paths.RunFsPaths (FS.mkFsPath []) . RunNumber <$> [numRuns ..])
           wbs'
       newReaders <- liftIO $ do

--- a/test/Test/Util/Arbitrary.hs
+++ b/test/Test/Util/Arbitrary.hs
@@ -2,6 +2,7 @@ module Test.Util.Arbitrary (
     prop_arbitraryAndShrinkPreserveInvariant
   , prop_forAllArbitraryAndShrinkPreserveInvariant
   , deepseqInvariant
+  , noInvariant
   , noTags
   ) where
 
@@ -37,6 +38,9 @@ prop_forAllArbitraryAndShrinkPreserveInvariant tag gen shr inv =
 -- | Trivial invariant, but checks that the value is finite
 deepseqInvariant :: NFData a => a -> Bool
 deepseqInvariant x = x `deepseq` True
+
+noInvariant :: a -> Bool
+noInvariant _ = True
 
 noTags :: a -> Property -> Property
 noTags _ = id


### PR DESCRIPTION
# Description

Similarly to the existing `RunData`, these are simplified versions of `MergingRun` and `MergingTree`, which can be generated, shrunk and turned into their full on-disk versions.

I also added labelling and tests for the generators and shrinkers, as well as the code creating the `MergingTree` etc. from the data.

The tests are quite slow even after halving the maximum size. The main issue is that `RunData` has a lot of possible shrinks (sometimes over 100k), which gets even worse when there are dozens of them in the tree.

<details>
<summary>test output</summary>

```
  Test.Database.LSMTree.Generators
    RunData
      Arbitrary satisfies invariant:          OK (0.60s)
        +++ OK, passed 100 tests.
        
        run has large k/ops (100 in total):
        52% has large k/op
        48% no large k/op
        
        run length (100 in total):
        68% 10 <= n < 100
        26% 1 <= n < 10
         6% n == 0
        
        value size (1974 in total):
        53.80% 10 <= n < 100
        17.88% 100 <= n < 1000
        15.75% 1000 <= n < 10000
        11.65% 1 <= n < 10
         0.91% n == 0
      Shrinking satisfies invariant:          OK (6.67s)
        +++ OK, passed 100 tests (3% no shrinks).
        
        number of shrinks (97 in total):
        45% 10000 <= n < 100000
        32% 1000 <= n < 10000
        20% 100 <= n < 1000
         3% 10 <= n < 100
      withRun doesn't leak resources:         OK (0.65s)
        +++ OK, passed 100 tests.
    NonEmptyRunData
      Arbitrary satisfies invariant:          OK (0.69s)
        +++ OK, passed 100 tests.
        
        run has large k/ops (100 in total):
        57% has large k/op
        43% no large k/op
        
        run length (100 in total):
        67% 10 <= n < 100
        33% 1 <= n < 10
        
        value size (2475 in total):
        54.71% 10 <= n < 100
        18.83% 100 <= n < 1000
        15.27% 1000 <= n < 10000
        10.79% 1 <= n < 10
         0.40% n == 0
      Shrinking satisfies invariant:          OK (14.08s)
        +++ OK, passed 100 tests (1% no shrinks).
        
        number of shrinks (99 in total):
        45% 10000 <= n < 100000
        38% 1000 <= n < 10000
        12% 100 <= n < 1000
         2% 1 <= n < 10
         2% 10 <= n < 100
    MergingRunData
      Arbitrary satisfies invariant:          OK (0.56s)
        +++ OK, passed 100 tests.
        
        merge type (100 in total):
        50% MergeLastLevel
        50% MergeMidLevel
        
        merging run inputs (53 in total):
        55% 4 <= n < 8
        36% 2 <= n < 4
         9% 8 <= n < 16
        
        merging run state (100 in total):
        53% OngoingMerge
        47% CompletedMerge
        
        run has large k/ops (295 in total):
        75.3% no large k/op
        24.7% has large k/op
        
        run length (295 in total):
        74.6% 1 <= n < 10
        23.7% 10 <= n < 100
         1.7% n == 0
        
        value size (2138 in total):
        33.77% 10 <= n < 100
        30.17% 1 <= n < 10
        17.87% 100 <= n < 1000
        16.09% 1000 <= n < 10000
         2.10% n == 0
      Shrinking satisfies invariant:          OK (4.02s)
        +++ OK, passed 100 tests.
        
        number of shrinks (100 in total):
        47% 1000 <= n < 10000
        24% 100 <= n < 1000
        24% 10000 <= n < 100000
         3% 1 <= n < 10
         2% 10 <= n < 100
      withMergingRun doesn't leak resources:  OK (0.80s)
        +++ OK, passed 100 tests.
    MergingTreeData
      Arbitrary satisfies invariant:          OK (4.25s)
        +++ OK, passed 100 tests.
        
        merge type (593 in total):
        40.6% MergeMidLevel
        37.1% MergeLastLevel
        12.5% MergeLevel
         9.8% MergeUnion
        
        merging run inputs (278 in total):
        52.5% 4 <= n < 8
        33.1% 2 <= n < 4
        14.4% 8 <= n < 16
        
        merging run state (593 in total):
        53.1% CompletedMerge
        46.9% OngoingMerge
        
        merging tree state (604 in total):
        29.8% PendingLevelMerge
        25.0% PendingUnionMerge
        23.3% CompletedTreeMerge
        21.9% OngoingTreeMerge
        
        run has large k/ops (2214 in total):
        72.36% no large k/op
        27.64% has large k/op
        
        run length (2214 in total):
        70.28% 1 <= n < 10
        28.27% 10 <= n < 100
         1.45% n == 0
        
        tree depth (100 in total):
        51% 2 <= n < 4
        38% 4 <= n < 8
        11% 1 <= n < 2
        
        value size (16784 in total):
        37.786% 10 <= n < 100
        27.359% 1 <= n < 10
        17.165% 100 <= n < 1000
        15.473% 1000 <= n < 10000
         2.216% n == 0
      Shrinking satisfies invariant:          OK (22.70s)
        +++ OK, passed 100 tests (2% no shrinks).
        
        number of shrinks (98 in total):
        39% 10000 <= n < 100000
        24% 1000 <= n < 10000
        21% 100000 <= n < 1000000
        13% 100 <= n < 1000
         1% 1 <= n < 10
         1% 10 <= n < 100
      withMergingTree doesn't leak resources: OK (6.39s)
        +++ OK, passed 100 tests.
```

</details>
