### PR TITLE
Enable unions in lockstep tests

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -1649,4 +1649,9 @@ supplyUnionCredits t credits = do
       RW.withWriteAccess (tableContent tEnv) $ \tableContent ->
         case tableUnionLevel tableContent of
           NoUnion -> pure (tableContent, credits) -- all leftovers
-          Union{} -> error "supplyUnionCredits: not yet implemented"
+          Union{}
+           | credits <= UnionCredits 0 -> pure (tableContent, UnionCredits 0)
+           --TODO: remove this 0 special case once the general case covers it.
+           -- We do not need to optimise the 0 case. It is just here to
+           -- simplify test coverage.
+           | otherwise -> error "supplyUnionCredits: not yet implemented"

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -358,10 +358,7 @@ iforLevelM_ lvls k = V.iforM_ lvls $ \i lvl -> k (LevelNo (i + 1)) lvl
 -- of multiple runs, but a nested tree of merges.
 --
 -- TODO: So far, this is
--- * never created
--- * not stored in snapshots
--- * not loaded from snapshots
--- * ignored in lookups
+-- * not considered when creating cursors (also used for range lookups)
 -- * never made merge progress on (by supplying credits to it)
 -- * never merged into the regular levels
 data UnionLevel m h =

--- a/test/Database/LSMTree/Model/Session.hs
+++ b/test/Database/LSMTree/Model/Session.hs
@@ -846,7 +846,7 @@ supplyUnionCredits ::
 supplyUnionCredits t@Table{..} c@(UnionCredits credits)
   | credits <= 0 = do
       _ <- guardTableIsOpen t
-      pure c
+      pure (UnionCredits 0) -- always 0, not negative
   | otherwise = do
       (updc, table) <- guardTableIsOpen t
       when (isUnionDescendant == IsUnionDescendant) $

--- a/test/Database/LSMTree/Model/Session.hs
+++ b/test/Database/LSMTree/Model/Session.hs
@@ -844,7 +844,9 @@ supplyUnionCredits ::
   -> UnionCredits
   -> m UnionCredits
 supplyUnionCredits t@Table{..} c@(UnionCredits credits)
-  | credits <= 0 = pure c
+  | credits <= 0 = do
+      _ <- guardTableIsOpen t
+      pure c
   | otherwise = do
       (updc, table) <- guardTableIsOpen t
       when (isUnionDescendant == IsUnionDescendant) $

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -2221,7 +2221,7 @@ instance InterpretOp Op (ModelValue (ModelState h)) where
 data Stats = Stats {
     -- === Tags
     -- | Names for which snapshots exist
-    snapshotted        :: Set R.SnapshotName
+    snapshotted        :: !(Set R.SnapshotName)
     -- === Final tags (per action sequence, across all tables)
     -- | Number of succesful lookups and their results
   , numLookupsResults  :: {-# UNPACK #-} !(Int, Int, Int)
@@ -2242,13 +2242,13 @@ data Stats = Stats {
   , closedTables       :: !(Map Model.TableID Model.SomeTable)
     -- | The ultimate parents for each table. These are the 'TableId's of tables
     -- created using 'new' or 'open'.
-  , parentTable        :: Map Model.TableID [Model.TableID]
+  , parentTable        :: !(Map Model.TableID [Model.TableID])
     -- | Track the interleavings of operations via different but related tables.
     -- This is a map from each ultimate parent table to a summary log of which
     -- tables (derived from that parent table via duplicate or union) have had
     -- \"interesting\" actions performed on them. We record only the
     -- interleavings of different tables not multiple actions on the same table.
-  , dupTableActionLog  :: Map Model.TableID [Model.TableID]
+  , dupTableActionLog  :: !(Map Model.TableID [Model.TableID])
     -- | The subset of tables (open or closed) that were created as a result
     -- of a union operation. This can be used for example to select subsets of
     -- the other per-table tracking maps above, or the state from the model.

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -2253,7 +2253,7 @@ data Stats = Stats {
     -- sizes from the final model state (which of course has only tables still
     -- open in the final state).
   , closedTableSizes   :: !(Map Model.TableID Int)
-    -- | The ultimate parent for each table. This is the 'TableId' of a table
+    -- | The ultimate parents for each table. These are the 'TableId's of tables
     -- created using 'new' or 'open'.
   , parentTable        :: Map Model.TableID [Model.TableID]
     -- | Track the interleavings of operations via different but related tables.

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -2229,8 +2229,6 @@ instance InterpretOp Op (ModelValue (ModelState h)) where
   Statistics, labelling/tagging
 -------------------------------------------------------------------------------}
 
--- TODO: add tagging of interesting cases for union-related actions.
-
 data Stats = Stats {
     -- === Tags
     -- | Names for which snapshots exist
@@ -2262,6 +2260,12 @@ data Stats = Stats {
     -- \"interesting\" actions performed on them. We record only the
     -- interleavings of different tables not multiple actions on the same table.
   , dupTableActionLog  :: Map Model.TableID [Model.TableID]
+    -- | The subset of tables (open or closed) that were created as a result
+    -- of a union operation. This can be used for example to select subsets of
+    -- the other per-table tracking maps above, or the state from the model.
+    -- The map value is the size of the union table at the point it was created,
+    -- so we can distinguish trivial empty unions from non-trivial.
+  , unionTables        :: !(Map Model.TableID Int)
   }
   deriving stock Show
 
@@ -2278,6 +2282,7 @@ initStats = Stats {
     , closedTables       = Map.empty
     , parentTable        = Map.empty
     , dupTableActionLog  = Map.empty
+    , unionTables        = Map.empty
     }
 
 updateStats ::
@@ -2293,7 +2298,7 @@ updateStats ::
   -> Val h a
   -> Stats
   -> Stats
-updateStats action@(Action _merrs action') lookUp modelBefore _modelAfter result =
+updateStats action@(Action _merrs action') lookUp modelBefore modelAfter result =
       -- === Tags
       updSnapshotted
       -- === Final tags
@@ -2305,6 +2310,7 @@ updateStats action@(Action _merrs action') lookUp modelBefore _modelAfter result
     . updClosedTables
     . updDupTableActionLog
     . updParentTable
+    . updUnionTables
   where
     -- === Tags
 
@@ -2549,6 +2555,22 @@ updateStats action@(Action _merrs action') lookUp modelBefore _modelAfter result
 
     updDupTableActionLog stats = stats
 
+    updUnionTables stats = case action' of
+        Union{}  -> insertUnionTable
+        Unions{} -> insertUnionTable
+        _        -> stats
+      where
+        insertUnionTable
+          | MEither (Right (MTable t)) <- result
+          , let tid = Model.tableID t
+          , Just (_,tbl) <- Map.lookup tid (Model.tables modelAfter)
+          , let sz = Model.withSomeTable Model.size tbl
+          = stats {
+              unionTables = Map.insert tid sz (unionTables stats)
+            }
+          | otherwise
+          = stats
+
     getTableId :: ModelValue (ModelState h) (WrapTable h IO k v b)
                      -> Model.TableID
     getTableId (MTable t) = Model.tableID t
@@ -2705,6 +2727,8 @@ tagFinalState' (getModel -> ModelState finalState finalStats) = concat [
     , tagNumTableActions
     , tagTableSizes
     , tagDupTableActionLog
+    , tagNumUnionTables
+    , tagNumUnionTableActions
     ]
   where
     tagNumLookupsResults = [
@@ -2765,6 +2789,23 @@ tagFinalState' (getModel -> ModelState finalState finalStats) = concat [
            [DupTableActionLog (showPowersOf 2 n)])
         | (_, alog) <- Map.toList (dupTableActionLog finalStats)
         , let n = length alog
+        ]
+
+    tagNumUnionTables =
+        [ ("Number of union tables (empty)",
+           [NumTables (showPowersOf 2 (Map.size trivial))])
+        , ("Number of union tables (non-empty)",
+           [NumTables (showPowersOf 2 (Map.size nonTrivial))])
+        ]
+      where
+        (nonTrivial, trivial) = Map.partition (> 0) (unionTables finalStats)
+
+    tagNumUnionTableActions =
+        [ ("Number of actions per table with non-empty unions",
+           [ NumTableActions (showPowersOf 2 n) ])
+        | n <- Map.elems $ numActionsPerTable finalStats
+                             `Map.intersection`
+                           Map.filter (> 0) (unionTables finalStats)
         ]
 
 {-------------------------------------------------------------------------------

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -68,6 +68,12 @@ import           Data.Bifunctor (Bifunctor (..))
 import           Data.Constraint (Dict (..))
 import           Data.Either (partitionEithers)
 import           Data.Kind (Type)
+#if MIN_VERSION_base(4,20,0)
+import           Data.List (nub)
+#else
+import           Data.List (foldl', nub)
+                 -- foldl' is included in the Prelude from base 4.20 onwards
+#endif
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
@@ -2249,10 +2255,10 @@ data Stats = Stats {
   , closedTableSizes   :: !(Map Model.TableID Int)
     -- | The ultimate parent for each table. This is the 'TableId' of a table
     -- created using 'new' or 'open'.
-  , parentTable        :: Map Model.TableID Model.TableID
+  , parentTable        :: Map Model.TableID [Model.TableID]
     -- | Track the interleavings of operations via different but related tables.
-    -- This is a map from the ultimate parent table to a summary log of which
-    -- tables (derived from that parent table via duplicate) have had
+    -- This is a map from each ultimate parent table to a summary log of which
+    -- tables (derived from that parent table via duplicate or union) have had
     -- \"interesting\" actions performed on them. We record only the
     -- interleavings of different tables not multiple actions on the same table.
   , dupTableActionLog  :: Map Model.TableID [Model.TableID]
@@ -2449,15 +2455,11 @@ updateStats action@(Action _merrs action') lookUp modelBefore _modelAfter result
         (OpenSnapshot{}, MEither (Right (MTable tbl))) ->
           insertParentTableNew tbl stats
         (Duplicate ptblVar, MEither (Right (MTable tbl))) ->
-          insertParentTableDerived ptblVar tbl stats
-        (Union ptblVar _ptblVar2, MEither (Right (MTable tbl))) ->
-          insertParentTableDerived ptblVar tbl stats
-        (Unions (ptblVar :| _ptblVars), MEither (Right (MTable tbl))) ->
-          insertParentTableDerived ptblVar tbl stats
-        -- TODO: we're abitrarily picking the first parent as the parent (and
-        -- ignoring ptblVar2 and ptblVars above). Tables should be able to have
-        -- *multiple* ultimate parent tables, which is currently not possible:
-        --parentTable only stores a single ultimate parent table per table.
+          insertParentTableDerived [ptblVar] tbl stats
+        (Union ptblVar1 ptblVar2, MEither (Right (MTable tbl))) ->
+          insertParentTableDerived [ptblVar1, ptblVar2]  tbl stats
+        (Unions ptblVars, MEither (Right (MTable tbl))) ->
+          insertParentTableDerived (NE.toList ptblVars) tbl stats
         _ -> stats
 
     -- insert an entry into the parentTable for a completely new table
@@ -2465,22 +2467,25 @@ updateStats action@(Action _merrs action') lookUp modelBefore _modelAfter result
     insertParentTableNew tbl stats =
       stats {
         parentTable = Map.insert (Model.tableID tbl)
-                                 (Model.tableID tbl)
+                                 [Model.tableID tbl]
                                  (parentTable stats)
       }
 
     -- insert an entry into the parentTable for a table derived from a parent
     insertParentTableDerived :: forall k v b.
-                                GVar Op (WrapTable h IO k v b)
+                                [GVar Op (WrapTable h IO k v b)]
                              -> Model.Table k v b -> Stats -> Stats
-    insertParentTableDerived ptblVar tbl stats =
-      let -- immediate and ultimate parent table ids
-          iptblId, uptblId :: Model.TableID
-          iptblId = getTableId (lookUp ptblVar)
-          uptblId = parentTable stats Map.! iptblId
+    insertParentTableDerived ptblVars tbl stats =
+      let uptblIds :: [Model.TableID] -- the set of ultimate parent table ids
+          uptblIds = nub [ uptblId
+                         | ptblVar <- ptblVars
+                           -- immediate and ultimate parent table id:
+                         , let iptblId = getTableId (lookUp ptblVar)
+                         , uptblId <- parentTable stats Map.! iptblId
+                         ]
        in stats {
             parentTable = Map.insert (Model.tableID tbl)
-                                     uptblId
+                                     uptblIds
                                      (parentTable stats)
           }
 
@@ -2526,18 +2531,19 @@ updateStats action@(Action _merrs action') lookUp modelBefore _modelAfter result
         -- not the latest one already
         updateLastActionLog :: GVar Op (WrapTable h IO k v b) -> Stats
         updateLastActionLog tableVar =
-          case Map.lookup pthid (dupTableActionLog stats) of
-            Just (thid' : _)
-              | thid == thid' -> stats -- the most recent action was via this table
-            malog ->
-              let alog = thid : fromMaybe [] malog
-               in stats {
-                    dupTableActionLog = Map.insert pthid alog
-                                                   (dupTableActionLog stats)
-                  }
+          stats {
+            dupTableActionLog = foldl' (flip (Map.alter extendLog))
+                                       (dupTableActionLog stats)
+                                       (parentTable stats Map.! thid)
+          }
           where
-            thid  = getTableId (lookUp tableVar)
-            pthid = parentTable stats Map.! thid
+            thid = getTableId (lookUp tableVar)
+
+            extendLog :: Maybe [Model.TableID] -> Maybe [Model.TableID]
+            extendLog (Just alog@(thid' : _)) | thid == thid'
+                                  = Just alog          -- action via same table
+            extendLog (Just alog) = Just (thid : alog) -- action via different table
+            extendLog Nothing     = Just (thid : [])   -- first action on table
 
         emptyRange (R.FromToExcluding l u) = l >= u
         emptyRange (R.FromToIncluding l u) = l >  u
@@ -2755,7 +2761,7 @@ tagFinalState' (getModel -> ModelState finalState finalStats) = concat [
         ]
 
     tagDupTableActionLog =
-        [ ("Interleaved actions on table duplicates",
+        [ ("Interleaved actions on table duplicates or unions",
            [DupTableActionLog (showPowersOf 2 n)])
         | (_, alog) <- Map.toList (dupTableActionLog finalStats)
         , let n = length alog

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -1969,42 +1969,36 @@ arbitraryActionWithVars _ label ctx (ModelState st _stats) =
         , let genErrors = pure Nothing -- TODO: generate errors
         ]
      ++ [ (2,  fmap Some $ (Action <$> genErrors <*>) $
-            RemainingUnionDebt <$> genUnionTableVar)
-        | let genErrors = pure Nothing -- TODO: generate errors
+            RemainingUnionDebt <$> genUnionDescendantTableVar)
+            -- Tables not derived from unions are covered in UnitTests.
+        | not (null unionDescendantTableVars)
+        , let genErrors = pure Nothing -- TODO: generate errors
           -- TODO: this is currently only enabled for the reference
           -- implementation. Enable this unconditionally once table union is
           -- implemented
         , isJust (eqT @h @ModelIO.Table)
         ]
      ++ [ (8, fmap Some $ (Action <$> genErrors <*>) $
-            SupplyUnionCredits <$> genUnionTableVar <*> genUnionCredits)
-        | let genErrors = pure Nothing -- TODO: generate errors
+            SupplyUnionCredits <$> genUnionDescendantTableVar <*> genUnionCredits)
+            -- Tables not derived from unions are covered in UnitTests.
+        | not (null unionDescendantTableVars)
+        , let genErrors = pure Nothing -- TODO: generate errors
           -- TODO: this is currently only enabled for the reference
           -- implementation. Enable this unconditionally once table union is
           -- implemented
         , isJust (eqT @h @ModelIO.Table)
         ]
       ++ [ (2, fmap Some $ (Action <$> genErrors <*>) $
-            SupplyPortionOfDebt <$> genUnionTableVar <*> genPortion)
-        | let genErrors  = pure Nothing -- TODO: generate errors
+            SupplyPortionOfDebt <$> genUnionDescendantTableVar <*> genPortion)
+            -- Tables not derived from unions are covered in UnitTests.
+        | not (null unionDescendantTableVars)
+        , let genErrors  = pure Nothing -- TODO: generate errors
           -- TODO: this is currently only enabled for the reference
           -- implementation. Enable this unconditionally once table union is
           -- implemented
         , isJust (eqT @h @ModelIO.Table)
         ]
       where
-        -- For querying the union debt or supplying union credits, the
-        -- interesting cases to test for are when tables are union tables. For
-        -- non-union tables, these operations should just be no-ops, so we
-        -- generate them only rarely.
-        --
-        -- TODO: tweak distribution once table unions are implemented
-        -- TODO: replace union actions on non-union tables with unit tests?
-        genUnionTableVar = QC.frequency [
-            (9 * length unionDescendantTableVars,    genUnionDescendantTableVar)
-          , (1 * length notUnionDescendantTableVars, genNotUnionDescendantTableVar)
-          ]
-
         -- TODO: tweak distribution once table unions are implemented
         genUnionCredits = QC.frequency [
             -- The typical, interesting case is to supply a positive number of

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -2600,6 +2600,8 @@ data Tag =
     -- | A snapshot failed to open because we detected that the snapshot was
     -- corrupt
   | OpenSnapshotDetectsCorruption R.SnapshotName
+    -- | Opened a snapshot (successfully) for a table involving a union
+  | OpenSnapshotUnion
   deriving stock (Show, Eq, Ord)
 
 -- | This is run for after every action
@@ -2620,6 +2622,7 @@ tagStep' (ModelState _stateBefore statsBefore,
     , tagDeleteMissingSnapshot
     , tagCreateSnapshotCorruptedOrUncorrupted
     , tagOpenSnapshotDetectsCorruption
+    , tagOpenSnapshotUnion
     ]
   where
     tagSnapshotTwice
@@ -2670,6 +2673,14 @@ tagStep' (ModelState _stateBefore statsBefore,
       | OpenSnapshot _ _ name <- action'
       , MEither (Left (MErr (Model.ErrSnapshotCorrupted _))) <- result
       = Just (OpenSnapshotDetectsCorruption name)
+      | otherwise
+      = Nothing
+
+    tagOpenSnapshotUnion
+      | OpenSnapshot{} <- action'
+      , MEither (Right (MTable t)) <- result
+      , Model.isUnionDescendant t == Model.IsUnionDescendant
+      = Just OpenSnapshotUnion
       | otherwise
       = Nothing
 

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -1999,15 +1999,10 @@ arbitraryActionWithVars _ label ctx (ModelState st _stats) =
         , isJust (eqT @h @ModelIO.Table)
         ]
       where
-        -- TODO: tweak distribution once table unions are implemented
-        genUnionCredits = QC.frequency [
-            -- The typical, interesting case is to supply a positive number of
-            -- union credits.
-            (9, R.UnionCredits . QC.getPositive <$> QC.arbitrary)
-            -- Supplying 0 or less credits is a no-op, so we generate it only
-            -- rarely.
-          , (1, R.UnionCredits <$> QC.arbitrary)
-          ]
+        -- The typical, interesting case is to supply a positive number of
+        -- union credits. Supplying 0 or less credits is a no-op. We cover
+        -- it in UnitTests so we don't have to cover it here.
+        genUnionCredits = R.UnionCredits . QC.getPositive <$> QC.arbitrary
 
         -- TODO: tweak distribution once table unions are implemented
         genPortion = Portion <$> QC.elements [1, 2, 3]

--- a/test/Test/Database/LSMTree/UnitTests.hs
+++ b/test/Test/Database/LSMTree/UnitTests.hs
@@ -18,10 +18,10 @@ import           Database.LSMTree as R
 
 import           Control.Exception (Exception, bracket, try)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact)
-import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck.Arbitrary as QC
+import qualified Test.QuickCheck.Gen as QC
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
-import           Test.Tasty.QuickCheck (Property, testProperty)
 import           Test.Util.FS (withTempIOHasBlockIO)
 
 
@@ -33,12 +33,7 @@ tests =
       , testCase      "unit_closed_cursor"  unit_closed_cursor
       , testCase      "unit_twoTableTypes"  unit_twoTableTypes
       , testCase      "unit_snapshots"      unit_snapshots
-
-        -- Properties
-
-      , testProperty "prop_unions_1" $
-          -- TODO: enable once unions are implemented
-          QC.expectFailure prop_unions_1
+      , testCase      "unit_unions_1"       unit_unions_1
       ]
 
 unit_blobs :: (String -> IO ()) -> Assertion
@@ -155,9 +150,8 @@ unit_snapshots =
     snap2 = "table2"
 
 -- | Unions of 1 table are equivalent to duplicate
-prop_unions_1 :: Property
-prop_unions_1 =
-    QC.once $ QC.ioProperty $
+unit_unions_1 :: Assertion
+unit_unions_1 =
     withTempIOHasBlockIO "test" $ \hfs hbio ->
     withSession nullTracer hfs hbio (FS.mkFsPath []) $ \sess ->
     withTable @_ @Key1 @Value1 @Blob1 sess defaultTableConfig $ \table -> do
@@ -165,8 +159,8 @@ prop_unions_1 =
 
       bracket (unions $ table :| []) close $ \table' ->
         bracket (duplicate table) close $ \table'' -> do
-          inserts table [(Key1 17, Value1 43, Nothing)]
-          inserts table [(Key1 17, Value1 44, Nothing)]
+          inserts table' [(Key1 17, Value1 43, Nothing)]
+          inserts table'' [(Key1 17, Value1 44, Nothing)]
 
           -- The original table is unmodified
           r <- lookups table [Key1 17]


### PR DESCRIPTION
# Description

Should go on top of #608 and #609. We should also add some union-related labelling.

