### PR TITLE
fix: remove unused `deserialiseValueN`

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Normal.hs
+++ b/bench/micro/Bench/Database/LSMTree/Normal.hs
@@ -52,7 +52,6 @@ instance NFData V1 where
 instance SerialiseValue V1 where
   serialiseValue (V1 x s) = serialiseValue x <> serialiseValue s
   deserialiseValue rb = V1 (deserialiseValue $ RB.take 8 rb) (deserialiseValue $ RB.drop 8 rb)
-  deserialiseValueN _ = error "deserialiseValueN: unused"
 
 newtype B1 = B1 Void
   deriving newtype (Show, Eq, Ord, NFData, SerialiseValue)

--- a/src-extras/Database/LSMTree/Extras/Orphans.hs
+++ b/src-extras/Database/LSMTree/Extras/Orphans.hs
@@ -58,7 +58,6 @@ instance SerialiseValue Word256 where
   deserialiseValue (RawBytes (VP.Vector off len ba)) =
     requireBytesExactly "Word256" 32 len $
       indexWord8ArrayAsWord256 ba off
-  deserialiseValueN = deserialiseValue . mconcat -- TODO: optimise
 
 instance Arbitrary Word256 where
   arbitrary = Word256 <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
@@ -116,7 +115,6 @@ instance SerialiseValue Word128 where
   deserialiseValue (RawBytes (VP.Vector off len ba)) =
     requireBytesExactly "Word128" 16 len $
       indexWord8ArrayAsWord128 ba off
-  deserialiseValueN = deserialiseValue . mconcat -- TODO: optimise
 
 instance Arbitrary Word128 where
   arbitrary = Word128 <$> arbitrary <*> arbitrary
@@ -162,7 +160,6 @@ instance SerialiseKey RawBytes where
 instance SerialiseValue RawBytes where
   serialiseValue = id
   deserialiseValue = id
-  deserialiseValueN = mconcat
 
 {-------------------------------------------------------------------------------
   SerialisedKey/Value/Blob

--- a/src-extras/Database/LSMTree/Extras/UTxO.hs
+++ b/src-extras/Database/LSMTree/Extras/UTxO.hs
@@ -114,7 +114,6 @@ instance SerialiseValue UTxOValue where
                 (indexWord8ArrayAsWord128 ba (off + 32))
                 (indexWord8ArrayAsWord64  ba (off + 48))
                 (indexWord8ArrayAsWord32  ba (off + 56))
-  deserialiseValueN = deserialiseValue . mconcat -- TODO: optimise
 
 instance Arbitrary UTxOValue where
   arbitrary = UTxOValue <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
@@ -150,4 +149,3 @@ newtype UTxOBlob = UTxOBlob BS.ByteString
 instance SerialiseValue UTxOBlob where
   serialiseValue (UTxOBlob bs) = Class.serialiseValue bs
   deserialiseValue = error "deserialiseValue: UTxOBlob"
-  deserialiseValueN = error "deserialiseValueN: UTxOBlob"


### PR DESCRIPTION
This PR removes the unused method `deserialiseValueN`.