### PR TITLE
Implement remainingUnionDebt and supplyUnionCredits

### DIFF
--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -377,7 +377,7 @@ lookupsEnv runSizes keyRng0 hfs hbio caching = do
     putStr "DONE"
 
     -- return runs
-    runs <- V.fromList <$> mapM Run.fromMutable rbs
+    runs <- V.fromList <$> mapM Run.fromBuilder rbs
     let blooms  = V.map (\(DeRef r) -> Run.runFilter   r) runs
         indexes = V.map (\(DeRef r) -> Run.runIndex    r) runs
         handles = V.map (\(DeRef r) -> Run.runKOpsFile r) runs

--- a/bench/micro/Bench/Database/LSMTree/Internal/Index.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Index.hs
@@ -7,8 +7,9 @@ import           Control.DeepSeq (rnf)
 import           Control.Monad.ST.Strict (runST)
 import           Criterion.Main (Benchmark, Benchmarkable, bench, bgroup, env,
                      whnf)
-#if __GLASGOW_HASKELL__ < 910
+#if !MIN_VERSION_base(4,20,0)
 import           Data.List (foldl')
+                 -- foldl' is included in the Prelude from base 4.20 onwards
 #endif
 import           Database.LSMTree.Extras.Generators (getKeyForIndexCompact,
                      mkPages, toAppends)

--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -1371,8 +1371,17 @@ remainingDebtMergingTree :: MergingTree s -> ST s (Debt, Size)
 remainingDebtMergingTree (MergingTree ref) =
     readSTRef ref >>= \case
       CompletedTreeMerge r -> return (0, runSize r)
-      OngoingTreeMerge mr  -> remainingDebtMergingRun mr
-      PendingTreeMerge pm  -> remainingDebtPendingMerge pm
+      OngoingTreeMerge mr  -> addDebtOne <$> remainingDebtMergingRun mr
+      PendingTreeMerge pm  -> addDebtOne <$> remainingDebtPendingMerge pm
+  where
+    -- An ongoing merge should never have 0 debt, even if the 'MergingRun' in it
+    -- says it is completed. We still need to update it to 'CompletedTreeMerge'.
+    -- Similarly, a pending merge needs some work to complete it, even if all
+    -- its inputs are empty.
+    --
+    -- Note that we can't use @max 1@, as this would violate the property that
+    -- supplying N credits reduces the remaining debt by at least N.
+    addDebtOne (debt, size) = (debt + 1, size)
 
 remainingDebtPendingMerge :: PendingMerge s -> ST s (Debt, Size)
 remainingDebtPendingMerge (PendingMerge _ prs trees) = do
@@ -1381,11 +1390,7 @@ remainingDebtPendingMerge (PendingMerge _ prs trees) = do
         , traverse remainingDebtMergingTree trees
         ]
     let totalSize = sum sizes
-    -- A pending merge should never have 0 remaining debt. It needs some work to
-    -- complete it, even if all its inputs are empty. It's not enought to use
-    -- @max 1@, as this would violate the property that supplying N credits
-    -- reduces the remaining debt by at least N.
-    let totalDebt = sum debts + totalSize + 1
+    let totalDebt = sum debts + totalSize
     return (totalDebt, totalSize)
   where
     remainingDebtPreExistingRun = \case

--- a/prototypes/ScheduledMerges.hs
+++ b/prototypes/ScheduledMerges.hs
@@ -1483,8 +1483,9 @@ supplyCreditsPendingMerge = checked remainingDebtPendingMerge $ \credits -> \cas
     -- approximately equal, being more precise would require more iterations
     splitEqually :: (Credit -> a -> ST s Credit) -> [a] -> Credit -> ST s Credit
     splitEqually f xs credits =
-        -- first give each tree k = ceil(1/n) credits (last ones might get less)
-        -- any remainders go left to right
+        -- first give each tree k = ceil(1/n) credits (last ones might get less).
+        -- it's important we fold here to collect leftovers.
+        -- any remainders go left to right.
         foldM supply credits xs >>= leftToRight f xs
       where
         !n = length xs

--- a/src-extras/Database/LSMTree/Extras/RunData.hs
+++ b/src-extras/Database/LSMTree/Extras/RunData.hs
@@ -149,6 +149,9 @@ unsafeCreateRunAt ::
   -> SerialisedRunData
   -> IO (Ref (Run IO h))
 unsafeCreateRunAt fs hbio runParams fsPaths (RunData m) = do
+    -- the WBB file path doesn't have to be at a specific place relative to
+    -- the run we want to create, but fsPaths should already point to a unique
+    -- location, so we just append something to not conflict with that.
     let blobpath = FS.addExtension (runBlobPath fsPaths) ".wb"
     bracket (WBB.new fs blobpath) releaseRef $ \wbblobs -> do
       wb <- WB.fromMap <$> traverse (traverse (WBB.addBlob fs wbblobs)) m

--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -564,15 +564,19 @@ remainingUnionDebt (Internal.Table' t) =
     (\(Internal.UnionDebt x) -> UnionDebt x) <$>
       Internal.remainingUnionDebt t
 
-{-# SPECIALISE supplyUnionCredits :: Table IO k v b -> UnionCredits -> IO UnionCredits #-}
+{-# SPECIALISE supplyUnionCredits ::
+     ResolveValue v => Table IO k v b -> UnionCredits -> IO UnionCredits #-}
 supplyUnionCredits ::
-     IOLike m
+     forall m k v b. (IOLike m, ResolveValue v)
   => Table m k v b
   -> UnionCredits
   -> m UnionCredits
 supplyUnionCredits (Internal.Table' t) (UnionCredits credits) =
     (\(Internal.UnionCredits x) -> UnionCredits x) <$>
-      Internal.supplyUnionCredits t (Internal.UnionCredits credits)
+      Internal.supplyUnionCredits
+        (resolve (Proxy @v))
+        t
+        (Internal.UnionCredits credits)
 
 {-------------------------------------------------------------------------------
   Monoidal value resolution

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -113,6 +113,7 @@ import           Database.LSMTree.Internal.Lookup (ByteCountDiscrepancy,
 import           Database.LSMTree.Internal.MergeSchedule
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.MergingTree
+import qualified Database.LSMTree.Internal.MergingTree as MT
 import qualified Database.LSMTree.Internal.MergingTree.Lookup as MT
 import           Database.LSMTree.Internal.Paths (SessionRoot (..),
                      SnapshotMetaDataChecksumFile (..),
@@ -1626,14 +1627,19 @@ newtype UnionDebt = UnionDebt Int
 
 {-# SPECIALISE remainingUnionDebt :: Table IO h -> IO UnionDebt #-}
 -- | See 'Database.LSMTree.Normal.remainingUnionDebt'.
-remainingUnionDebt :: (MonadSTM m, MonadThrow m) => Table m h -> m UnionDebt
+remainingUnionDebt ::
+     (MonadSTM m, MonadMVar m, MonadThrow m, PrimMonad m)
+  => Table m h -> m UnionDebt
 remainingUnionDebt t = do
     traceWith (tableTracer t) TraceRemainingUnionDebt
     withOpenTable t $ \tEnv -> do
-      RW.withReadAccess (tableContent tEnv) $ \tableContent ->
+      RW.withReadAccess (tableContent tEnv) $ \tableContent -> do
         case tableUnionLevel tableContent of
-          NoUnion -> pure (UnionDebt 0)
-          Union{} -> error "remainingUnionDebt: not yet implemented"
+          NoUnion ->
+            pure (UnionDebt 0)
+          Union mt -> do
+            (MergeDebt (MergeCredits c), _) <- MT.remainingMergeDebt mt
+            pure (UnionDebt c)
 
 -- | See 'Database.LSMTree.Normal.UnionCredits'.
 newtype UnionCredits = UnionCredits Int

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -174,6 +174,9 @@ new ::
 new hfs hbio runParams mergeType mergeMappend targetPaths runs = do
     -- no offset, no write buffer
     mreaders <- Readers.new Readers.NoOffsetKey Nothing runs
+    -- TODO: Exception safety! If Readers.new fails after already creating some
+    -- run readers, or Builder.new fails, the run readers will stay open,
+    -- holding handles of the input runs' files.
     for mreaders $ \mergeReaders -> do
       -- calculate upper bounds based on input runs
       let numEntries = V.foldMap' Run.size runs

--- a/src/Database/LSMTree/Internal/Merge.hs
+++ b/src/Database/LSMTree/Internal/Merge.hs
@@ -236,7 +236,7 @@ complete Merge{..} = do
       Merging -> error "complete: Merge is not done"
       MergingDone -> do
         -- the readers are already drained, therefore closed
-        r <- Run.fromMutable mergeBuilder
+        r <- Run.fromBuilder mergeBuilder
         writeMutVar mergeState $! Completed
         pure r
       Completed -> error "complete: Merge is already completed"

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -762,18 +762,10 @@ mergingRunParamsForLevel ::
   -> Unique
   -> LevelNo
   -> (RunParams, RunFsPaths)
-mergingRunParamsForLevel dir
-                         conf@TableConfig {
-                                confDiskCachePolicy,
-                                confFencePointerIndex
-                         }
-                         unique ln =
-    (RunParams {..}, runPaths)
+mergingRunParamsForLevel dir conf unique ln =
+    (runParamsForLevel conf (RegularLevel ln), runPaths)
   where
-    !runParamCaching = diskCachePolicyForLevel confDiskCachePolicy ln
-    !runParamAlloc   = bloomFilterAllocForLevel conf ln
-    !runParamIndex   = indexTypeForRun confFencePointerIndex
-    !runPaths        = Paths.runPath dir (uniqueToRunNumber unique)
+    !runPaths = Paths.runPath dir (uniqueToRunNumber unique)
 
 -- | We use levelling on the last level, unless that is also the first level.
 mergePolicyForLevel ::

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -10,6 +10,7 @@ module Database.LSMTree.Internal.MergingRun (
   , newCompleted
   , duplicateRuns
   , remainingMergeDebt
+  , supplyChecked
   , supplyCreditsRelative
   , supplyCreditsAbsolute
   , expectCompleted
@@ -69,6 +70,7 @@ import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import           GHC.Stack (HasCallStack, callStack)
 import           System.FS.API (HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
 
@@ -763,6 +765,36 @@ remainingMergeDebt (DeRef mr) = do
         assert (debt >= 0) $ pure ()
         return (MergeDebt debt, size)
 
+{-# INLINE supplyChecked #-}
+-- | Helper function to assert common invariants for functions that supply
+-- credits.
+supplyChecked ::
+     forall m r s. (HasCallStack, Monad m)
+  => (r -> m (MergeDebt, s))  -- how to query current debt
+  -> (r -> MergeCredits -> m MergeCredits)  -- how to supply
+  -> (r -> MergeCredits -> m MergeCredits)
+supplyChecked _query supply x credits = do
+    assertM $ credits > 0   -- only call them when there are credits to supply
+#ifdef NO_IGNORE_ASSERTS
+    debt <- fst <$> _query x
+    assertM $ debt >= MergeDebt 0 -- debt can't be negative
+    leftovers <- supply x credits
+    assertM $ leftovers <= credits -- can't have more left than we started with
+    assertM $ leftovers >= 0       -- leftovers can't be negative
+    debt' <- fst <$> _query x
+    assertM $ debt' >= MergeDebt 0
+    -- the debt was reduced sufficiently (amount of credits spent)
+    assertM $ debt' <= let MergeDebt d = debt
+                       in MergeDebt (d - (credits - leftovers))
+    return leftovers
+#else
+    supply x credits
+#endif
+  where
+    assertM :: HasCallStack => Bool -> m ()
+    assertM p = let _ = callStack in assert p (pure ())
+    -- just uses callStack so the constraint is not redundant in release builds
+
 {-# INLINE supplyCreditsRelative #-}
 -- | Supply the given amount of credits to a merging run. This /may/ cause an
 -- ongoing merge to progress.
@@ -771,27 +803,24 @@ remainingMergeDebt (DeRef mr) = do
 -- supplied credits. See 'supplyCreditsAbsolute' to set the supplied credits
 -- to an absolute value.
 --
--- The result is:
---
---  1. The (absolute value of the) supplied credits beforehand.
---  2. The (absolute value of the) supplied credits afterwards.
---  3. The number of credits left over. This will be non-zero if the credits
---     supplied would take the total supplied credits over the total merge debt.
+-- The result is the number of credits left over. This will be non-zero if the
+-- credits supplied would take the total supplied credits over the total merge
+-- debt.
 --
 supplyCreditsRelative ::
      forall t m h. (MonadSTM m, MonadST m, MonadMVar m, MonadMask m)
   => Ref (MergingRun t m h)
   -> CreditThreshold
   -> MergeCredits
-  -> m (MergeCredits, MergeCredits, MergeCredits)
-       -- ^ (suppliedCredits, suppliedCredits', leftoverCredits)
-supplyCreditsRelative mr th c = do
-    r@(_suppliedCredits, suppliedCredits', leftoverCredits)
-      <- supplyCredits mr th (SupplyMergeCredits SupplyRelative c)
+  -> m MergeCredits
+supplyCreditsRelative = flip $ \th ->
+    supplyChecked remainingMergeDebt $ \mr c -> do
+      (_suppliedCredits, suppliedCredits', leftoverCredits)
+        <- supplyCredits mr th (SupplyMergeCredits SupplyRelative c)
 
-    assert (suppliedCredits' == mergeDebtAsCredits (totalMergeDebt mr)
-            || leftoverCredits == 0) $
-      pure r
+      assert (suppliedCredits' == mergeDebtAsCredits (totalMergeDebt mr)
+              || leftoverCredits == 0) $
+        pure leftoverCredits
 
 {-# INLINE supplyCreditsAbsolute #-}
 -- | Set the supplied credits to the given value, unless the current value is

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -388,7 +388,7 @@ might not finish in time, which will mess up the shape of the levels tree.
 -}
 
 newtype MergeCredits = MergeCredits Int
-  deriving stock (Eq, Ord)
+  deriving stock (Eq, Ord, Show)
   deriving newtype (Num, Real, Enum, Integral, NFData)
 
 newtype MergeDebt = MergeDebt MergeCredits
@@ -414,13 +414,14 @@ numEntriesToMergeDebt (NumEntries n) = MergeDebt (MergeCredits n)
 -- co-prime so that merge work at different levels is not synchronised.
 --
 newtype CreditThreshold = CreditThreshold UnspentCredits
+  deriving stock Show
 
 -- | The spent credits are supplied credits that have been spent on performing
 -- merging steps plus the supplied credits that are in the process of being
 -- spent (by some thread calling 'supplyCredits').
 --
 newtype SpentCredits = SpentCredits MergeCredits
-  deriving newtype (Eq, Ord)
+  deriving newtype (Eq, Ord, Show)
 
 -- | 40 bit unsigned number
 instance Bounded SpentCredits where
@@ -436,7 +437,7 @@ instance Bounded SpentCredits where
 -- current unspent credits being negative for a time.
 --
 newtype UnspentCredits = UnspentCredits MergeCredits
-  deriving newtype (Eq, Ord)
+  deriving newtype (Eq, Ord, Show)
 
 -- | 24 bit signed number
 instance Bounded UnspentCredits where

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -902,7 +902,7 @@ completeMerge mergeVar mergeKnownCompletedVar = do
       (OngoingMerge rs m) -> do
         -- first try to complete the merge before performing other side effects,
         -- in case the completion fails
-        --TODO: Run.fromMutable (used in Merge.complete) claims not to be
+        --TODO: Run.fromBuilder (used in Merge.complete) claims not to be
         -- exception safe so we should probably be using the resource registry
         -- and test for exception safety.
         r <- Merge.complete m

--- a/src/Database/LSMTree/Internal/MergingTree.hs
+++ b/src/Database/LSMTree/Internal/MergingTree.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 -- | An incremental merge of multiple runs, preserving a bracketing structure.
@@ -11,25 +12,40 @@ module Database.LSMTree.Internal.MergingTree (
   , newPendingUnionMerge
   , isStructurallyEmpty
   , remainingMergeDebt
+  , supplyCredits
     -- * Internal state
   , MergingTreeState (..)
   , PendingMerge (..)
   ) where
 
+import           Control.ActionRegistry
 import           Control.Concurrent.Class.MonadMVar.Strict
-import           Control.Monad ((<$!>))
+import           Control.Exception (assert)
+import           Control.Monad (foldM, (<$!>))
+import           Control.Monad.Class.MonadST (MonadST)
+import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (MonadMask)
 import           Control.Monad.Primitive
 import           Control.RefCount
-import           Data.Foldable (traverse_)
+import           Data.Foldable (toList, traverse_)
+#if !MIN_VERSION_base(4,20,0)
+import           Data.List (foldl')
+                 -- foldl' is included in the Prelude from base 4.20 onwards
+#endif
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
+import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.MergingRun (MergeDebt (..),
                      MergingRun)
 import qualified Database.LSMTree.Internal.MergingRun as MR
+import           Database.LSMTree.Internal.Paths (SessionRoot)
+import qualified Database.LSMTree.Internal.Paths as Paths
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.UniqCounter
+import           System.FS.API (HasFS)
+import           System.FS.BlockIO.API (HasBlockIO)
 
 -- $mergingtrees Semantically, tables are key-value stores like Haskell's
 -- @Map@. Table unions then behave like @Map.unionWith (<>)@. If one of the
@@ -251,11 +267,13 @@ newPendingUnionMerge mts = do
 --
 isStructurallyEmpty :: MonadMVar m => Ref (MergingTree m h) -> m Bool
 isStructurallyEmpty (DeRef MergingTree {mergeState}) =
-    isEmpty <$> readMVar mergeState
-  where
-    isEmpty (PendingTreeMerge (PendingLevelMerge prs Nothing)) = V.null prs
-    isEmpty (PendingTreeMerge (PendingUnionMerge mts))         = V.null mts
-    isEmpty _                                                  = False
+    isStructurallyEmptyState <$> readMVar mergeState
+
+isStructurallyEmptyState :: MergingTreeState m h -> Bool
+isStructurallyEmptyState = \case
+    PendingTreeMerge (PendingLevelMerge prs Nothing) -> V.null prs
+    PendingTreeMerge (PendingUnionMerge mts)         -> V.null mts
+    _                                                -> False
     -- It may also turn out to be useful to consider CompletedTreeMerge with
     -- a zero length runs as empty.
 
@@ -343,3 +361,181 @@ debtOfNestedMerge debts =
 
     add (MergeDebt !d1, NumEntries !n1) (MergeDebt !d2, NumEntries !n2) =
         (MergeDebt (d1 + d2), NumEntries (n1 + n2))
+
+{-# SPECIALISE supplyCredits ::
+     HasFS IO h
+  -> HasBlockIO IO h
+  -> ResolveSerialisedValue
+  -> Run.RunParams
+  -> MR.CreditThreshold
+  -> SessionRoot
+  -> UniqCounter IO
+  -> Ref (MergingTree IO h)
+  -> MR.MergeCredits
+  -> IO MR.MergeCredits #-}
+supplyCredits ::
+     forall m h.
+     (MonadMVar m, MonadST m, MonadSTM m, MonadMask m)
+  => HasFS m h
+  -> HasBlockIO m h
+  -> ResolveSerialisedValue
+  -> Run.RunParams
+  -> MR.CreditThreshold
+  -> SessionRoot
+  -> UniqCounter m
+  -> Ref (MergingTree m h)
+  -> MR.MergeCredits
+  -> m MR.MergeCredits
+supplyCredits hfs hbio resolve runParams threshold root uc = \mt0 c0 -> do
+    if c0 <= 0
+      then return 0
+      else supplyTree mt0 c0
+  where
+    mkFreshRunPaths = do
+        runNumber <- uniqueToRunNumber <$> incrUniqCounter uc
+        return (Paths.runPath (Paths.activeDir root) runNumber)
+
+    supplyTree =
+        MR.supplyChecked remainingMergeDebt $ \(DeRef mt) credits ->
+          -- TODO: This locks the tree for everyone, for the entire call.
+          -- Lookups have to wait until supplyCredits is done.
+          -- It should be enough to take the lock only to turn a pending into
+          -- an ongoing or ongoing into completed tree, very briefly.
+          modifyWithActionRegistry
+            (takeMVar (mergeState mt))
+            (putMVar (mergeState mt))
+            (\reg state -> supplyState reg state credits)
+
+    supplyState reg state credits =
+        case state of
+          CompletedTreeMerge _ ->
+            return (state, credits)
+
+          OngoingTreeMerge mr -> do
+            leftovers <- MR.supplyCreditsRelative mr threshold credits
+            if leftovers <= 0
+              then
+                return (state, 0)
+              else do
+                -- complete ongoing merge
+                r <- withRollback reg (MR.expectCompleted mr) releaseRef
+                delayedCommit reg (releaseRef mr)
+                -- all work is done, we can't spend any more credits
+                return (CompletedTreeMerge r, leftovers)
+
+          PendingTreeMerge _
+            | isStructurallyEmptyState state -> do
+            -- make a completely fresh empty run. this can only happen at the
+            -- root. the structurally empty tree still has debt 1, so we want to
+            -- merge it into a single run.
+            -- we handle this as a special case here since in several places
+            -- below we require the list of children to be non-empty.
+            runPaths <- mkFreshRunPaths
+            run <-
+              withRollback reg
+                -- TODO: the builder's handles aren't cleaned up if we fail
+                -- before fromBuilder closes them
+                (Run.newEmpty hfs hbio runParams runPaths)
+                releaseRef
+            return (CompletedTreeMerge run, credits)
+
+          PendingTreeMerge pm -> do
+            leftovers <- supplyPending pm credits
+            if leftovers <= 0
+              then
+                -- still remaining work in children, we can't do more for now
+                return (state, leftovers)
+              else do
+                -- all children must be done, create new merge!
+                state' <- startPendingMerge reg pm
+                -- use any remaining credits to progress the new merge
+                supplyState reg state' leftovers
+
+    supplyPending ::
+         PendingMerge m h -> MR.MergeCredits -> m MR.MergeCredits
+    supplyPending =
+        MR.supplyChecked remainingMergeDebtPendingMerge $ \pm credits -> do
+          case pm of
+            PendingLevelMerge prs mt ->
+              leftToRight supplyPreExisting (V.toList prs) credits
+                >>= leftToRight (flip supplyTree) (toList mt)
+            PendingUnionMerge mts ->
+              splitEqually (flip supplyTree) (V.toList mts) credits
+
+    supplyPreExisting c = \case
+        PreExistingRun _r        -> return c  -- no work to do, all leftovers
+        PreExistingMergingRun mr -> MR.supplyCreditsRelative mr threshold c
+
+    -- supply credits left to right until they are used up
+    leftToRight ::
+         (MR.MergeCredits -> a -> m MR.MergeCredits)
+      -> [a] -> MR.MergeCredits -> m MR.MergeCredits
+    leftToRight _ _      0 = return 0
+    leftToRight _ []     c = return c
+    leftToRight f (x:xs) c = f c x >>= leftToRight f xs
+
+    -- approximately equal, being more precise would require more iterations
+    splitEqually ::
+         (MR.MergeCredits -> a -> m MR.MergeCredits)
+      -> [a] -> MR.MergeCredits -> m MR.MergeCredits
+    splitEqually f xs (MR.MergeCredits credits) =
+        -- first give each tree k = ceil(1/n) credits (last ones might get less).
+        -- it's important we fold here to collect leftovers.
+        -- any remainders go left to right.
+        foldM supplyNth (MR.MergeCredits credits) xs >>= leftToRight f xs
+      where
+        !n = length xs
+        !k = MR.MergeCredits ((credits + (n - 1)) `div` n)
+
+        supplyNth 0 _ = return 0
+        supplyNth c t = do
+            let creditsToSpend = min k c
+            leftovers <- f creditsToSpend t
+            return (c - creditsToSpend + leftovers)
+
+    startPendingMerge reg pm = do
+        (mergeType, rs) <- expectCompletedChildren reg pm
+        assert (V.length rs > 0) $ pure ()
+        runPaths <- mkFreshRunPaths
+        mr <-
+          withRollback reg
+            (MR.new hfs hbio resolve runParams mergeType runPaths rs)
+            releaseRef
+        -- no need for the runs anymore, 'MR.new' made duplicates
+        traverse_ (\r -> delayedCommit reg (releaseRef r)) rs
+        return (OngoingTreeMerge mr)
+
+    -- Child references are released using 'delayedCommit', so they get released
+    -- if the whole supply operation runs successfully (so the pending merge
+    -- is replaced).
+    --
+    -- Returned references are registered in the ActionRegistry, so they will
+    -- get released in case of an exception.
+    expectCompletedChildren ::
+         ActionRegistry m
+      -> PendingMerge m h
+      -> m (MR.TreeMergeType, Vector (Ref (Run m h)))
+    expectCompletedChildren reg (PendingMerge ty prs mts) = do
+        rs1 <- V.forM prs $ \case
+          PreExistingRun r -> do
+            delayedCommit reg (releaseRef r)  -- only released at the end
+            withRollback reg (dupRef r) releaseRef
+          PreExistingMergingRun mr -> do
+            delayedCommit reg (releaseRef mr)  -- only released at the end
+            withRollback reg (MR.expectCompleted mr) releaseRef
+        rs2 <- V.forM mts $ \mt -> do
+          delayedCommit reg (releaseRef mt)  -- only released at the end
+          withRollback reg (expectCompleted mt) releaseRef
+        return (ty, rs1 <> rs2)
+
+-- | This does /not/ release the reference, but allocates a new reference for
+-- the returned run, which must be released at some point.
+expectCompleted ::
+     (MonadMVar m, MonadSTM m, MonadST m, MonadMask m)
+  => Ref (MergingTree m h) -> m (Ref (Run m h))
+expectCompleted (DeRef MergingTree {..}) = do
+    withMVar mergeState $ \case
+      CompletedTreeMerge r -> dupRef r  -- return a fresh reference to the run
+      OngoingTreeMerge mr  -> MR.expectCompleted mr
+      PendingTreeMerge{}   ->
+        error "expectCompleted: expected a completed merging tree, but found a pending one"

--- a/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
+++ b/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
@@ -62,7 +62,6 @@ mergeLookupAcc ::
   -> V.Vector (LookupAcc m h)
   -> LookupAcc m h
 mergeLookupAcc resolve mt accs =
-    -- TODO assert (not (null accs)) $
     assert (V.length accs > 1) $
     assert (V.all ((== V.length (V.head accs)) . V.length) accs) $
       foldl1 (V.zipWith updateEntry) accs

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -715,7 +715,8 @@ remainingUnionDebt (Internal.MonoidalTable t) =
     (\(Internal.UnionDebt x) -> UnionDebt x) <$>
       Internal.remainingUnionDebt t
 
-{-# SPECIALISE supplyUnionCredits :: Table IO k v -> UnionCredits -> IO UnionCredits #-}
+{-# SPECIALISE supplyUnionCredits ::
+     ResolveValue v => Table IO k v -> UnionCredits -> IO UnionCredits #-}
 -- | Supply union credits to reduce union debt.
 --
 -- Supplying union credits leads to union merging work being performed in
@@ -728,13 +729,16 @@ remainingUnionDebt (Internal.MonoidalTable t) =
 -- a union has finished. In particular, if the returned number of credits is
 -- non-negative, then the union is finished.
 supplyUnionCredits ::
-     IOLike m
+     forall m k v. (IOLike m, ResolveValue v)
   => Table m k v
   -> UnionCredits
   -> m UnionCredits
 supplyUnionCredits (Internal.MonoidalTable t) (UnionCredits credits) =
     (\(Internal.UnionCredits x) -> UnionCredits x) <$>
-      Internal.supplyUnionCredits t (Internal.UnionCredits credits)
+      Internal.supplyUnionCredits
+        (resolve @v Proxy)
+        t
+        (Internal.UnionCredits credits)
 
 {-------------------------------------------------------------------------------
   Monoidal value resolution

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -854,4 +854,4 @@ supplyUnionCredits ::
   -> m UnionCredits
 supplyUnionCredits (Internal.NormalTable t) (UnionCredits credits) =
     (\(Internal.UnionCredits x) -> UnionCredits x) <$>
-      Internal.supplyUnionCredits t (Internal.UnionCredits credits)
+      Internal.supplyUnionCredits const t (Internal.UnionCredits credits)

--- a/test/Test/Database/LSMTree/Class.hs
+++ b/test/Test/Database/LSMTree/Class.hs
@@ -52,34 +52,7 @@ tests = testGroup "Test.Database.LSMTree.Class"
               action (SessionArgs hfs hbio (FS.mkFsPath []))
         }
 
-    expectFailures2 = [
-        False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , False
-      , True  -- merge
-      ] ++ repeat False
+    expectFailures2 = repeat False
 
     props RunSetup {..} =
       [ testProperty' "lookup-insert" $ prop_lookupInsert . runSetup

--- a/test/Test/Database/LSMTree/Generators.hs
+++ b/test/Test/Database/LSMTree/Generators.hs
@@ -19,10 +19,12 @@ import qualified Database.LSMTree.Internal.Index as Index
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.PageAcc (entryWouldFitInPage,
                      sizeofEntry)
+import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import qualified Database.LSMTree.Internal.RunAcc as RunAcc
 import qualified Database.LSMTree.Internal.RunBuilder as RunBuilder
+import           Database.LSMTree.Internal.RunNumber (RunNumber (..))
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.UniqCounter
 import qualified System.FS.API as FS
@@ -155,7 +157,10 @@ prop_withRunDoesntLeak ::
   -> IO Property
 prop_withRunDoesntLeak hfs hbio rd = do
     let indexType = Index.Ordinary
-    withRunAt hfs hbio (runParams indexType) (simplePath 0) rd $ \_run -> do
+    let path = FS.mkFsPath ["something-1"]
+    let fsPaths = RunFsPaths path (RunNumber 0)
+    FS.createDirectory hfs path
+    withRunAt hfs hbio (runParams indexType) fsPaths rd $ \_run -> do
       return (QC.property True)
 
 prop_withMergingRunDoesntLeak ::
@@ -165,7 +170,8 @@ prop_withMergingRunDoesntLeak ::
   -> IO Property
 prop_withMergingRunDoesntLeak hfs hbio mrd = do
     let indexType = Index.Ordinary
-    let path = FS.mkFsPath []
+    let path = FS.mkFsPath ["something-2"]
+    FS.createDirectory hfs path
     counter <- newUniqCounter 0
     withMergingRun hfs hbio resolveVal (runParams indexType) path counter mrd $
       \_mr -> do
@@ -180,7 +186,8 @@ prop_withMergingTreeDoesntLeak ::
   -> IO Property
 prop_withMergingTreeDoesntLeak hfs hbio mrd = do
     let indexType = Index.Ordinary
-    let path = FS.mkFsPath []
+    let path = FS.mkFsPath ["something-3"]
+    FS.createDirectory hfs path
     counter <- newUniqCounter 0
     withMergingTree hfs hbio resolveVal (runParams indexType) path counter mrd $
       \_tree -> do

--- a/test/Test/Database/LSMTree/Internal/MergingRun.hs
+++ b/test/Test/Database/LSMTree/Internal/MergingRun.hs
@@ -37,10 +37,6 @@ prop_CreditsPair spentCredits unspentCredits =
 deriving newtype instance Enum SpentCredits
 deriving newtype instance Enum UnspentCredits
 
-deriving stock instance Show MergeCredits
-deriving stock instance Show SpentCredits
-deriving stock instance Show UnspentCredits
-
 instance Arbitrary SpentCredits where
   arbitrary =
     frequency [ (1, pure minBound)

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -384,7 +384,6 @@ deriving stock instance Show r => Show (SnapPendingMerge r)
 deriving stock instance Show r => Show (SnapPreExistingRun r)
 
 deriving stock instance Show MergeDebt
-deriving stock instance Show MergeCredits
 deriving stock instance Show NominalDebt
 deriving stock instance Show NominalCredits
 

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -78,12 +78,12 @@ import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe, isJust)
+import           Data.Maybe (catMaybes, fromMaybe)
 import           Data.Monoid (First (..))
 import           Data.Primitive.MutVar
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Typeable (Proxy (..), Typeable, cast, eqT)
+import           Data.Typeable (Proxy (..), Typeable, cast)
 import qualified Data.Vector as V
 import qualified Database.LSMTree as R
 import           Database.LSMTree.Class (LookupResult (..), QueryResult (..))
@@ -1983,30 +1983,18 @@ arbitraryActionWithVars _ label ctx (ModelState st _stats) =
             -- Tables not derived from unions are covered in UnitTests.
         | not (null unionDescendantTableVars)
         , let genErrors = pure Nothing -- TODO: generate errors
-          -- TODO: this is currently only enabled for the reference
-          -- implementation. Enable this unconditionally once table union is
-          -- implemented
-        , isJust (eqT @h @ModelIO.Table)
         ]
      ++ [ (8, fmap Some $ (Action <$> genErrors <*>) $
             SupplyUnionCredits <$> genUnionDescendantTableVar <*> genUnionCredits)
             -- Tables not derived from unions are covered in UnitTests.
         | not (null unionDescendantTableVars)
         , let genErrors = pure Nothing -- TODO: generate errors
-          -- TODO: this is currently only enabled for the reference
-          -- implementation. Enable this unconditionally once table union is
-          -- implemented
-        , isJust (eqT @h @ModelIO.Table)
         ]
       ++ [ (2, fmap Some $ (Action <$> genErrors <*>) $
             SupplyPortionOfDebt <$> genUnionDescendantTableVar <*> genPortion)
             -- Tables not derived from unions are covered in UnitTests.
         | not (null unionDescendantTableVars)
         , let genErrors  = pure Nothing -- TODO: generate errors
-          -- TODO: this is currently only enabled for the reference
-          -- implementation. Enable this unconditionally once table union is
-          -- implemented
-        , isJust (eqT @h @ModelIO.Table)
         ]
       where
         -- The typical, interesting case is to supply a positive number of

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -761,8 +761,8 @@ data Action' h a where
   -- 'SupplyUnionCredits' gets no information about union debt, so the union
   -- credits we generate are arbitrary, and it would require precarious, manual
   -- tuning to make sure the debt is ever paid off by an action sequence.
-  -- 'SupplyUnionCredits' supplies a portion (if not al) of the current debt, so
-  -- that unions are more likely to finish during a sequence of actions.
+  -- 'SupplyUnionCredits' supplies a portion (if not all) of the current debt,
+  -- so that unions are more likely to finish during a sequence of actions.
   SupplyPortionOfDebt ::
        C k v b
     => Var h (WrapTable h IO k v b)
@@ -904,6 +904,7 @@ instance ( Eq (Class.TableConfig h)
     MSnapshotName :: R.SnapshotName -> Val h R.SnapshotName
     MUnionDebt :: R.UnionDebt -> Val h R.UnionDebt
     MUnionCredits :: R.UnionCredits -> Val h R.UnionCredits
+    MUnionCreditsPortion :: R.UnionCredits -> Val h R.UnionCredits
     MErr :: Model.Err -> Val h Model.Err
     -- combinators
     MUnit   :: () -> Val h ()
@@ -926,6 +927,8 @@ instance ( Eq (Class.TableConfig h)
                  -> Obs h (QueryResult k v (WrapBlobRef h IO b))
     OBlob :: (Show b, Typeable b, Eq b)
           => WrapBlob b -> Obs h (WrapBlob b)
+    OUnionCredits :: R.UnionCredits -> Obs h R.UnionCredits
+    OUnionCreditsPortion :: R.UnionCredits -> Obs h R.UnionCredits
     OId :: (Show a, Typeable a, Eq a) => a -> Obs h a
     -- combinators
     OPair   :: (Obs h a, Obs h b) -> Obs h (a, b)
@@ -935,21 +938,22 @@ instance ( Eq (Class.TableConfig h)
 
   observeModel :: Val h a -> Obs h a
   observeModel = \case
-      MTable _       -> OTable
-      MCursor _            -> OCursor
-      MBlobRef _           -> OBlobRef
-      MLookupResult x      -> OLookupResult $ fmap observeModel x
-      MQueryResult x       -> OQueryResult $ fmap observeModel x
-      MSnapshotName x      -> OId x
-      MBlob x              -> OBlob x
-      MUnionDebt x         -> OId x
-      MUnionCredits x      -> OId x
-      MErr x               -> OId x
-      MUnit x              -> OId x
-      MPair x              -> OPair $ bimap observeModel observeModel x
-      MEither x            -> OEither $ bimap observeModel observeModel x
-      MList x              -> OList $ map observeModel x
-      MVector x            -> OVector $ V.map observeModel x
+      MTable _               -> OTable
+      MCursor _              -> OCursor
+      MBlobRef _             -> OBlobRef
+      MLookupResult x        -> OLookupResult $ fmap observeModel x
+      MQueryResult x         -> OQueryResult $ fmap observeModel x
+      MSnapshotName x        -> OId x
+      MBlob x                -> OBlob x
+      MUnionDebt x           -> OId x
+      MUnionCredits x        -> OUnionCredits x
+      MUnionCreditsPortion x -> OUnionCreditsPortion x
+      MErr x                 -> OId x
+      MUnit x                -> OId x
+      MPair x                -> OPair $ bimap observeModel observeModel x
+      MEither x              -> OEither $ bimap observeModel observeModel x
+      MList x                -> OList $ map observeModel x
+      MVector x              -> OVector $ V.map observeModel x
 
   modelNextState ::  forall a.
        LockstepAction (ModelState h) a
@@ -1047,19 +1051,28 @@ instance Eq (Obs h a) where
         , Just Model.DefaultErrSnapshotCorrupted <- cast rhs
         -> True
 
+      -- RemainingUnionDebt
+      --
       -- Debt in the model is always 0, while debt in the real implementation
       -- may be larger than 0.
       (OEither (Right (OId lhs)), OEither (Right (OId rhs)))
         | Just (lhsDebt :: R.UnionDebt) <- cast lhs
         , Just (rhsDebt :: R.UnionDebt) <- cast rhs
-        -> lhsDebt >= rhsDebt
+        -> lhsDebt >= R.UnionDebt 0 && rhsDebt == R.UnionDebt 0
 
+      -- SupplyUnionCredits
+      --
       -- In the model, all supplied union credits are returned as leftovers,
-      -- whereas in the real implementation may use up some union credits.
-      (OEither (Right (OId lhs)), OEither (Right (OId rhs)))
-        | Just (lhsLeftovers :: R.UnionCredits) <- cast lhs
-        , Just (rhsLeftovers :: R.UnionCredits) <- cast rhs
+      -- whereas the real implementation may use up some union credits.
+      (OEither (Right (OUnionCredits lhsLeftovers)), OEither (Right (OUnionCredits rhsLeftovers)))
         -> lhsLeftovers <= rhsLeftovers
+
+      -- SupplyPortionOfDebt
+      --
+      -- In the model, a portion of the debt is always 0, whereas in the real
+      -- implementation the portion of the debt is non-negative.
+      (OEither (Right (OUnionCreditsPortion lhsLeftovers)), OEither (Right (OUnionCreditsPortion rhsLeftovers)))
+        -> lhsLeftovers >= rhsLeftovers
 
       -- default equalities
       (OTable, OTable) -> True
@@ -1068,6 +1081,8 @@ instance Eq (Obs h a) where
       (OLookupResult x, OLookupResult y) -> x == y
       (OQueryResult x, OQueryResult y) -> x == y
       (OBlob x, OBlob y) -> x == y
+      (OUnionCredits x, OUnionCredits y) -> x == y
+      (OUnionCreditsPortion x, OUnionCreditsPortion y) -> x == y
       (OId x, OId y) -> x == y
       (OPair x, OPair y) -> x == y
       (OEither x, OEither y) -> x == y
@@ -1083,6 +1098,8 @@ instance Eq (Obs h a) where
           OLookupResult{} -> ()
           OQueryResult{} -> ()
           OBlob{} -> ()
+          OUnionCredits{} -> ()
+          OUnionCreditsPortion{} -> ()
           OId{} -> ()
           OPair{} -> ()
           OEither{} -> ()
@@ -1175,8 +1192,8 @@ instance ( Eq (Class.TableConfig h)
       Union{}               -> OEither $ bimap OId (const OTable) result
       Unions{}              -> OEither $ bimap OId (const OTable) result
       RemainingUnionDebt{}  -> OEither $ bimap OId OId result
-      SupplyUnionCredits{}  -> OEither $ bimap OId OId result
-      SupplyPortionOfDebt{} -> OEither $ bimap OId OId result
+      SupplyUnionCredits{}  -> OEither $ bimap OId OUnionCredits result
+      SupplyPortionOfDebt{} -> OEither $ bimap OId OUnionCreditsPortion result
 
   showRealResponse ::
        Proxy (RealMonad h IO)
@@ -1241,8 +1258,8 @@ instance ( Eq (Class.TableConfig h)
       Union{}               -> OEither $ bimap OId (const OTable) result
       Unions{}              -> OEither $ bimap OId (const OTable) result
       RemainingUnionDebt{}  -> OEither $ bimap OId OId result
-      SupplyUnionCredits{}  -> OEither $ bimap OId OId result
-      SupplyPortionOfDebt{} -> OEither $ bimap OId OId result
+      SupplyUnionCredits{}  -> OEither $ bimap OId OUnionCredits result
+      SupplyPortionOfDebt{} -> OEither $ bimap OId OUnionCreditsPortion result
 
   showRealResponse ::
        Proxy (RealMonad h (IOSim s))
@@ -1418,7 +1435,7 @@ runModel lookUp (Action merrs action') = case action' of
           (Model.supplyUnionCredits (getTable $ lookUp tableVar) credits)
           (pure ()) -- TODO(err)
     SupplyPortionOfDebt tableVar portion ->
-      wrap MUnionCredits
+      wrap MUnionCreditsPortion
       . Model.runModelMWithInjectedErrors merrs
           (do let table = getTable $ lookUp tableVar
               debt <- Model.remainingUnionDebt table
@@ -2181,7 +2198,7 @@ shrinkAction'WithVars _ctx _st a = case a of
     -- the union debt is larger.
     SupplyPortionOfDebt tableVar (Portion x) -> [
         Some $ SupplyUnionCredits tableVar (R.UnionCredits x')
-      | x' <- [2 ^ i - 1 | (i :: Int) <- [0..63]]
+      | x' <- [2 ^ i - 1 | (i :: Int) <- [0..20]]
       , assert (x' >= 0) True
       ] ++ [
         Some $ SupplyPortionOfDebt tableVar (Portion x')


### PR DESCRIPTION
There is an issue in the lockstep tests with how `SupplyPortionOfDebt` works, so I had to disable that action for now. I'll see if we can salvage it, but we'd probably have to relax the `Eq (Obs h a)` instance for `UnionCredits`. Ideally we'd have separate cases for `SupplyUnionCredits` and `SupplyPortionOfDebt` to enforce that for one the implementation can't return fewer and for the other it can't return more leftovers than the model.

I'm also still adding a property based test for supplying into the `MergingTree`.