### PR TITLE
Small improvements related to table unions

### DIFF
--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -486,7 +486,8 @@ benchLookupsIO !hbio !arenaManager !resolve !wb !wbblobs !rs !bs !ics !hs =
       | n <= 0    = pure ()
       | otherwise = do
           let (!ks, !keyRng') = genLookupBatch keyRng benchmarkGenBatchSize
-          !_ <- lookupsIO hbio arenaManager resolve wb wbblobs rs bs ics hs ks
+          !_ <- lookupsIOWithWriteBuffer
+                  hbio arenaManager resolve wb wbblobs rs bs ics hs ks
           go keyRng' (n-benchmarkGenBatchSize)
 
 {-------------------------------------------------------------------------------

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -127,7 +127,7 @@ import           Database.LSMTree.Internal.Entry (Entry, NumEntries (..))
 import           Database.LSMTree.Internal.IncomingRun (IncomingRun (..))
 import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue,
                      TableCorruptedError (..), lookupsIO,
-                     lookupsIOWithoutWriteBuffer)
+                     lookupsIOWithWriteBuffer)
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun (TableTooLargeError (..))
 import qualified Database.LSMTree.Internal.MergingRun as MR
@@ -838,7 +838,7 @@ lookups resolve ks t = do
   where
     regularLevelLookups tEnv tableContent = do
         let !cache = tableCache tableContent
-        lookupsIO
+        lookupsIOWithWriteBuffer
           (tableHasBlockIO tEnv)
           (tableArenaManager t)
           resolve
@@ -851,7 +851,7 @@ lookups resolve ks t = do
           ks
 
     treeBatchLookups tEnv runs =
-        lookupsIOWithoutWriteBuffer
+        lookupsIO
           (tableHasBlockIO tEnv)
           (tableArenaManager t)
           resolve

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -761,8 +761,8 @@ atomicSpendCredits (CreditsVar var) spend =
 
 {-# SPECIALISE remainingMergeDebt ::
      Ref (MergingRun t IO h) -> IO (MergeDebt, NumEntries) #-}
--- | Calculate an upper bound on the merge credits required to complete the
--- merge, as well as an upper bound on the size of the resulting run.
+-- | Calculate the merge credits required to complete the merge, as well as an
+-- upper bound on the size of the resulting run.
 remainingMergeDebt ::
      (MonadMVar m, PrimMonad m)
   => Ref (MergingRun t m h) -> m (MergeDebt, NumEntries)

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -258,6 +258,10 @@ unsafeNew mergeDebt (SpentCredits spentCredits)
 
 -- | Create references to the runs that should be queried for lookups.
 -- In particular, if the merge is not complete, these are the input runs.
+--
+-- TODO: This interface doesn't work well with the action registry. Just doing
+-- @withRollback reg (duplicateRuns mr) (mapM_ releaseRef)@ isn't exception-safe
+-- since if one of the @releaseRef@ calls fails, the following ones aren't run.
 {-# SPECIALISE duplicateRuns ::
      Ref (MergingRun t IO h) -> IO (V.Vector (Ref (Run IO h))) #-}
 duplicateRuns ::

--- a/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
+++ b/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
@@ -81,9 +81,6 @@ mergeLookupAcc resolve mt accs =
 --
 -- This function duplicates the references to all the tree's runs.
 -- These references later need to be released using 'releaseLookupTree'.
---
--- This function should be run with asynchronous exceptions masked to prevent
--- failing after internal resources have already been created.
 {-# SPECIALISE buildLookupTree ::
      ActionRegistry IO
   -> Ref (MT.MergingTree IO h)

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -319,7 +319,7 @@ prop_roundtripFromWriteBufferLookupIO (SmallList dats) =
     arenaManager <- newArenaManager
     realres <-
       fetchBlobs hfs =<< -- retrieve blobs to match type of model result
-      lookupsIO
+      lookupsIOWithWriteBuffer
         hbio
         arenaManager
         resolveV
@@ -339,8 +339,9 @@ prop_roundtripFromWriteBufferLookupIO (SmallList dats) =
     fetchBlobs hfs = traverse (traverse (traverse (readWeakBlobRef hfs)))
 
 -- | Given a bunch of 'InMemLookupData', prepare the data into the form needed
--- for 'lookupsIO': a write buffer (and blobs) and a vector of on-disk runs.
--- Also passes the model and the keys to look up to the inner action.
+-- for 'lookupsIOWithWriteBuffer': a write buffer (and blobs) and a vector of
+-- on-disk runs. Also passes the model and the keys to look up to the inner
+-- action.
 --
 withWbAndRuns :: FS.HasFS IO h
          -> FS.HasBlockIO IO h


### PR DESCRIPTION
# Description

Follow-ups to feedback in #609 and #633.

The test output for `prop_supplyCredits` now is:

```
  Test.Database.LSMTree.Internal.MergingTree
    prop_supplyCredits: OK (10.59s)
      +++ OK, passed 100 tests:
      73% completed
      10% trivial
      
      supplied credits (853 in total):
      82.8% 10 <= n < 100
      17.2% 1 <= n < 10
```

