### PR TITLE
fix: rename ErrSnapshotNotExists to ErrSnapshotDoesNotExist

### DIFF
--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -209,7 +209,7 @@ data LSMTreeError =
     -- the idempotent operation 'Database.LSMTree.Common.closeCursor'.
   | ErrCursorClosed
   | ErrSnapshotExists SnapshotName
-  | ErrSnapshotNotExists SnapshotName
+  | ErrSnapshotDoesNotExist SnapshotName
   | ErrSnapshotDeserialiseFailure DeserialiseFailure SnapshotName
   | ErrSnapshotWrongTableType
       SnapshotName
@@ -1294,7 +1294,7 @@ openSnapshot sesh label tableType override snap resolve = do
         -- Guard that the snapshot exists
         let snapDir = Paths.namedSnapshotDir (sessionRoot seshEnv) snap
         FS.doesDirectoryExist hfs (Paths.getNamedSnapshotDir snapDir) >>= \b ->
-          unless b $ throwIO (ErrSnapshotNotExists snap)
+          unless b $ throwIO (ErrSnapshotDoesNotExist snap)
 
         let SnapshotMetaDataFile contentPath = Paths.snapshotMetaDataFile snapDir
             SnapshotMetaDataChecksumFile checksumPath = Paths.snapshotMetaDataChecksumFile snapDir
@@ -1360,7 +1360,7 @@ deleteSnapshot sesh snap = do
       let snapDir = Paths.namedSnapshotDir (sessionRoot seshEnv) snap
       doesSnapshotExist <-
         FS.doesDirectoryExist (sessionHasFS seshEnv) (Paths.getNamedSnapshotDir snapDir)
-      unless doesSnapshotExist $ throwIO (ErrSnapshotNotExists snap)
+      unless doesSnapshotExist $ throwIO (ErrSnapshotDoesNotExist snap)
       FS.removeDirectoryRecursive hfs (Paths.getNamedSnapshotDir snapDir)
 
 {-# SPECIALISE listSnapshots :: Session IO h -> IO [SnapshotName] #-}

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -489,7 +489,7 @@ lsmTreeErrorHandler = Handler $ pure . handler'
     handler' :: LSMTreeError -> Maybe Model.Err
     handler' ErrTableClosed               = Just Model.ErrTableClosed
     handler' ErrCursorClosed              = Just Model.ErrCursorClosed
-    handler' (ErrSnapshotNotExists _snap) = Just Model.ErrSnapshotDoesNotExist
+    handler' (ErrSnapshotDoesNotExist _snap) = Just Model.ErrSnapshotDoesNotExist
     handler' (ErrSnapshotExists _snap)    = Just Model.ErrSnapshotExists
     handler' ErrSnapshotWrongTableType{}  = Just Model.ErrSnapshotWrongType
     handler' (ErrBlobRefInvalid _)        = Just Model.ErrBlobRefInvalidated

--- a/test/Test/Database/LSMTree/UnitTests.hs
+++ b/test/Test/Database/LSMTree/UnitTests.hs
@@ -133,7 +133,7 @@ unit_snapshots =
     withSession nullTracer hfs hbio (FS.mkFsPath []) $ \sess -> do
       table <- new @_ @Key1 @Value1 @Blob1 sess defaultTableConfig
 
-      assertException (ErrSnapshotNotExists snap2) $
+      assertException (ErrSnapshotDoesNotExist snap2) $
         deleteSnapshot sess snap2
 
       createSnapshot label1 snap1 table
@@ -146,7 +146,7 @@ unit_snapshots =
         _ <- openSnapshot @_ @Key2 @Value2 @Blob2 sess configNoOverride label2 snap1
         return ()
 
-      assertException (ErrSnapshotNotExists snap2) $ do
+      assertException (ErrSnapshotDoesNotExist snap2) $ do
         _ <- openSnapshot @_ @Key1 @Value1 @Blob1 sess configNoOverride label2 snap2
         return ()
   where


### PR DESCRIPTION
This PR renames `ErrSnapshotNotExists` to `ErrSnapshotDoesNotExist` for consistency.