### PR TITLE
Remove some obsolete TODOs and unused declarations

### DIFF
--- a/src/Database/LSMTree/Internal/Config.hs
+++ b/src/Database/LSMTree/Internal/Config.hs
@@ -164,12 +164,7 @@ data MergePolicy =
     -- This makes it easier for delete operations to disappear on the last
     -- level.
     MergePolicyLazyLevelling
-{- TODO: disabled for now. Would we ever want to provide pure tiering?
-  | MergePolicyTiering
--}
-{- TODO: disabled for now
-  | MergePolicyLevelling
--}
+    -- TODO: add other merge policies, like tiering and levelling.
   deriving stock (Eq, Show)
 
 instance NFData MergePolicy where
@@ -200,13 +195,6 @@ data WriteBufferAlloc =
     -- NOTE: if the sizes of values vary greatly, this can lead to wonky runs on
     -- disk, and therefore unpredictable performance.
     AllocNumEntries !NumEntries
-{- TODO: disabled for now
-  | -- | Total number of bytes that the write buffer can use.
-    --
-    -- The maximum is 4GiB, which should be more than enough for realistic
-    -- applications.
-    AllocTotalBytes !Word32
--}
   deriving stock (Show, Eq)
 
 instance NFData WriteBufferAlloc where

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -36,7 +36,6 @@ module Database.LSMTree.Internal.MergeSchedule (
   , MergeDebt (..)
   , MergeCredits (..)
   , supplyCredits
-  , creditThresholdForLevel
   , NominalDebt (..)
   , NominalCredits (..)
   , nominalDebtAsCredits
@@ -353,7 +352,6 @@ iforLevelM_ lvls k = V.iforM_ lvls $ \i lvl -> k (LevelNo (i + 1)) lvl
 --
 -- TODO: So far, this is
 -- * not considered when creating cursors (also used for range lookups)
--- * never made merge progress on (by supplying credits to it)
 -- * never merged into the regular levels
 data UnionLevel m h =
     NoUnion
@@ -939,10 +937,3 @@ nominalDebtForLevel TableConfig {
                       confSizeRatio
                     } ln =
     NominalDebt (maxRunSizeTiering (sizeRatioInt confSizeRatio) bufferSize ln)
-
--- TODO: the thresholds for doing merge work should be different for each level,
--- maybe co-prime?
-creditThresholdForLevel :: TableConfig -> LevelNo -> MR.CreditThreshold
-creditThresholdForLevel conf (LevelNo _i) =
-    let AllocNumEntries (NumEntries x) = confWriteBufferAlloc conf
-    in  MR.CreditThreshold (MR.UnspentCredits (MergeCredits x))

--- a/src/Database/LSMTree/Internal/Range.hs
+++ b/src/Database/LSMTree/Internal/Range.hs
@@ -11,8 +11,6 @@ import           Control.DeepSeq (NFData (..))
 -------------------------------------------------------------------------------}
 
 -- | A range of keys.
---
--- TODO: consider adding key prefixes to the range type.
 data Range k =
     -- | Inclusive lower bound, exclusive upper bound
     FromToExcluding k k

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -97,7 +97,6 @@ lookups ::
   -> V.Vector (Maybe (Entry SerialisedValue BlobSpan))
 lookups (WB !m) !ks = V.mapStrict (`Map.lookup` m) ks
 
--- | TODO: update once blob references are implemented
 lookup ::
      WriteBuffer
   -> SerialisedKey

--- a/test/Test/Database/LSMTree/Internal.hs
+++ b/test/Test/Database/LSMTree/Internal.hs
@@ -2,10 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
-{- HLINT ignore "Use <=<" -}
-
--- TODO: generalise tests in this module for IOSim, not just IO. Do this once we
--- add proper support for IOSim for fault testing.
 module Test.Database.LSMTree.Internal (tests) where
 
 import           Control.Exception

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -27,8 +27,6 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Arbitrary
 
--- TODO: we should add golden tests for the CBOR encoders. This should prevent
--- accidental breakage in the format.
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.Snapshot.Codec" [
       testGroup "SnapshotVersion" [

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -768,8 +768,6 @@ data Action' h a where
     => Var h (WrapTable h IO k v b)
     -> Portion
     -> Act' h R.UnionCredits
-  -- TODO: we should assert that debt decreases monotonically as credits are
-  -- supplied.
 
 portionOf :: Portion -> R.UnionDebt -> R.UnionCredits
 portionOf (Portion denominator) (R.UnionDebt debt)
@@ -1317,7 +1315,7 @@ instance ( Eq (Class.TableConfig h)
   Interpreter for the model
 -------------------------------------------------------------------------------}
 
--- TODO: there are a bunch of TODO(err) in 'runMode;' on the last argument to
+-- TODO: there are a bunch of TODO(err) in 'runModel' on the last argument to
 -- 'Model.runModelMWithInjectedErrors'. This last argument defines how the model
 -- should respond to injected errors. Since we don't generate injected errors
 -- for most of these actions yet, they are left open. We will fill these in as
@@ -2591,12 +2589,6 @@ data Tag =
   | DeleteExistingSnapshot
     -- | Delete a missing snapshot
   | DeleteMissingSnapshot
-    -- | Open a snapshot with the wrong label
-  | OpenSnapshotWrongLabel -- TODO: implement
-    -- | A merge happened on level @n@
-  | MergeOnLevel Int -- TODO: implement
-    -- | A table was closed twice
-  | TableCloseTwice String -- TODO: implement
     -- | A corrupted snapshot was created successfully
   | CreateSnapshotCorrupted R.SnapshotName
     -- | An /un/corrupted snapshot was created successfully
@@ -2718,8 +2710,6 @@ data FinalTag =
   | ActionSuccess String
     -- | Which actions failed
   | ActionFail String Model.Err
-    -- | Total number of flushes
-  | NumFlushes String -- TODO: implement
     -- | Number of tables created (new, open or duplicate)
   | NumTables String
     -- | Number of actions on each table

--- a/test/Test/Database/LSMTree/StateMachine/Op.hs
+++ b/test/Test/Database/LSMTree/StateMachine/Op.hs
@@ -130,7 +130,6 @@ sameOp = go
 instance Eq (Op a b)  where
   (==) = sameOp
 
--- TODO: parentheses
 instance Show (Op a b) where
   showsPrec :: Int -> Op a b -> ShowS
   showsPrec p = \op -> case op of


### PR DESCRIPTION
I perused comments about TODOs and found some things that we can probably remove or simplify
