### PR TITLE
Lookups in merging tree

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -141,6 +141,7 @@ library
     Database.LSMTree.Internal.MergeSchedule
     Database.LSMTree.Internal.MergingRun
     Database.LSMTree.Internal.MergingTree
+    Database.LSMTree.Internal.MergingTree.Lookup
     Database.LSMTree.Internal.Page
     Database.LSMTree.Internal.PageAcc
     Database.LSMTree.Internal.PageAcc1

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -49,7 +49,8 @@ module Database.LSMTree.Common (
   ) where
 
 import           Control.Concurrent.Class.MonadMVar.Strict
-import           Control.Concurrent.Class.MonadSTM (MonadSTM, STM)
+import           Control.Concurrent.Class.MonadSTM (STM)
+import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive (PrimMonad)
@@ -74,8 +75,8 @@ import           System.FS.IO (HandleIO)
 -------------------------------------------------------------------------------}
 
 -- | Utility class for grouping @io-classes@ constraints.
-class ( MonadMVar m, MonadSTM m, MonadThrow (STM m), MonadThrow m, MonadCatch m
-      , MonadMask m, PrimMonad m, MonadST m
+class ( MonadAsync m, MonadMVar m, MonadThrow (STM m), MonadThrow m
+      , MonadCatch m , MonadMask m, PrimMonad m, MonadST m
       ) => IOLike m
 
 instance IOLike IO

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -82,6 +82,7 @@ import           Control.Concurrent.Class.MonadSTM.RWVar (RWVar)
 import qualified Control.Concurrent.Class.MonadSTM.RWVar as RW
 import           Control.DeepSeq
 import           Control.Monad (forM, unless, void)
+import           Control.Monad.Class.MonadAsync as Async
 import           Control.Monad.Class.MonadST (MonadST (..))
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive
@@ -105,9 +106,12 @@ import           Database.LSMTree.Internal.Config
 import qualified Database.LSMTree.Internal.Cursor as Cursor
 import           Database.LSMTree.Internal.Entry (Entry)
 import           Database.LSMTree.Internal.Lookup (ByteCountDiscrepancy,
-                     ResolveSerialisedValue, lookupsIO)
+                     ResolveSerialisedValue, lookupsIO,
+                     lookupsIOWithoutWriteBuffer)
 import           Database.LSMTree.Internal.MergeSchedule
+import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.MergingTree
+import qualified Database.LSMTree.Internal.MergingTree.Lookup as MT
 import           Database.LSMTree.Internal.Paths (SessionRoot (..),
                      SnapshotMetaDataChecksumFile (..),
                      SnapshotMetaDataFile (..), SnapshotName)
@@ -123,6 +127,7 @@ import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..),
 import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.Snapshot.Codec
 import           Database.LSMTree.Internal.UniqCounter
+import qualified Database.LSMTree.Internal.Vector as V
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import qualified Database.LSMTree.Internal.WriteBufferBlobs as WBB
 import qualified System.FS.API as FS
@@ -799,7 +804,7 @@ close t = do
   -> IO (V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef IO h)))) #-}
 -- | See 'Database.LSMTree.Normal.lookups'.
 lookups ::
-     (MonadST m, MonadSTM m, MonadThrow m)
+     (MonadAsync m, MonadMask m, MonadMVar m, MonadST m)
   => ResolveSerialisedValue
   -> V.Vector SerialisedKey
   -> Table m h
@@ -807,8 +812,40 @@ lookups ::
 lookups resolve ks t = do
     traceWith (tableTracer t) $ TraceLookups (V.length ks)
     withOpenTable t $ \tEnv ->
-      RW.withReadAccess (tableContent tEnv) $ \tableContent ->
-        let !cache = tableCache tableContent in
+      RW.withReadAccess (tableContent tEnv) $ \tableContent -> do
+        case tableUnionLevel tableContent of
+          NoUnion -> regularLevelLookups tEnv tableContent
+          Union tree -> do
+            isStructurallyEmpty tree >>= \case
+              True  -> regularLevelLookups tEnv tableContent
+              False ->
+                -- TODO: the blob refs returned from the tree can be invalidated
+                -- by supplyUnionCredits or other operations on any table that
+                -- shares merging runs or trees. We need to keep open the runs!
+                -- This could be achieved by storing the LookupTree and only
+                -- calling MT.releaseLookupTree later, when we are okay with
+                -- invalidating the blob refs (similar to the LevelsCache).
+                -- Lookups then use the cached tree, but when should we rebuild
+                -- the tree? On each call to supplyUnionCredits?
+                withActionRegistry $ \reg -> do
+                  regularResult <-
+                    -- asynchronously, so tree lookup batches can already be
+                    -- submitted without waiting for the result.
+                    Async.async $ regularLevelLookups tEnv tableContent
+                  treeBatches <- MT.buildLookupTree reg tree
+                  treeResults <- forM treeBatches $ \runs ->
+                    Async.async $ treeBatchLookups tEnv runs
+                  -- TODO: if regular levels are empty, don't add them to tree
+                  res <- MT.foldLookupTree resolve $
+                    MT.mkLookupNode MR.MergeLevel $ V.fromList
+                      [ MT.LookupBatch regularResult
+                      , treeResults
+                      ]
+                  MT.releaseLookupTree reg treeBatches
+                  return res
+  where
+    regularLevelLookups tEnv tableContent = do
+        let !cache = tableCache tableContent
         lookupsIO
           (tableHasBlockIO tEnv)
           (tableArenaManager t)
@@ -819,6 +856,17 @@ lookups resolve ks t = do
           (cachedFilters cache)
           (cachedIndexes cache)
           (cachedKOpsFiles cache)
+          ks
+
+    treeBatchLookups tEnv runs =
+        lookupsIOWithoutWriteBuffer
+          (tableHasBlockIO tEnv)
+          (tableArenaManager t)
+          resolve
+          runs
+          (V.mapStrict (\(DeRef r) -> Run.runFilter   r) runs)
+          (V.mapStrict (\(DeRef r) -> Run.runIndex    r) runs)
+          (V.mapStrict (\(DeRef r) -> Run.runKOpsFile r) runs)
           ks
 
 {-# SPECIALISE rangeLookup ::

--- a/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
+++ b/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
@@ -1,0 +1,138 @@
+module Database.LSMTree.Internal.MergingTree.Lookup (
+    LookupTree (..)
+  , mkLookupNode
+  , buildLookupTree
+  , releaseLookupTree
+  , foldLookupTree
+  ) where
+
+import           Control.ActionRegistry
+import           Control.Concurrent.Class.MonadMVar.Strict
+import           Control.Exception (assert)
+import           Control.Monad.Class.MonadAsync (Async, MonadAsync)
+import qualified Control.Monad.Class.MonadAsync as Async
+import           Control.Monad.Class.MonadThrow (MonadMask)
+import           Control.Monad.Primitive
+import           Control.RefCount
+import           Data.Foldable (traverse_)
+import qualified Data.Vector as V
+import qualified Database.LSMTree.Internal.Entry as Entry
+import           Database.LSMTree.Internal.Lookup (LookupAcc,
+                     ResolveSerialisedValue)
+import qualified Database.LSMTree.Internal.MergingRun as MR
+import qualified Database.LSMTree.Internal.MergingTree as MT
+import           Database.LSMTree.Internal.Run (Run)
+
+-- | A simplified representation of the shape of a 'MT.MergingTree'.
+data LookupTree a =
+    LookupBatch !a
+    -- | Use 'mkLookupNode' to construct this.
+  | LookupNode !MR.TreeMergeType !(V.Vector (LookupTree a))  -- ^ length 2 or more
+  deriving stock (Foldable, Functor, Traversable)
+
+-- | Asserts that the vector is non-empty. Collapses singleton nodes.
+mkLookupNode :: MR.TreeMergeType -> V.Vector (LookupTree a) -> LookupTree a
+mkLookupNode ty ts
+  | assert (not (null ts)) (V.length ts == 1) = V.head ts
+  | otherwise                                 = LookupNode ty ts
+
+-- | Combine a tree of accs into a single one, using the 'MR.TreeMergeType' of
+-- each node.
+{-# SPECIALISE foldLookupTree ::
+     ResolveSerialisedValue
+  -> LookupTree (Async IO (LookupAcc IO h))
+  -> IO (LookupAcc IO h) #-}
+foldLookupTree ::
+     MonadAsync m
+  => ResolveSerialisedValue
+  -> LookupTree (Async m (LookupAcc m h))
+  -> m (LookupAcc m h)
+foldLookupTree resolve = \case
+    LookupBatch batch ->
+      Async.wait batch
+    LookupNode mt children ->
+      mergeLookupAcc resolve mt <$> traverse (foldLookupTree resolve) children
+
+-- | Requires multiple inputs, all of the same length.
+--
+-- TODO: do more efficiently on mutable vectors?
+mergeLookupAcc ::
+     ResolveSerialisedValue
+  -> MR.TreeMergeType
+  -> V.Vector (LookupAcc m h)
+  -> LookupAcc m h
+mergeLookupAcc resolve mt accs =
+    -- TODO assert (not (null accs)) $
+    assert (V.length accs > 1) $
+    assert (V.all ((== V.length (V.head accs)) . V.length) accs) $
+      foldl1 (V.zipWith updateEntry) accs
+  where
+    updateEntry Nothing    old        = old
+    updateEntry new        Nothing    = new
+    updateEntry (Just new) (Just old) = Just (combine new old)
+
+    combine = case mt of
+        MR.MergeLevel -> Entry.combine resolve
+        MR.MergeUnion -> Entry.combineUnion resolve
+
+-- | Create a 'LookupTree' of batches of runs, e.g. to do lookups on. The
+-- entries within each batch are to be combined using 'MR.MergeLevel'.
+--
+-- Assumes that the merging tree is not 'MT.isStructurallyEmpty'.
+--
+-- This function duplicates the references to all the tree's runs.
+-- These references later need to be released using 'releaseLookupTree'.
+--
+-- This function should be run with asynchronous exceptions masked to prevent
+-- failing after internal resources have already been created.
+{-# SPECIALISE buildLookupTree ::
+     ActionRegistry IO
+  -> Ref (MT.MergingTree IO h)
+  -> IO (LookupTree (V.Vector (Ref (Run IO h)))) #-}
+buildLookupTree ::
+     (PrimMonad m, MonadMVar m, MonadMask m)
+  => ActionRegistry m
+  -> Ref (MT.MergingTree m h)
+  -> m (LookupTree (V.Vector (Ref (Run m h))))
+buildLookupTree reg (DeRef mt) =
+    -- we make sure the state is not updated while we look at it, so no runs get
+    -- dropped before we duplicated the reference.
+    withMVar (MT.mergeState mt) $ \case
+      MT.CompletedTreeMerge r ->
+        LookupBatch . V.singleton <$> dupRun r
+      MT.OngoingTreeMerge mr -> do
+        rs <- withRollback reg (MR.duplicateRuns mr) (V.mapM_ releaseRef)
+        ty <- MR.mergeType mr
+        return $ case ty of
+          Nothing            -> LookupBatch rs  -- just one run
+          Just MR.MergeLevel -> LookupBatch rs  -- combine runs
+          Just MR.MergeUnion -> mkLookupNode MR.MergeUnion  -- separate
+                                  (LookupBatch . V.singleton <$> rs)
+      MT.PendingTreeMerge (MT.PendingLevelMerge prs Nothing) -> do
+        LookupBatch . V.concat . V.toList <$>  -- combine runs
+          traverse duplicatePreExistingRun prs
+      MT.PendingTreeMerge (MT.PendingLevelMerge prs (Just tree)) -> do
+        child <- buildLookupTree reg tree
+        if V.null prs
+          then return child
+          else do
+            preExisting <- do
+              LookupBatch . V.concat . V.toList <$>  -- combine runs
+                traverse duplicatePreExistingRun prs
+            return $ mkLookupNode MR.MergeLevel $ V.fromList [preExisting, child]
+      MT.PendingTreeMerge (MT.PendingUnionMerge trees) ->
+        mkLookupNode MR.MergeUnion <$> traverse (buildLookupTree reg) trees
+  where
+    dupRun r = withRollback reg (dupRef r) releaseRef
+
+    duplicatePreExistingRun (MT.PreExistingRun r) =
+        V.singleton <$> dupRun r
+    duplicatePreExistingRun (MT.PreExistingMergingRun mr) =
+        withRollback reg (MR.duplicateRuns mr) (V.mapM_ releaseRef)
+
+{-# SPECIALISE releaseLookupTree ::
+     ActionRegistry IO -> LookupTree (V.Vector (Ref (Run IO h))) -> IO () #-}
+releaseLookupTree ::
+     (PrimMonad m, MonadMask m)
+  => ActionRegistry m -> LookupTree (V.Vector (Ref (Run m h))) -> m ()
+releaseLookupTree reg = traverse_ (traverse_ (delayedCommit reg . releaseRef))

--- a/test/Test/Database/LSMTree/Internal/MergingTree.hs
+++ b/test/Test/Database/LSMTree/Internal/MergingTree.hs
@@ -1,15 +1,43 @@
 module Test.Database.LSMTree.Internal.MergingTree (tests) where
 
+import           Control.ActionRegistry
 import           Control.Exception (bracket)
+import           Control.Monad.Class.MonadAsync as Async
 import           Control.RefCount
+import           Data.Arena (newArenaManager)
+import           Data.Foldable (toList)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Vector as V
+import           Database.LSMTree.Extras.MergingRunData
+import           Database.LSMTree.Extras.MergingTreeData
+import           Database.LSMTree.Extras.RunData
+import           Database.LSMTree.Internal.BlobRef
+import           Database.LSMTree.Internal.Entry (Entry)
+import qualified Database.LSMTree.Internal.Entry as Entry
+import qualified Database.LSMTree.Internal.Index as Index
+import qualified Database.LSMTree.Internal.Lookup as Lookup
+import           Database.LSMTree.Internal.MergingRun
 import           Database.LSMTree.Internal.MergingTree
+import           Database.LSMTree.Internal.MergingTree.Lookup
+import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.UniqCounter
+import qualified System.FS.API as FS
+import qualified System.FS.BlockIO.API as FS
+import qualified System.FS.Sim.MockFS as MockFS
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
+import           Test.Util.FS (propNoOpenHandles, withSimHasBlockIO)
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.MergingTree"
     [ testProperty "prop_isStructurallyEmpty" prop_isStructurallyEmpty
+    , testProperty "prop_lookupTree" $ \keys mtd ->
+        ioProperty $
+          withSimHasBlockIO propNoOpenHandles MockFS.empty $ \hfs hbio _ ->
+            prop_lookupTree hfs hbio keys mtd
     ]
 
 -- | Check that the merging tree constructor functions preserve the property
@@ -63,3 +91,102 @@ mkEmptyMergingTree (NonObviouslyEmptyUnionMerge emts) = do
     mapM_ releaseRef mts
     return mt'
 
+{-------------------------------------------------------------------------------
+  Lookup
+-------------------------------------------------------------------------------}
+
+prop_lookupTree ::
+     forall h.
+     FS.HasFS IO h
+  -> FS.HasBlockIO IO h
+  -> V.Vector SerialisedKey
+  -> MergingTreeData SerialisedKey SerialisedValue SerialisedBlob
+  -> IO Property
+prop_lookupTree hfs hbio keys (serialiseMergingTreeData -> mtd) = do
+    let index = Index.Ordinary
+    let path = FS.mkFsPath []
+    counter <- newUniqCounter 0
+    withMergingTree hfs hbio resolveVal index path counter mtd $ \tree -> do
+      arenaManager <- newArenaManager
+      withActionRegistry $ \reg -> do
+        res <- fetchBlobs =<< lookupsIO reg arenaManager tree
+        return $
+          normalise res
+            === normalise (modelLookup (modelFoldMergingTree mtd) keys)
+  where
+    fetchBlobs ::
+         V.Vector (Maybe (Entry v (WeakBlobRef IO h)))
+      -> IO (V.Vector (Maybe (Entry v SerialisedBlob)))
+    fetchBlobs = traverse (traverse (traverse (readWeakBlobRef hfs)))
+
+    -- trees are always in the last level, there is no distinction between
+    -- (Nothing and Just Delete), (Insert and Mupsert)
+    normalise = V.map toLookupResult
+
+    toLookupResult Nothing  = Nothing
+    toLookupResult (Just e) = case e of
+      Entry.Insert v           -> Just (v, Nothing)
+      Entry.InsertWithBlob v b -> Just (v, Just b)
+      Entry.Mupdate v          -> Just (v, Nothing)
+      Entry.Delete             -> Nothing
+
+    lookupsIO reg mgr tree =
+        isStructurallyEmpty tree >>= \case
+          True ->
+            -- if the tree was empty, then the model should also have no results
+            return $ V.map (const Nothing) keys
+          False -> do
+            batches <- buildLookupTree reg tree
+            releaseLookupTree reg batches  -- only happens at the end
+            results <- traverse (performLookups mgr) batches
+            foldLookupTree resolveVal results
+
+    performLookups mgr runs =
+        Async.async $
+          Lookup.lookupsIOWithoutWriteBuffer
+            hbio
+            mgr
+            resolveVal
+            runs
+            (fmap (\(DeRef r) -> Run.runFilter   r) runs)
+            (fmap (\(DeRef r) -> Run.runIndex    r) runs)
+            (fmap (\(DeRef r) -> Run.runKOpsFile r) runs)
+            keys
+
+type SerialisedEntry = Entry SerialisedValue SerialisedBlob
+type LookupAcc' = V.Vector (Maybe (Entry SerialisedValue SerialisedBlob))
+
+modelLookup :: Map SerialisedKey SerialisedEntry -> V.Vector SerialisedKey -> LookupAcc'
+modelLookup m = V.map (\k -> Map.lookup k m)
+
+modelFoldMergingTree :: SerialisedMergingTreeData -> Map SerialisedKey SerialisedEntry
+modelFoldMergingTree = goMergingTree
+  where
+    goMergingTree :: SerialisedMergingTreeData -> Map SerialisedKey SerialisedEntry
+    goMergingTree = \case
+        CompletedTreeMergeData r ->
+          unRunData r
+        OngoingTreeMergeData mr ->
+          goMergingRun mr
+        PendingLevelMergeData prs t ->
+          modelMerge MergeLevel (map goPreExistingRun prs <> map goMergingTree (toList t))
+        PendingUnionMergeData ts ->
+          modelMerge MergeUnion (map goMergingTree ts)
+
+    goPreExistingRun = \case
+        PreExistingRunData r -> unRunData r
+        PreExistingMergingRunData mr -> goMergingRun mr
+
+    goMergingRun :: IsMergeType t => SerialisedMergingRunData t -> Map SerialisedKey SerialisedEntry
+    goMergingRun = \case
+        CompletedMergeData _ _ r -> unRunData r
+        OngoingMergeData mt rs -> modelMerge mt (map (unRunData . toRunData) rs)
+
+modelMerge :: (Ord k, IsMergeType t) => t -> [Map k SerialisedEntry] -> Map k SerialisedEntry
+modelMerge mt = handleDeletes . Map.unionsWith (combine resolveVal)
+  where
+    handleDeletes = if isLastLevel mt then Map.filter (/= Entry.Delete) else id
+    combine = if isUnion mt then Entry.combineUnion else Entry.combine
+
+resolveVal :: SerialisedValue -> SerialisedValue -> SerialisedValue
+resolveVal (SerialisedValue x) (SerialisedValue y) = SerialisedValue (x <> y)


### PR DESCRIPTION
# Description

There are a few TODOs that can still be improved, but doesn't necessarily have to be in this PR.

The last commit should still be dropped (in favour of #611), but shows that the lockstep tests pass with unions enabled.
