### PR TITLE
Improve the reliability of forgotten refs checking in the state machine tests

### DIFF
--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -547,7 +547,11 @@ checkForgottenRefs = do
   where
 #endif
 
--- | Run 'checkForgottenRefs', but ignore the resulting exception, if any.
+-- | Ignore and reset the state of forgotten reference tracking. This ensures
+-- that any stale fogotten references are not reported later.
+--
+-- This is especillay important in QC tests with shrinking which otherwise
+-- leads to confusion.
 ignoreForgottenRefs :: IO ()
 ignoreForgottenRefs = void $ try @_ @SomeException $ checkForgottenRefs
 


### PR DESCRIPTION
Make sure the forgotten refs state is reset reliably after each run, so that during shrinking we do not get false errors from previous runs causing us to produce nonsense shrunk test cases.