### PR TITLE
Make `RefException`s `catch`able in `IOSim`

### DIFF
--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -256,7 +256,7 @@ releaseRef ref@Ref{refobj} = do
 -- | Get the object in a 'Ref'. Be careful with retaining the object for too
 -- long, since the object must not be used after 'releaseRef' is called.
 --
-pattern DeRef :: obj -> Ref obj
+pattern DeRef :: HasCallStackIfDebug => obj -> Ref obj
 #ifndef NO_IGNORE_ASSERTS
 pattern DeRef obj <- Ref obj
 #else

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -420,7 +420,7 @@ releaseIncomingRun (Merging _ _ _ mr) = releaseRef mr
   -> Ref (Run IO h)
   -> IO (IncomingRun IO h) #-}
 newIncomingSingleRun ::
-     PrimMonad m
+     (PrimMonad m, MonadThrow m)
   => Tracer m (AtLevel MergeTrace)
   -> LevelNo
   -> Ref (Run m h)


### PR DESCRIPTION
`RefException`s are currently thrown from `IO`, but we can not catch these exceptions in `IOSim`. This PR makes changes to ensure we can catch (almost all) exceptions in any monad that has the right constraints. The only exceptions we still can't catch outside of `IO` are exceptions thrown by the `DeRef` pattern.