### PR TITLE
Make run parameters explicit

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -19,15 +19,17 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Extras.Random (frequency, randomByteStringR,
                      sampleUniformWithReplacement, uniformWithoutReplacement)
-import           Database.LSMTree.Extras.RunData (defaultRunParams)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Entry (Entry (..), NumEntries (..))
+import           Database.LSMTree.Internal.Index as Index
 import           Database.LSMTree.Internal.Lookup (bloomQueries, indexSearches,
                      intraPageLookups, lookupsIO, prepLookups)
 import           Database.LSMTree.Internal.Page (getNumPages)
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import qualified Database.LSMTree.Internal.RunAcc as RunAcc
+import           Database.LSMTree.Internal.RunBuilder as RunBuilder
 import           Database.LSMTree.Internal.RunNumber
 import           Database.LSMTree.Internal.Serialise
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
@@ -191,7 +193,7 @@ lookupsInBatchesEnv Config {..} = do
     wbblobs <- WBB.new hasFS (FS.mkFsPath ["0.wbblobs"])
     wb <- WB.fromMap <$> traverse (traverse (WBB.addBlob hasFS wbblobs)) storedKeys
     let fsps = RunFsPaths (FS.mkFsPath []) (RunNumber 0)
-    r <- Run.fromWriteBuffer hasFS hasBlockIO defaultRunParams fsps wb wbblobs
+    r <- Run.fromWriteBuffer hasFS hasBlockIO runParams fsps wb wbblobs
     let NumEntries nentriesReal = Run.size r
     assertEqual nentriesReal nentries $ pure ()
     -- 42 to 43 entries per page
@@ -204,6 +206,14 @@ lookupsInBatchesEnv Config {..} = do
          , V.singleton r
          , lookupKeys
          )
+  where
+    runParams :: RunBuilder.RunParams
+    runParams =
+        RunBuilder.RunParams {
+          runParamCaching = RunBuilder.CacheRunData,
+          runParamAlloc   = RunAcc.RunAllocFixed 10,
+          runParamIndex   = Index.Compact
+        }
 
 lookupsInBatchesCleanup ::
      ( FilePath -- ^ Temporary directory


### PR DESCRIPTION
This pull request removes `defaultRunParams` in favor of explicit specification of run parameters.
