### PR TITLE
Run `Class`-based and `StateMachine` tests using both index types

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Index.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Index.hs
@@ -112,8 +112,8 @@ searchBenchmarkable index = whnf $ foldl' (\ _ key -> rnf (search key index)) ()
 -- ** Incremental construction
 
 -- | Constructs append operations to be used in index construction.
-incrementalConstructionAppends
-    :: Int      -- ^ Number of keys used in the construction
+incrementalConstructionAppends ::
+       Int      -- ^ Number of keys used in the construction
     -> [Append] -- ^ Constructed append operations
 incrementalConstructionAppends = appendsForIndexCompact
 

--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -460,9 +460,31 @@ deriving anyclass instance Typeable s
   GrowingVector
 -------------------------------------------------------------------------------}
 
-deriving stock instance Generic (GrowingVector s a)
-deriving anyclass instance (Typeable s, Typeable a, NoThunks a)
-                        => NoThunks (GrowingVector s a)
+instance (NoThunks a, Typeable s, Typeable a) => NoThunks (GrowingVector s a) where
+  showTypeOf (p :: Proxy (GrowingVector s a)) = show $ typeRep p
+  wNoThunks ctx
+    (GrowingVector (a :: STRef s (VM.MVector s a)) (b :: PrimVar s Int))
+    = allNoThunks [
+          noThunks ctx b
+          -- Check that the STRef is in WHNF
+        , noThunks ctx $ OnlyCheckWhnf a
+          -- Check that the MVector is in WHNF
+        , do
+            mvec <- unsafeSTToIO $ readSTRef a
+            noThunks ctx' $ OnlyCheckWhnf mvec
+          -- Check that the vector elements contain no thunks. The vector
+          -- contains undefined elements after the first @n@ elements
+        , do
+            n <- unsafeSTToIO $ readPrimVar b
+            mvec <- unsafeSTToIO $ readSTRef a
+            allNoThunks [
+                unsafeSTToIO (VM.read mvec i) >>= \x -> noThunks ctx'' x
+              | i <- [0..n-1]
+              ]
+        ]
+    where
+      ctx' = showTypeOf (Proxy @(STRef s (VM.MVector s a))) : ctx
+      ctx'' = showTypeOf (Proxy @(VM.MVector s a)) : ctx'
 
 {-------------------------------------------------------------------------------
   Baler
@@ -662,15 +684,21 @@ instance (NoThunks a, Typeable s, Typeable a) => NoThunks (MutableHeap s a) wher
     (MH (a :: PrimVar s Int) (b :: SmallMutableArray s a))
     = allNoThunks [
           noThunks ctx a
-          -- the small array may contain bogus/undefined placeholder values
-          -- after the first @n@ elements in the heap
-        , noThunks ctx $! do
+          -- Check that the array is in WHNF
+        , noThunks ctx (OnlyCheckWhnf b)
+          -- Check that the array elements contain no thunks. The small array
+          -- may contain undefined placeholder values after the first @n@
+          -- elements in the array. The very first element of the array can also
+          -- be undefined.
+        , do
             n <- unsafeSTToIO (readPrimVar a)
             allNoThunks [
-                unsafeSTToIO (readSmallArray b i) >>= \x -> noThunks ctx x
-              | i <- [0..n-1]
+                unsafeSTToIO (readSmallArray b i) >>= \x -> noThunks ctx' x
+              | i <- [1..n-1]
               ]
         ]
+    where
+      ctx' = showTypeOf (Proxy @(SmallMutableArray s a)) : ctx
 
 {-------------------------------------------------------------------------------
   IOLike

--- a/src/Database/LSMTree/Internal/Index.hs
+++ b/src/Database/LSMTree/Internal/Index.hs
@@ -154,8 +154,8 @@ fromSBS Ordinary input = second OrdinaryIndex <$> Ordinary.fromSBS input
     Incremental index construction is only guaranteed to work correctly when the
     supplied key ranges do not overlap and are given in ascending order.
 -}
-data IndexAcc s = CompactIndexAcc  (IndexCompactAcc  s)
-                | OrdinaryIndexAcc (IndexOrdinaryAcc s)
+data IndexAcc s = CompactIndexAcc  !(IndexCompactAcc  s)
+                | OrdinaryIndexAcc !(IndexOrdinaryAcc s)
 
 -- | Create a new index accumulator, using a default configuration.
 newWithDefaults :: IndexType -> ST s (IndexAcc s)

--- a/src/Database/LSMTree/Internal/Index/Ordinary.hs
+++ b/src/Database/LSMTree/Internal/Index/Ordinary.hs
@@ -80,7 +80,17 @@ toLastKeys (IndexOrdinary lastKeys) = lastKeys
     type-agnostic version]('Database.LSMTree.Internal.Index.search').
 -}
 search :: SerialisedKey -> IndexOrdinary -> PageSpan
-search key (IndexOrdinary lastKeys) = assert (pageCount > 0) result where
+search key (IndexOrdinary lastKeys)
+  -- TODO: ideally, we could assert that an index is never empty, but
+  -- unfortunately we can not currently do this. Runs (and thefeore indexes)
+  -- /can/ be empty if they were created by a last-level merge where all input
+  -- entries were deletes. Other parts of the @lsm-tree@ code won't fail as long
+  -- as we return @PageSpan 0 0@ when we search an empty ordinary index. The
+  -- ideal fix would be to remove empty runs from the levels entirely, but this
+  -- requires more involved changes to the merge schedule and until then we'll
+  -- just hack the @pageCount <= 0@ case in.
+  | pageCount <= 0 = PageSpan (PageNo 0) (PageNo 0)
+  | otherwise = assert (pageCount > 0) result where
 
     protoStart :: Int
     !protoStart = binarySearchL lastKeys key

--- a/src/Database/LSMTree/Internal/Index/Ordinary.hs
+++ b/src/Database/LSMTree/Internal/Index/Ordinary.hs
@@ -234,7 +234,7 @@ fromSBS shortByteString@(SBS unliftedByteArray)
                           = Primitive.splitAt firstSize postFirstSizeBytes
 
                       first :: SerialisedKey
-                      first = SerialisedKey' (Primitive.force firstBytes)
+                      !first = SerialisedKey' (Primitive.force firstBytes)
 
                   others <- lastKeys othersBytes
                   return (first : others)

--- a/src/Database/LSMTree/Internal/Vector/Growing.hs
+++ b/src/Database/LSMTree/Internal/Vector/Growing.hs
@@ -70,7 +70,7 @@ append (GrowingVector bufferRef lengthRef) count val
           length <- readPrimVar lengthRef
           makeRoom
           buffer' <- readSTRef bufferRef
-          Mutable.set (Mutable.slice length count buffer') val
+          Mutable.set (Mutable.slice length count buffer') $! val
     where
 
     makeRoom :: ST s ()

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
@@ -55,8 +55,8 @@ handleOutputFiles :: TestTree -> TestTree
 handleOutputFiles = Tasty.localOption Au.OnPass
 
 -- | Internally, the function will infer the correct filepath names.
-snapshotCodecTest
-  :: String -- ^ Name of the test
+snapshotCodecTest ::
+     String -- ^ Name of the test
   -> SnapshotMetaData -- ^ Data to be serialized
   -> TestTree
 snapshotCodecTest name datum =

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -239,12 +239,13 @@ instance Arbitrary R.TableConfig where
         , (4, pure R.Incremental)
         ]
     confWriteBufferAlloc <- QC.arbitrary
+    confFencePointerIndex <- QC.arbitrary
     pure $ R.TableConfig {
         R.confMergePolicy       = R.MergePolicyLazyLevelling
       , R.confSizeRatio         = R.Four
       , confWriteBufferAlloc
       , R.confBloomFilterAlloc  = R.AllocFixed 10
-      , R.confFencePointerIndex = R.CompactIndex
+      , confFencePointerIndex
       , R.confDiskCachePolicy   = R.DiskCacheNone
       , confMergeSchedule
       }
@@ -252,9 +253,11 @@ instance Arbitrary R.TableConfig where
   shrink R.TableConfig{..} =
       [ R.TableConfig {
             confWriteBufferAlloc = confWriteBufferAlloc'
+          , confFencePointerIndex = confFencePointerIndex'
           , ..
           }
-      | confWriteBufferAlloc' <- QC.shrink confWriteBufferAlloc
+      | ( confWriteBufferAlloc', confFencePointerIndex')
+          <- QC.shrink (confWriteBufferAlloc, confFencePointerIndex)
       ]
 
 -- TODO: the current generator is suboptimal, and should be improved. There are
@@ -288,6 +291,13 @@ instance Arbitrary R.WriteBufferAlloc where
       [ R.AllocNumEntries (R.NumEntries x')
       | QC.Positive x' <- QC.shrink (QC.Positive x)
       ]
+
+deriving stock instance Enum R.FencePointerIndex
+deriving stock instance Bounded R.FencePointerIndex
+instance Arbitrary R.FencePointerIndex where
+  arbitrary = QC.arbitraryBoundedEnum
+  shrink R.OrdinaryIndex = []
+  shrink R.CompactIndex  = [R.OrdinaryIndex]
 
 propLockstep_RealImpl_RealFS_IO ::
      Tracer IO R.LSMTreeTrace


### PR DESCRIPTION
Enabling both types of tests for both types of indexes unearthed some `NoThunks` failures and a subtle assertion failure. Both are fixed now, though the assertion failure currently has a workaround instead of a proper fix.