### PR TITLE
In the state machine tests, shrink mupserts and table unions

### DIFF
--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -1687,6 +1687,19 @@ shrinkActionWithVars _ctx _st = \case
       | let f k = (k, R.Delete)
       ]
 
+    Mupserts kvs tableVar -> [
+        Some $ Mupserts kvs' tableVar
+      | kvs' <- QC.shrink kvs
+      ] <> [
+        Some $ Updates (V.map f kvs) tableVar
+      | let f (k, v) = (k, R.Mupsert v)
+      ]
+
+    Unions tableVars -> [
+        Some $ Unions tableVars'
+      | tableVars' <- QC.liftShrink (const []) tableVars
+      ]
+
     Lookups ks tableVar -> [ Some $ Lookups ks' tableVar | ks' <- QC.shrink ks ]
 
     -- Snapshots


### PR DESCRIPTION
This gives us reasonable shrunk test sizes if you happen to hit mupserts, and also helps considerably with multi-way unions.