### PR TITLE
Use `hlint` on every Haskell file

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -27,6 +27,15 @@
 - ignore: {name: "Use shows"}
 - ignore: {name: "Use fmap"}
 - ignore: {name: "Use <=<"}
+- ignore: {name: "Use void"}
+- ignore: {name: "Use zipWith"}
+- ignore: {name: "Evaluate"}
+- ignore: {name: "Redundant if"}
+- ignore: {name: "Use catMaybes"}
+- ignore: {name: "Replace case with maybe"}
+- ignore: {name: "Redundant =="}
+- ignore: {name: "Hoist not"}
+- ignore: {name: "Use /="}
 
 # Specify additional command line arguments
 #

--- a/bench/micro/Bench/Database/LSMTree/Internal/BloomFilter.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/BloomFilter.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications   #-}
-{- HLINT ignore "Use camelCase" -}
-{- HLINT ignore "Eta reduce" -}
+
 
 module Bench.Database.LSMTree.Internal.BloomFilter (
     benchmarks

--- a/bench/micro/Bench/Database/LSMTree/Internal/Index/Compact.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Index/Compact.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications   #-}
-{- HLINT ignore "Eta reduce" -}
 
 module Bench.Database.LSMTree.Internal.Index.Compact (
     benchmarks

--- a/blockio-api/test/Main.hs
+++ b/blockio-api/test/Main.hs
@@ -3,8 +3,6 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-{- HLINT ignore "Use camelCase" -}
-
 module Main (main) where
 
 import           Control.Concurrent (modifyMVar_, newMVar, threadDelay,

--- a/bloomfilter/examples/Words.hs
+++ b/bloomfilter/examples/Words.hs
@@ -29,7 +29,7 @@ main = do
   forM_ files $ \file -> do
     a <- getCurrentTime
     words <- B.lines `fmap` B.readFile file
-    putStrLn $ {-# SCC "words/length" #-} show (length words) ++ " words"
+    putStrLn $ {-# SCC "words/length" #-} (show (length words) ++ " words")
     b <- getCurrentTime
     putStrLn $ show (diffUTCTime b a) ++ "s to count words"
     let filt = {-# SCC "construct" #-} testFunction 0.01 words

--- a/bloomfilter/src/Data/BloomFilter/BitVec64.hs
+++ b/bloomfilter/src/Data/BloomFilter/BitVec64.hs
@@ -20,31 +20,27 @@ import           Control.Monad.ST (ST)
 import           Data.Bits
 import           Data.Primitive.ByteArray (ByteArray (ByteArray),
                      newPinnedByteArray, setByteArray)
-import qualified Data.Vector.Primitive as P
-import qualified Data.Vector.Primitive.Mutable as MP
+import qualified Data.Vector.Primitive as VP
+import qualified Data.Vector.Primitive.Mutable as VPM
 import           Data.Word (Word64, Word8)
 
 import           GHC.Exts (Int (I#), prefetchByteArray0#, uncheckedIShiftRL#,
                      (+#))
+import qualified GHC.Exts
 import           GHC.ST (ST (ST))
 import           GHC.Word (Word64 (W64#))
 
-#if MIN_VERSION_base(4,17,0)
-import           GHC.Exts (remWord64#)
-#else
-import           GHC.Exts (remWord#)
-#endif
 
 -- | Bit vector backed up by an array of Word64
 --
 -- This vector's offset and length are multiples of 64
-newtype BitVec64 = BV64 (P.Vector Word64)
+newtype BitVec64 = BV64 (VP.Vector Word64)
   deriving (Eq, Show)
 
 {-# INLINE unsafeIndex #-}
 unsafeIndex :: BitVec64 -> Int -> Bool
 unsafeIndex (BV64 bv) i =
-    unsafeTestBit (P.unsafeIndex bv j) k
+    unsafeTestBit (VP.unsafeIndex bv j) k
   where
     !j = unsafeShiftR i 6 -- `div` 64, bit index to Word64 index.
     !k = i .&. 63         -- `mod` 64, bit within Word64
@@ -56,14 +52,14 @@ unsafeTestBit w k = w .&. (1 `unsafeShiftL` k) /= 0
 
 {-# INLINE prefetchIndex #-}
 prefetchIndex :: BitVec64 -> Int -> ST s ()
-prefetchIndex (BV64 (P.Vector (I# off#) _ (ByteArray ba#))) (I# i#) =
+prefetchIndex (BV64 (VP.Vector (I# off#) _ (ByteArray ba#))) (I# i#) =
     ST (\s -> case prefetchByteArray0# ba# (off# +# uncheckedIShiftRL# i# 3#) s of
                 s' -> (# s', () #))
     -- We only need to shiftR 3 here, not 6, because we're going from a bit
     -- offset to a byte offset for prefetch. Whereas in unsafeIndex, we go from
     -- a bit offset to a Word64 offset, so an extra shiftR 3, for 6 total.
 
-newtype MBitVec64 s = MBV64 (P.MVector s Word64)
+newtype MBitVec64 s = MBV64 (VP.MVector s Word64)
 
 -- | Will create an explicitly pinned byte array if it is larger than 1 kB.
 -- This is done because pinned byte arrays allow for more efficient
@@ -77,36 +73,36 @@ new s
   | numWords >= 128 = do
     mba <- newPinnedByteArray numBytes
     setByteArray mba 0 numBytes (0 :: Word8)
-    return (MBV64 (P.MVector 0 numWords mba))
+    return (MBV64 (VP.MVector 0 numWords mba))
   | otherwise =
-    MBV64 <$> MP.new numWords
+    MBV64 <$> VPM.new numWords
   where
     !numWords = w2i (roundUpTo64 s)
     !numBytes = unsafeShiftL numWords 3 -- * 8
 
 unsafeWrite :: MBitVec64 s -> Word64 -> Bool -> ST s ()
 unsafeWrite (MBV64 mbv) i x = do
-    MP.unsafeModify mbv (\w -> if x then setBit w (w2i k) else clearBit w (w2i k)) (w2i j)
+    VPM.unsafeModify mbv (\w -> if x then setBit w (w2i k) else clearBit w (w2i k)) (w2i j)
   where
     !j = unsafeShiftR i 6 -- `div` 64
     !k = i .&. 63         -- `mod` 64
 
 unsafeRead :: MBitVec64 s -> Word64 -> ST s Bool
 unsafeRead (MBV64 mbv) i = do
-    !w <- MP.unsafeRead mbv (w2i j)
+    !w <- VPM.unsafeRead mbv (w2i j)
     return $! testBit w (w2i k)
   where
     !j = unsafeShiftR i 6 -- `div` 64
     !k = i .&. 63         -- `mod` 64
 
 freeze :: MBitVec64 s -> ST s BitVec64
-freeze (MBV64 mbv) = BV64 <$> P.freeze mbv
+freeze (MBV64 mbv) = BV64 <$> VP.freeze mbv
 
 unsafeFreeze :: MBitVec64 s -> ST s BitVec64
-unsafeFreeze (MBV64 mbv) = BV64 <$> P.unsafeFreeze mbv
+unsafeFreeze (MBV64 mbv) = BV64 <$> VP.unsafeFreeze mbv
 
 thaw :: BitVec64 -> ST s (MBitVec64 s)
-thaw (BV64 bv) = MBV64 <$> P.thaw bv
+thaw (BV64 bv) = MBV64 <$> VP.thaw bv
 
 -- this may overflow, but so be it (1^64 bits is a lot)
 roundUpTo64 :: Word64 -> Word64
@@ -115,9 +111,9 @@ roundUpTo64 i = unsafeShiftR (i + 63) 6
 -- | Like 'rem' but does not check for division by 0.
 unsafeRemWord64 :: Word64 -> Word64 -> Word64
 #if MIN_VERSION_base(4,17,0)
-unsafeRemWord64 (W64# x#) (W64# y#) = W64# (x# `remWord64#` y#)
+unsafeRemWord64 (W64# x#) (W64# y#) = W64# (x# `GHC.Exts.remWord64#` y#)
 #else
-unsafeRemWord64 (W64# x#) (W64# y#) = W64# (x# `remWord#` y#)
+unsafeRemWord64 (W64# x#) (W64# y#) = W64# (x# `GHC.Exts.remWord#` y#)
 #endif
 
 w2i :: Word64 -> Int

--- a/bloomfilter/src/Data/BloomFilter/Internal.hs
+++ b/bloomfilter/src/Data/BloomFilter/Internal.hs
@@ -10,7 +10,7 @@ import           Data.Bits
 import qualified Data.BloomFilter.BitVec64 as V
 import           Data.Kind (Type)
 import           Data.Primitive.ByteArray (sizeofByteArray)
-import qualified Data.Vector.Primitive as P
+import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word64)
 
 type Bloom' :: (Type -> Type) -> Type -> Type
@@ -22,7 +22,7 @@ data Bloom' h a = Bloom {
 type role Bloom' nominal nominal
 
 bloomInvariant :: Bloom' h a -> Bool
-bloomInvariant (Bloom _ s (V.BV64 (P.Vector off len ba))) =
+bloomInvariant (Bloom _ s (V.BV64 (VP.Vector off len ba))) =
        s > 0
     && s <= 2^(48 :: Int)
     && off >= 0
@@ -38,7 +38,7 @@ instance Eq (Bloom' h a) where
     Bloom k n (V.BV64 v) == Bloom k' n' (V.BV64 v') =
         k == k' &&
         n == n' &&
-        P.take w v == P.take w v' && -- compare full words
+        VP.take w v == VP.take w v' && -- compare full words
         if l == 0 then True else unsafeShiftL x s == unsafeShiftL x' s -- compare last words
       where
         !w = fromIntegral (unsafeShiftR n 6) :: Int  -- n `div` 64
@@ -46,8 +46,8 @@ instance Eq (Bloom' h a) where
         !s = 64 - l
 
         -- last words
-        x = P.unsafeIndex v w
-        x' = P.unsafeIndex v' w
+        x = VP.unsafeIndex v w
+        x' = VP.unsafeIndex v' w
 
 instance Show (Bloom' h a) where
     show mb = "Bloom { " ++ show (size mb) ++ " bits } "

--- a/bloomfilter/tests/bloomfilter-tests.hs
+++ b/bloomfilter/tests/bloomfilter-tests.hs
@@ -10,7 +10,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Int (Int16, Int32, Int64, Int8)
-import qualified Data.Vector.Primitive as P
+import qualified Data.Vector.Primitive as VP
 import           Data.Word (Word32, Word64)
 import           System.IO (BufferMode (..), hSetBuffering, stdout)
 import           Test.Tasty
@@ -42,12 +42,12 @@ tests = testGroup "bloomfilter"
         ]
     , testGroup "equality"
         [ testProperty "doesn't care about leftover bits a" $
-          BI.Bloom 1 48 (BV64.BV64 (P.singleton 0xffff_0000_1234_5678)) ===
-          BI.Bloom 1 48 (BV64.BV64 (P.singleton 0xeeee_0000_1234_5678))
+          BI.Bloom 1 48 (BV64.BV64 (VP.singleton 0xffff_0000_1234_5678)) ===
+          BI.Bloom 1 48 (BV64.BV64 (VP.singleton 0xeeee_0000_1234_5678))
 
         , testProperty "doesn't care about leftover bits b" $
-          BI.Bloom 1 49 (BV64.BV64 (P.singleton 0xffff_0000_1234_5678)) =/=
-          BI.Bloom 1 49 (BV64.BV64 (P.singleton 0xeeee_0000_1234_5678))
+          BI.Bloom 1 49 (BV64.BV64 (VP.singleton 0xffff_0000_1234_5678)) =/=
+          BI.Bloom 1 49 (BV64.BV64 (VP.singleton 0xeeee_0000_1234_5678))
         ]
     ]
 

--- a/scripts/lint-hlint.sh
+++ b/scripts/lint-hlint.sh
@@ -20,4 +20,4 @@ fi
 # Lint Haskell files with HLint
 echo "Linting Haskell files with HLint..."
 # shellcheck disable=SC2086
-git ls-files --exclude-standard --no-deleted --deduplicate 'src/**/*.hs' 'test/**/*.hs' 'src-extras/**/*.hs' 'src-fcntl-nocache/**/*.hs' 'src-kmerge/**/*.hs' 'src-mcg/**/*.hs' 'src-rocksdb/**/*.hs' | xargs -L50 ${hlint}
+git ls-files --exclude-standard --no-deleted --deduplicate '*.hs' | xargs -L50 ${hlint}

--- a/src-extras/Database/LSMTree/Extras/Generators.hs
+++ b/src-extras/Database/LSMTree/Extras/Generators.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-{- HLINT ignore "Use camelCase" -}
 
 module Database.LSMTree.Extras.Generators (
     -- * WithSerialised

--- a/src-extras/Database/LSMTree/Extras/MergingTreeData.hs
+++ b/src-extras/Database/LSMTree/Extras/MergingTreeData.hs
@@ -374,7 +374,6 @@ shrinkMergingTreeData shrinkKey shrinkVal shrinkBlob = \case
     | mr' <- shrinkMergingRunData shrinkKey shrinkVal shrinkBlob mr
     ]
   PendingLevelMergeData prs t ->
-    {- HLINT ignore "Use catMaybes" -}
     -- just use the child tree, if present
     [ t' | Just t' <- [t] ]
     <>

--- a/src-extras/Database/LSMTree/Extras/RunData.hs
+++ b/src-extras/Database/LSMTree/Extras/RunData.hs
@@ -261,7 +261,6 @@ type SerialisedNonEmptyRunData =
   QuickCheck
 -------------------------------------------------------------------------------}
 
-{- HLINT ignore "Hoist not" -}
 labelRunData :: SerialisedRunData -> Property -> Property
 labelRunData (RunData m) =
       tabulate "value size" valSizes

--- a/src-extras/Database/LSMTree/Extras/UTxO.hs
+++ b/src-extras/Database/LSMTree/Extras/UTxO.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE TypeFamilies               #-}
-{- HLINT ignore "Redundant <$>" -}
 
 module Database.LSMTree.Extras.UTxO (
     UTxOKey (..)

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_HADDOCK not-home #-}
-{- HLINT ignore "Use unless" -}
 
 module Database.LSMTree.Internal.BlobRef (
     BlobSpan (..)

--- a/src/Database/LSMTree/Internal/RawBytes.hs
+++ b/src/Database/LSMTree/Internal/RawBytes.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE TypeFamilies       #-}
 {-# LANGUAGE UnboxedTuples      #-}
 {-# OPTIONS_HADDOCK not-home #-}
-{- HLINT ignore "Redundant lambda" -}
 
 #ifndef __HLINT__
 -- HLint would fail to find this file and emit a warning

--- a/src/Database/LSMTree/Internal/RunAcc.hs
+++ b/src/Database/LSMTree/Internal/RunAcc.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_HADDOCK not-home #-}
-{- HLINT ignore "Redundant lambda" -}
-{- HLINT ignore "Use camelCase" -}
 
 -- | Incremental (in-memory portion of) run consruction
 --

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-partial-fields #-}
 {-# OPTIONS_HADDOCK not-home #-}
-{- HLINT ignore "Use record patterns" -}
 
 -- | An on-disk store for blobs for the write buffer.
 --

--- a/test/Test/Database/LSMTree/Internal/CRC32C.hs
+++ b/test/Test/Database/LSMTree/Internal/CRC32C.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-{- HLINT ignore "Use camelCase" -}
 
 module Test.Database.LSMTree.Internal.CRC32C (
     -- * Main test tree

--- a/test/Test/Database/LSMTree/Internal/Index/Compact.hs
+++ b/test/Test/Database/LSMTree/Internal/Index/Compact.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-{- HLINT ignore "Eta reduce" -}
 
 module Test.Database.LSMTree.Internal.Index.Compact (tests) where
 

--- a/test/Test/Database/LSMTree/Internal/RawBytes.hs
+++ b/test/Test/Database/LSMTree/Internal/RawBytes.hs
@@ -1,11 +1,8 @@
-{- HLINT ignore "Avoid restricted alias" -}
-{- HLINT ignore "Use /=" -}
-
 module Test.Database.LSMTree.Internal.RawBytes (tests) where
 
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.Internal.RawBytes (RawBytes)
-import qualified Database.LSMTree.Internal.RawBytes as RawBytes (size)
+import qualified Database.LSMTree.Internal.RawBytes as RB (size)
 import           Test.QuickCheck (Property, classify, collect, mapSize,
                      withDiscardRatio, withMaxSuccess, (.||.), (===), (==>))
 import           Test.Tasty (TestTree, testGroup)
@@ -41,7 +38,7 @@ twoBlocksProp msgAddition block1 block2
 
 withFirstBlockSizeInfo :: RawBytes -> Property -> Property
 withFirstBlockSizeInfo firstBlock
-    = collect ("Size of first block is " ++ show (RawBytes.size firstBlock))
+    = collect ("Size of first block is " ++ show (RB.size firstBlock))
 
 -- * Properties to test
 

--- a/test/Test/Database/LSMTree/UnitTests.hs
+++ b/test/Test/Database/LSMTree/UnitTests.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-{- HLINT ignore "Use void" -}
-
 module Test.Database.LSMTree.UnitTests (tests) where
 
 import           Control.Tracer (nullTracer)

--- a/test/Test/Util/FS.hs
+++ b/test/Test/Util/FS.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-{- HLINT ignore "Redundant if" -}
 
 module Test.Util.FS (
     -- * Real file system


### PR DESCRIPTION
Also, clean up HLINT pragmas by replacing them with `ignore` entries in the `.hlint.yaml`.
