### PR TITLE
fix: restructure TableNotCompatibleError to TableUnionNotCompatibleError

### DIFF
--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -16,7 +16,7 @@ module Database.LSMTree (
   , Common.TableClosedError (..)
   , Common.TableCorruptedError (..)
   , Common.TableTooLargeError (..)
-  , Common.TableNotCompatibleError (..)
+  , Common.TableUnionNotCompatibleError (..)
   , Common.SnapshotExistsError (..)
   , Common.SnapshotDoesNotExistError (..)
   , Common.SnapshotCorruptedError (..)
@@ -129,7 +129,8 @@ import           Data.Bifunctor (Bifunctor (..))
 import           Data.Coerce (coerce)
 import           Data.Kind (Type)
 import           Data.List.NonEmpty (NonEmpty (..))
-import           Data.Typeable (Proxy (..), Typeable, eqT, type (:~:) (Refl))
+import           Data.Typeable (Proxy (..), Typeable, eqT, type (:~:) (Refl),
+                     typeRep)
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (BlobRef (BlobRef), IOLike, Range (..),
                      SerialiseKey, SerialiseValue, Session, UnionCredits (..),
@@ -570,7 +571,7 @@ unions (t :| ts) =
       -> m (Internal.Table m h)
     checkTableType _ i (Internal.Table' (t' :: Internal.Table m h'))
       | Just Refl <- eqT @h @h' = pure t'
-      | otherwise = throwIO (Common.ErrTableTypeMismatch 0 i)
+      | otherwise = throwIO $ Common.ErrTableUnionHandleTypeMismatch 0 (typeRep $ Proxy @h) i (typeRep $ Proxy @h')
 
 {-# SPECIALISE remainingUnionDebt :: Table IO k v b -> IO UnionDebt #-}
 remainingUnionDebt :: IOLike m => Table m k v b -> m UnionDebt

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -9,7 +9,7 @@ module Database.LSMTree.Common (
   , Internal.TableClosedError (..)
   , Internal.TableCorruptedError (..)
   , Internal.TableTooLargeError (..)
-  , Internal.TableNotCompatibleError (..)
+  , Internal.TableUnionNotCompatibleError (..)
   , Internal.SnapshotExistsError (..)
   , Internal.SnapshotDoesNotExistError (..)
   , Internal.SnapshotCorruptedError (..)

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -31,7 +31,7 @@ module Database.LSMTree.Monoidal (
   , Common.TableClosedError (..)
   , Common.TableCorruptedError (..)
   , Common.TableTooLargeError (..)
-  , Common.TableNotCompatibleError (..)
+  , Common.TableUnionNotCompatibleError (..)
   , Common.SnapshotExistsError (..)
   , Common.SnapshotDoesNotExistError (..)
   , Common.SnapshotCorruptedError (..)
@@ -149,8 +149,8 @@ import           Data.Coerce (coerce)
 import           Data.Kind (Type)
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Monoid (Sum (..))
-import           Data.Proxy (Proxy (Proxy))
-import           Data.Typeable (Typeable, eqT, type (:~:) (Refl))
+import           Data.Typeable (Proxy (..), Typeable, eqT, type (:~:) (Refl),
+                     typeRep)
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (IOLike, Range (..), SerialiseKey,
                      SerialiseValue (..), Session, UnionCredits (..),
@@ -719,7 +719,7 @@ unions (t :| ts) =
       -> m (Internal.Table m h)
     checkTableType _ i (Internal.MonoidalTable (t' :: Internal.Table m h'))
       | Just Refl <- eqT @h @h' = pure t'
-      | otherwise = throwIO (Common.ErrTableTypeMismatch 0 i)
+      | otherwise = throwIO $ Common.ErrTableUnionHandleTypeMismatch 0 (typeRep $ Proxy @h) i (typeRep $ Proxy @h')
 
 {-# SPECIALISE remainingUnionDebt :: Table IO k v -> IO UnionDebt #-}
 -- | Return the current union debt. This debt can be reduced until it is paid

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -30,7 +30,7 @@ module Database.LSMTree.Normal (
   , Common.TableClosedError (..)
   , Common.TableCorruptedError (..)
   , Common.TableTooLargeError (..)
-  , Common.TableNotCompatibleError (..)
+  , Common.TableUnionNotCompatibleError (..)
   , Common.SnapshotExistsError (..)
   , Common.SnapshotDoesNotExistError (..)
   , Common.SnapshotCorruptedError (..)
@@ -140,7 +140,8 @@ import           Control.Monad.Class.MonadThrow
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Kind (Type)
 import           Data.List.NonEmpty (NonEmpty (..))
-import           Data.Typeable (Typeable, eqT, type (:~:) (Refl))
+import           Data.Typeable (Proxy (..), Typeable, eqT, type (:~:) (Refl),
+                     typeRep)
 import qualified Data.Vector as V
 import           Database.LSMTree.Common (BlobRef (BlobRef), IOLike, Range (..),
                      SerialiseKey, SerialiseValue, Session, UnionCredits (..),
@@ -839,7 +840,7 @@ unions (t :| ts) =
       -> m (Internal.Table m h)
     checkTableType _ i (Internal.NormalTable (t' :: Internal.Table m h'))
       | Just Refl <- eqT @h @h' = pure t'
-      | otherwise = throwIO (Common.ErrTableTypeMismatch 0 i)
+      | otherwise = throwIO $ Common.ErrTableUnionHandleTypeMismatch 0 (typeRep $ Proxy @h) i (typeRep $ Proxy @h')
 
 {-# SPECIALISE remainingUnionDebt :: Table IO k v b -> IO UnionDebt #-}
 -- | Return the current union debt. This debt can be reduced until it is paid

--- a/test/Database/LSMTree/Model/Session.hs
+++ b/test/Database/LSMTree/Model/Session.hs
@@ -267,8 +267,8 @@ data Err
   | ErrSessionClosed
   | ErrTableClosed
   | ErrTableCorrupted
-  | ErrTableTypeMismatch
-  | ErrTableSessionMismatch
+  | ErrTableUnionHandleTypeMismatch
+  | ErrTableUnionSessionMismatch
   | ErrSnapshotExists !SnapshotName
   | ErrSnapshotDoesNotExist !SnapshotName
   | ErrSnapshotCorrupted !SnapshotName

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -94,7 +94,8 @@ import           Database.LSMTree.Common (BlobRefInvalidError (..),
                      SessionDirLockedError (..), SnapshotCorruptedError (..),
                      SnapshotDoesNotExistError (..), SnapshotExistsError (..),
                      SnapshotNotCompatibleError (..), TableClosedError (..),
-                     TableCorruptedError (..), TableNotCompatibleError (..))
+                     TableCorruptedError (..),
+                     TableUnionNotCompatibleError (..))
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact)
 import           Database.LSMTree.Extras.NoThunks (propNoThunks)
@@ -483,7 +484,7 @@ handleSomeException e =
     , handleSessionClosedError <$> fromException e
     , handleTableClosedError <$> fromException e
     , handleTableCorruptedError <$> fromException e
-    , handleTableNotCompatibleError <$> fromException e
+    , handleTableUnionNotCompatibleError <$> fromException e
     , handleSnapshotExistsError <$> fromException e
     , handleSnapshotDoesNotExistError <$> fromException e
     , handleSnapshotCorruptedError <$> fromException e
@@ -528,12 +529,12 @@ handleTableClosedError = \case
 
 handleTableCorruptedError :: TableCorruptedError -> Model.Err
 handleTableCorruptedError = \case
-  ErrLookupByteCountDiscrepancy _ _ -> Model.ErrTableCorrupted
+  ErrLookupByteCountDiscrepancy{} -> Model.ErrTableCorrupted
 
-handleTableNotCompatibleError :: TableNotCompatibleError -> Model.Err
-handleTableNotCompatibleError = \case
-  ErrTableTypeMismatch _ _ -> Model.ErrTableTypeMismatch
-  ErrTableSessionMismatch _ _ -> Model.ErrTableSessionMismatch
+handleTableUnionNotCompatibleError :: TableUnionNotCompatibleError -> Model.Err
+handleTableUnionNotCompatibleError = \case
+  ErrTableUnionHandleTypeMismatch{} -> Model.ErrTableUnionHandleTypeMismatch
+  ErrTableUnionSessionMismatch{} -> Model.ErrTableUnionSessionMismatch
 
 handleSnapshotExistsError :: SnapshotExistsError -> Model.Err
 handleSnapshotExistsError = \case


### PR DESCRIPTION
This PR renames the `TableNotCompatbleError` to `TableUnionNotCompatibleError` and adds more information.