### PR TITLE
Update bloom filter FPR tests

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -372,7 +372,6 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Merge
     Test.Database.LSMTree.Internal.MergingRun
     Test.Database.LSMTree.Internal.MergingTree
-    Test.Database.LSMTree.Internal.Monkey
     Test.Database.LSMTree.Internal.PageAcc
     Test.Database.LSMTree.Internal.PageAcc1
     Test.Database.LSMTree.Internal.RawBytes
@@ -380,6 +379,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.RawPage
     Test.Database.LSMTree.Internal.Run
     Test.Database.LSMTree.Internal.RunAcc
+    Test.Database.LSMTree.Internal.RunBloomFilterAlloc
     Test.Database.LSMTree.Internal.RunBuilder
     Test.Database.LSMTree.Internal.RunReader
     Test.Database.LSMTree.Internal.RunReaders

--- a/src/Database/LSMTree/Internal/RunAcc.hs
+++ b/src/Database/LSMTree/Internal/RunAcc.hs
@@ -31,7 +31,9 @@ module Database.LSMTree.Internal.RunAcc (
     -- * Bloom filter allocation
   , RunBloomFilterAlloc (..)
     -- ** Exposed for testing
+  , newMBloom
   , numHashFunctions
+  , falsePositiveRate
   ) where
 
 import           Control.DeepSeq (NFData (..))
@@ -354,3 +356,20 @@ numHashFunctions ::
   -> Integer
 numHashFunctions nbits nentries = truncate @Double $ max 1 $
     (fromIntegral nbits / fromIntegral nentries) * log 2
+
+-- | False positive rate
+--
+-- Assumes that the bloom filter uses 'numHashFunctions' hash functions.
+--
+-- See Niv Dayan, Manos Athanassoulis, Stratos Idreos,
+-- /Optimal Bloom Filters and Adaptive Merging for LSM-Trees/,
+-- Equation 2.
+falsePositiveRate ::
+       Floating a
+    => a  -- ^ entries
+    -> a  -- ^ bits
+    -> a
+falsePositiveRate entries bits = exp ((-(bits / entries)) * sq (log 2))
+
+sq :: Num a => a -> a
+sq x = x * x

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,7 +19,6 @@ import qualified Test.Database.LSMTree.Internal.Lookup
 import qualified Test.Database.LSMTree.Internal.Merge
 import qualified Test.Database.LSMTree.Internal.MergingRun
 import qualified Test.Database.LSMTree.Internal.MergingTree
-import qualified Test.Database.LSMTree.Internal.Monkey
 import qualified Test.Database.LSMTree.Internal.PageAcc
 import qualified Test.Database.LSMTree.Internal.PageAcc1
 import qualified Test.Database.LSMTree.Internal.RawBytes
@@ -27,6 +26,7 @@ import qualified Test.Database.LSMTree.Internal.RawOverflowPage
 import qualified Test.Database.LSMTree.Internal.RawPage
 import qualified Test.Database.LSMTree.Internal.Run
 import qualified Test.Database.LSMTree.Internal.RunAcc
+import qualified Test.Database.LSMTree.Internal.RunBloomFilterAlloc
 import qualified Test.Database.LSMTree.Internal.RunBuilder
 import qualified Test.Database.LSMTree.Internal.RunReader
 import qualified Test.Database.LSMTree.Internal.RunReaders
@@ -66,7 +66,6 @@ main = do
     , Test.Database.LSMTree.Internal.Merge.tests
     , Test.Database.LSMTree.Internal.MergingRun.tests
     , Test.Database.LSMTree.Internal.MergingTree.tests
-    , Test.Database.LSMTree.Internal.Monkey.tests
     , Test.Database.LSMTree.Internal.PageAcc.tests
     , Test.Database.LSMTree.Internal.PageAcc1.tests
     , Test.Database.LSMTree.Internal.RawBytes.tests
@@ -74,6 +73,7 @@ main = do
     , Test.Database.LSMTree.Internal.RawPage.tests
     , Test.Database.LSMTree.Internal.Run.tests
     , Test.Database.LSMTree.Internal.RunAcc.tests
+    , Test.Database.LSMTree.Internal.RunBloomFilterAlloc.tests
     , Test.Database.LSMTree.Internal.RunBuilder.tests
     , Test.Database.LSMTree.Internal.RunReader.tests
     , Test.Database.LSMTree.Internal.RunReaders.tests

--- a/test/Test/Database/LSMTree/Internal/RunBloomFilterAlloc.hs
+++ b/test/Test/Database/LSMTree/Internal/RunBloomFilterAlloc.hs
@@ -5,10 +5,10 @@
 {-# LANGUAGE NumericUnderscores         #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeApplications           #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
-{- HLINT ignore "Use camelCase" -}
 
-module Test.Database.LSMTree.Internal.Monkey (
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Database.LSMTree.Internal.RunBloomFilterAlloc (
     -- * Main test tree
     tests
     -- * Bloom filter construction
@@ -47,7 +47,7 @@ import           Test.Util.Arbitrary (noTags,
 import           Text.Printf (printf)
 
 tests :: TestTree
-tests = testGroup "Database.LSMTree.Internal.Monkey" [
+tests = testGroup "Database.LSMTree.Internal.RunBloomFilterAlloc" [
       testProperty "prop_noFalseNegatives" $ prop_noFalseNegatives (Proxy @Word64)
     , testProperty "prop_verifyFPR" $ prop_verifyFPR (Proxy @Word64)
     , testGroup "RunBloomFilterAlloc" $


### PR DESCRIPTION
These tests were missing a link with the real implementation, since we were testing bloom filter construction functions that were not used in the real implementation. The updated tests test the `RunAcc`'s method of bloom filter allocation directly.