### PR TITLE
fix(ci): remove erroneous uses of fail-fast

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,9 +27,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-
     env:
       ghc: "9.6.6"
       cabal: "3.12.1.0"
@@ -93,9 +90,6 @@ jobs:
     needs: build-documentation
 
     runs-on: ubuntu-latest
-
-    strategy:
-        fail-fast: false
 
     # https://github.com/actions/deploy-pages
     permissions:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,7 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-
 permissions:
   contents: read
 
@@ -301,9 +300,6 @@ jobs:
   # HLint
   hlint:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This PR removes the uses of `fail-fast: false` without a strategy.