### PR TITLE
Make ordinary indexes the default

### DIFF
--- a/bench/macro/lsm-tree-bench-wp8.hs
+++ b/bench/macro/lsm-tree-bench-wp8.hs
@@ -80,6 +80,14 @@ import           Database.LSMTree.Internal.ByteString (byteArrayToSBS)
 import qualified Database.LSMTree.Normal as LSM
 
 -------------------------------------------------------------------------------
+-- Table configuration
+-------------------------------------------------------------------------------
+
+benchTableConfig :: LSM.TableConfig
+benchTableConfig =
+    LSM.defaultTableConfig {LSM.confFencePointerIndex = LSM.CompactIndex}
+
+-------------------------------------------------------------------------------
 -- Keys and values
 -------------------------------------------------------------------------------
 
@@ -407,7 +415,7 @@ doSetup' gopts opts = do
         LSM.mkSnapshotName "bench"
 
     LSM.withSession (mkTracer gopts) hasFS hasBlockIO (FS.mkFsPath []) $ \session -> do
-        tbl <- LSM.new @IO @K @V @B session (mkTableConfigSetup gopts opts LSM.defaultTableConfig)
+        tbl <- LSM.new @IO @K @V @B session (mkTableConfigSetup gopts opts benchTableConfig)
 
         forM_ (groupsOfN 256 [ 0 .. initialSize gopts ]) $ \batch -> do
             -- TODO: this procedure simply inserts all the keys into initial lsm tree
@@ -576,7 +584,7 @@ doRun gopts opts = do
         -- reference version starts with empty (as it's not practical or
         -- necessary for testing to load the whole snapshot).
         tbl <- if check opts
-                then LSM.new  @IO @K @V @B session (mkTableConfigRun gopts LSM.defaultTableConfig)
+                then LSM.new  @IO @K @V @B session (mkTableConfigRun gopts benchTableConfig)
                 else LSM.openSnapshot @IO @K @V @B session (mkTableConfigOverride gopts) label name
 
         -- In checking mode, compare each output against a pure reference.

--- a/bench/micro/Bench/Database/LSMTree/Monoidal.hs
+++ b/bench/micro/Bench/Database/LSMTree/Monoidal.hs
@@ -55,7 +55,8 @@ instance Monoidal.ResolveValue V where
 
 benchConfig :: Common.TableConfig
 benchConfig = Common.defaultTableConfig {
-      Common.confWriteBufferAlloc = Common.AllocNumEntries (Common.NumEntries 20000)
+      Common.confWriteBufferAlloc  = Common.AllocNumEntries (Common.NumEntries 20000)
+    , Common.confFencePointerIndex = Common.CompactIndex
     }
 
 {-------------------------------------------------------------------------------

--- a/bench/micro/Bench/Database/LSMTree/Normal.hs
+++ b/bench/micro/Bench/Database/LSMTree/Normal.hs
@@ -65,7 +65,8 @@ newtype B2 = B2 ShortByteString
 
 benchConfig :: Common.TableConfig
 benchConfig = Common.defaultTableConfig {
-      Common.confWriteBufferAlloc = Common.AllocNumEntries (Common.NumEntries 20000)
+      Common.confWriteBufferAlloc  = Common.AllocNumEntries (Common.NumEntries 20000)
+    , Common.confFencePointerIndex = Common.CompactIndex
     }
 
 {-------------------------------------------------------------------------------
@@ -232,7 +233,7 @@ benchInsertBatches =
       !batchSize = 256
 
       _benchConfig :: Common.TableConfig
-      _benchConfig = Common.defaultTableConfig {
+      _benchConfig = benchConfig {
           Common.confWriteBufferAlloc = Common.AllocNumEntries (Common.NumEntries 1000)
         }
 

--- a/src/Database/LSMTree/Internal/Config.hs
+++ b/src/Database/LSMTree/Internal/Config.hs
@@ -92,7 +92,7 @@ defaultTableConfig =
       , confSizeRatio         = Four
       , confWriteBufferAlloc  = AllocNumEntries (NumEntries 20_000)
       , confBloomFilterAlloc  = defaultBloomFilterAlloc
-      , confFencePointerIndex = CompactIndex
+      , confFencePointerIndex = OrdinaryIndex
       , confDiskCachePolicy   = DiskCacheAll
       , confMergeSchedule     = defaultMergeSchedule
       }

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
@@ -169,7 +169,9 @@ basicSnapshotTableType :: (ComponentAnnotation, SnapshotTableType)
 basicSnapshotTableType = head enumerateSnapshotTableType
 
 basicTableConfig :: (ComponentAnnotation, TableConfig)
-basicTableConfig = ( fuseAnnotations $ "T0" : replicate 4 blank, defaultTableConfig)
+basicTableConfig = ( fuseAnnotations $ "T0" : replicate 4 blank
+                   , defaultTableConfig {confFencePointerIndex = CompactIndex}
+                   )
 
 basicRunNumber :: RunNumber
 basicRunNumber = enumerateRunNumbers

--- a/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
@@ -208,7 +208,8 @@ prop_flipSnapshotBit (Positive (Small bufferSize)) es pickFileBit =
     namedSnapDir = namedSnapshotDir (SessionRoot root) snapName
 
     conf = defaultTableConfig {
-        confWriteBufferAlloc = AllocNumEntries (NumEntries bufferSize)
+        confWriteBufferAlloc  = AllocNumEntries (NumEntries bufferSize)
+      , confFencePointerIndex = CompactIndex
       }
     es' = fmap (bimap serialiseKey (bimap serialiseValue serialiseBlob)) es
 


### PR DESCRIPTION
Up to now, `defaultTableConfig` declared compact indexes to be used by default. This pull request changes this, making ordinary indexes the default.

Furthermore, this pull request changes the following files such that they now override the `confFencePointerIndex` field of `defaultTableConfig` with `CompactIndex` in order to continue using compact indexes:

* `bench/macro/lsm-tree-bench-wp8.hs`
* `bench/micro/Bench/Database/LSMTree/Monoidal.hs`
* `bench/micro/Bench/Database/LSMTree/Normal.hs`
* `test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs`
* `test/Test/Database/LSMTree/Internal/Snapshot/FS.hs`
* `test/Test/Database/LSMTree/UnitTests.hs`

The remaining source code files that use `defaultTableConfig` are the following ones:

* `test/Test/Database/LSMTree/Class.hs`
* `test/Test/Database/LSMTree/Internal.hs`

These are not changed, so that they now operate with ordinary indexes.
