### PR TITLE
Add assertions about keys to ordinary-index construction

### DIFF
--- a/src/Database/LSMTree/Internal/Index/OrdinaryAcc.hs
+++ b/src/Database/LSMTree/Internal/Index/OrdinaryAcc.hs
@@ -33,7 +33,11 @@ import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.Vector (byteVectorFromPrim)
 import           Database.LSMTree.Internal.Vector.Growing (GrowingVector)
 import qualified Database.LSMTree.Internal.Vector.Growing as Growing (append,
-                     freeze, new, readMaybeLast)
+                     freeze, new)
+#ifdef NO_IGNORE_ASSERTS
+import qualified Database.LSMTree.Internal.Vector.Growing as Growing
+                     (readMaybeLast)
+#endif
 
 {-|
     A general-purpose fence pointer index under incremental construction.


### PR DESCRIPTION
This pull request adds assertions that guarantee that minimum keys used in the construction of ordinary indexes fulfill necessary conditions.

This addition is important because we plan to change the tests of higher-level modules to use ordinary indexes instead of compact ones. After this change, these tests wouldn’t catch passing of bogus minimum keys anymore without the extra assertions of this pull request, since minimum keys are ignored when building ordinary indexes.
