### PR TITLE
Improve readability of numbers in traces and errors

### DIFF
--- a/src/Database/LSMTree/Internal/Paths.hs
+++ b/src/Database/LSMTree/Internal/Paths.hs
@@ -209,7 +209,7 @@ runChecksumsPath :: RunFsPaths -> FsPath
 runChecksumsPath = flip runFilePathWithExt "checksums"
 
 runFilePathWithExt :: RunFsPaths -> String -> FsPath
-runFilePathWithExt (RunFsPaths dir n) ext =
+runFilePathWithExt (RunFsPaths dir (RunNumber n)) ext =
     dir </> mkFsPath [show n] <.> ext
 
 runFileExts :: ForRunFiles String
@@ -311,7 +311,7 @@ writeBufferChecksumsPath :: WriteBufferFsPaths -> FsPath
 writeBufferChecksumsPath = flip writeBufferFilePathWithExt "checksums"
 
 writeBufferFilePathWithExt :: WriteBufferFsPaths -> String -> FsPath
-writeBufferFilePathWithExt (WriteBufferFsPaths dir n) ext =
+writeBufferFilePathWithExt (WriteBufferFsPaths dir (RunNumber n)) ext =
     dir </> mkFsPath [show n] <.> ext
 
 

--- a/src/Database/LSMTree/Internal/RunNumber.hs
+++ b/src/Database/LSMTree/Internal/RunNumber.hs
@@ -7,10 +7,13 @@ module Database.LSMTree.Internal.RunNumber (
 import           Control.DeepSeq (NFData)
 
 newtype RunNumber = RunNumber Int
-  deriving newtype (Eq, Ord, Show, NFData)
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (NFData)
 
 newtype TableId = TableId Int
-  deriving newtype (Eq, Ord, Show, NFData)
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (NFData)
 
 newtype CursorId = CursorId Int
-  deriving newtype (Eq, Ord, Show, NFData)
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (NFData)


### PR DESCRIPTION
Use stock derived show for newtypes RunNumber, TableId and CursorId, rather than newtype derived. This means they get rendered as "RunNumber 3" rather than 3. This makes traces easier to read. It also means when things are shown in errors or ghci output, the result can be pasted back in again as valid syntax.

Carefully checked that show was not being used for anything other than derived show for other types, so we don't change the rendering of anything important. Did this by temporarily removing the show instance entirely and looking for build errors. Fixed two such cases in file path rendering.