### PR TITLE
Make `IOLike` a type synonym instead of a class

### DIFF
--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -77,11 +77,10 @@ import           System.FS.IO (HandleIO)
 -------------------------------------------------------------------------------}
 
 -- | Utility class for grouping @io-classes@ constraints.
-class ( MonadAsync m, MonadMVar m, MonadThrow (STM m), MonadThrow m
-      , MonadCatch m , MonadMask m, PrimMonad m, MonadST m
-      ) => IOLike m
-
-instance IOLike IO
+type IOLike m = (
+      MonadAsync m, MonadMVar m, MonadThrow (STM m), MonadThrow m
+    , MonadCatch m , MonadMask m, PrimMonad m, MonadST m
+    )
 
 {-------------------------------------------------------------------------------
   Sessions

--- a/test/Test/Util/Orphans.hs
+++ b/test/Test/Util/Orphans.hs
@@ -20,7 +20,7 @@ import           Control.Monad ((<=<))
 import           Control.Monad.IOSim (IOSim)
 import           Data.Kind (Type)
 import           Database.LSMTree (Cursor, LookupResult, QueryResult, Table)
-import           Database.LSMTree.Common (BlobRef, IOLike, SerialiseValue)
+import           Database.LSMTree.Common (BlobRef, SerialiseValue)
 import           Database.LSMTree.Internal.Serialise (SerialiseKey)
 import           Test.QuickCheck.Modifiers (Small (..))
 import           Test.QuickCheck.StateModel (Realized)
@@ -33,8 +33,6 @@ import           Test.Util.TypeFamilyWrappers (WrapBlob (..), WrapBlobRef (..),
 {-------------------------------------------------------------------------------
   IOSim
 -------------------------------------------------------------------------------}
-
-instance IOLike (IOSim s)
 
 type instance Realized (IOSim s) a = RealizeIOSim s a
 


### PR DESCRIPTION
Slightly nicer for users of the public API, so that they can just use `io-classes` constraints in their library instead of propagating `IOLike` everywhere.