### PR TITLE
Cache lookup tree for the union level

### DIFF
--- a/src-extras/Database/LSMTree/Extras/NoThunks.hs
+++ b/src-extras/Database/LSMTree/Extras/NoThunks.hs
@@ -52,6 +52,7 @@ import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun
 import           Database.LSMTree.Internal.MergingTree
+import           Database.LSMTree.Internal.MergingTree.Lookup (LookupTree (..))
 import           Database.LSMTree.Internal.Page
 import           Database.LSMTree.Internal.PageAcc
 import           Database.LSMTree.Internal.Paths
@@ -338,6 +339,11 @@ deriving anyclass instance
   , NoThunks (StrictMVar m (MergingTreeState m h))
   ) => NoThunks (UnionLevel m h)
 
+deriving stock instance Generic (UnionCache m h)
+deriving anyclass instance
+  ( Typeable m, Typeable (PrimState m), Typeable h
+  ) => NoThunks (UnionCache m h)
+
 deriving stock instance Generic MergePolicyForLevel
 deriving anyclass instance NoThunks MergePolicyForLevel
 
@@ -403,6 +409,9 @@ deriving anyclass instance
   ( Typeable m, Typeable (PrimState m), Typeable h
   , NoThunks (StrictMVar m (MergingRunState LevelMergeType m h))
   ) => NoThunks (PreExistingRun m h)
+
+deriving stock instance Generic (LookupTree a)
+deriving anyclass instance NoThunks a => NoThunks (LookupTree a)
 
 {-------------------------------------------------------------------------------
   Entry

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -74,6 +74,7 @@ import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import qualified Database.LSMTree.Internal.Vector as V
 import           GHC.Stack (HasCallStack, callStack)
 import           System.FS.API (HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)
@@ -275,7 +276,7 @@ duplicateRuns (DeRef mr) =
     withMVar (mergeState mr) $ \case
       CompletedMerge r  -> V.singleton <$> dupRef r
       OngoingMerge rs _ -> withActionRegistry $ \reg ->
-        V.mapM (\r -> withRollback reg (dupRef r) releaseRef) rs
+        V.mapMStrict (\r -> withRollback reg (dupRef r) releaseRef) rs
 
 -- | Take a snapshot of the state of a merging run.
 --

--- a/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
+++ b/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
@@ -1,20 +1,20 @@
 module Database.LSMTree.Internal.MergingTree.Lookup (
     LookupTree (..)
+  , mapMStrict
   , mkLookupNode
   , buildLookupTree
-  , releaseLookupTree
   , foldLookupTree
   ) where
 
 import           Control.ActionRegistry
 import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.Exception (assert)
+import           Control.Monad
 import           Control.Monad.Class.MonadAsync (Async, MonadAsync)
 import qualified Control.Monad.Class.MonadAsync as Async
 import           Control.Monad.Class.MonadThrow (MonadMask)
 import           Control.Monad.Primitive
 import           Control.RefCount
-import           Data.Foldable (traverse_)
 import qualified Data.Vector as V
 import qualified Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.Lookup (LookupAcc,
@@ -22,13 +22,21 @@ import           Database.LSMTree.Internal.Lookup (LookupAcc,
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import qualified Database.LSMTree.Internal.MergingTree as MT
 import           Database.LSMTree.Internal.Run (Run)
+import qualified Database.LSMTree.Internal.Vector as V
 
 -- | A simplified representation of the shape of a 'MT.MergingTree'.
 data LookupTree a =
     LookupBatch !a
     -- | Use 'mkLookupNode' to construct this.
-  | LookupNode !MR.TreeMergeType !(V.Vector (LookupTree a))  -- ^ length 2 or more
-  deriving stock (Foldable, Functor, Traversable)
+  | LookupNode !MR.TreeMergeType !(V.Vector (LookupTree a)) -- ^ length 2 or more
+  deriving stock (Foldable)
+
+-- | Deriving 'Traversable' leads to functions that are not strict in the
+-- elements of the vector of children. This function avoids that issue.
+mapMStrict :: Monad m => (a -> m b) -> LookupTree a -> m (LookupTree b)
+mapMStrict f = \case
+  LookupBatch a  -> LookupBatch <$!> f a
+  LookupNode t v -> LookupNode t <$!> V.mapMStrict (mapMStrict f) v
 
 -- | Asserts that the vector is non-empty. Collapses singleton nodes.
 mkLookupNode :: MR.TreeMergeType -> V.Vector (LookupTree a) -> LookupTree a
@@ -79,8 +87,8 @@ mergeLookupAcc resolve mt accs =
 --
 -- Assumes that the merging tree is not 'MT.isStructurallyEmpty'.
 --
--- This function duplicates the references to all the tree's runs.
--- These references later need to be released using 'releaseLookupTree'.
+-- This function duplicates the references to all the tree's runs. These
+-- references later need to be released.
 {-# SPECIALISE buildLookupTree ::
      ActionRegistry IO
   -> Ref (MT.MergingTree IO h)
@@ -95,40 +103,33 @@ buildLookupTree reg (DeRef mt) =
     -- dropped before we duplicated the reference.
     withMVar (MT.mergeState mt) $ \case
       MT.CompletedTreeMerge r ->
-        LookupBatch . V.singleton <$> dupRun r
+        LookupBatch . V.singleton <$!> dupRun r
       MT.OngoingTreeMerge mr -> do
-        rs <- withRollback reg (MR.duplicateRuns mr) (V.mapM_ releaseRef)
+        !rs <- withRollback reg (MR.duplicateRuns mr) (V.mapM_ releaseRef)
         ty <- MR.mergeType mr
         return $ case ty of
           Nothing            -> LookupBatch rs  -- just one run
           Just MR.MergeLevel -> LookupBatch rs  -- combine runs
           Just MR.MergeUnion -> mkLookupNode MR.MergeUnion  -- separate
-                                  (LookupBatch . V.singleton <$> rs)
+                                  (LookupBatch . V.singleton <$!> rs)
       MT.PendingTreeMerge (MT.PendingLevelMerge prs Nothing) -> do
-        LookupBatch . V.concat . V.toList <$>  -- combine runs
-          traverse duplicatePreExistingRun prs
+        LookupBatch . V.concatMap id <$!>  -- combine runs
+          V.mapMStrict duplicatePreExistingRun prs
       MT.PendingTreeMerge (MT.PendingLevelMerge prs (Just tree)) -> do
-        child <- buildLookupTree reg tree
+        !child <- buildLookupTree reg tree
         if V.null prs
           then return child
           else do
             preExisting <- do
-              LookupBatch . V.concat . V.toList <$>  -- combine runs
-                traverse duplicatePreExistingRun prs
+              LookupBatch . V.concatMap id <$!>  -- combine runs
+                V.mapMStrict duplicatePreExistingRun prs
             return $ mkLookupNode MR.MergeLevel $ V.fromList [preExisting, child]
       MT.PendingTreeMerge (MT.PendingUnionMerge trees) ->
-        mkLookupNode MR.MergeUnion <$> traverse (buildLookupTree reg) trees
+        mkLookupNode MR.MergeUnion <$!> V.mapMStrict (buildLookupTree reg) trees
   where
     dupRun r = withRollback reg (dupRef r) releaseRef
 
     duplicatePreExistingRun (MT.PreExistingRun r) =
-        V.singleton <$> dupRun r
+        V.singleton <$!> dupRun r
     duplicatePreExistingRun (MT.PreExistingMergingRun mr) =
         withRollback reg (MR.duplicateRuns mr) (V.mapM_ releaseRef)
-
-{-# SPECIALISE releaseLookupTree ::
-     ActionRegistry IO -> LookupTree (V.Vector (Ref (Run IO h))) -> IO () #-}
-releaseLookupTree ::
-     (PrimMonad m, MonadMask m)
-  => ActionRegistry m -> LookupTree (V.Vector (Ref (Run m h))) -> m ()
-releaseLookupTree reg = traverse_ (traverse_ (delayedCommit reg . releaseRef))

--- a/test/Test/Database/LSMTree/Internal/MergingTree.hs
+++ b/test/Test/Database/LSMTree/Internal/MergingTree.hs
@@ -7,7 +7,7 @@ import           Control.Exception (bracket)
 import           Control.Monad.Class.MonadAsync as Async
 import           Control.RefCount
 import           Data.Coerce (coerce)
-import           Data.Foldable (toList)
+import           Data.Foldable (toList, traverse_)
 import           Data.List.NonEmpty (NonEmpty)
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -158,9 +158,9 @@ prop_lookupTree hfs hbio keys mtd = do
             return $ V.map (const Nothing) keys
           False -> do
             batches <- buildLookupTree reg tree
-            results <- traverse (performLookups mgr) batches
+            results <- mapMStrict (performLookups mgr) batches
             acc <- foldLookupTree resolveVal results
-            releaseLookupTree reg batches
+            traverse_ (traverse_ (delayedCommit reg . releaseRef)) batches
             return acc
 
     performLookups mgr runs =

--- a/test/Test/Database/LSMTree/UnitTests.hs
+++ b/test/Test/Database/LSMTree/UnitTests.hs
@@ -6,6 +6,7 @@ module Test.Database.LSMTree.UnitTests (tests) where
 import           Control.Tracer (nullTracer)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
+import           Data.Foldable (for_)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as Map
 import qualified Data.Vector as V
@@ -35,6 +36,7 @@ tests =
       , testCase      "unit_unions_1"       unit_unions_1
       , testCase      "unit_union_credits"  unit_union_credits
       , testCase      "unit_union_credit_0" unit_union_credit_0
+      , testCase      "unit_union_blobref_invalidation" unit_union_blobref_invalidation
       ]
 
 unit_blobs :: (String -> IO ()) -> Assertion
@@ -211,6 +213,40 @@ unit_union_credit_0 =
         -- And the table is still vaguely cromulent
         r <- lookups table' [Key1 17]
         V.map ignoreBlobRef r @?= [Found (Value1 42)]
+
+-- | Blob refs into a union don't get invalidated when updating the union's
+-- input tables.
+unit_union_blobref_invalidation :: Assertion
+unit_union_blobref_invalidation =
+    withTempIOHasBlockIO "test" $ \hfs hbio ->
+    withSession nullTracer hfs hbio (FS.mkFsPath []) $ \sess -> do
+      t1 <- new @_ @Key1 @Value1 @Blob1 sess config
+      for_ ([0..99] :: [Word64]) $ \i ->
+        inserts t1 [(Key1 i, Value1 i, Just (Blob1 i))]
+      t2 <- t1 `union` t1
+
+      -- do lookups on the union table (the result contains blob refs)
+      res <- lookups t2 (Key1 <$> [0..99])
+
+      -- progress original table (supplying merge credits would be most direct),
+      -- so merges complete
+      inserts t1 (fmap (\i -> (Key1 i, Value1 i, Nothing)) [1000..2000])
+      -- close it, so it doesn't hold open extra references
+      close t1
+
+      -- try to resolve the blob refs we obtained earlier
+      _blobs <- retrieveBlobs sess (V.mapMaybe getBlobRef res)
+      return ()
+  where
+    config = defaultTableConfig {
+        confWriteBufferAlloc = AllocNumEntries (NumEntries 4)
+      }
+
+getBlobRef :: LookupResult v b -> Maybe b
+getBlobRef = \case
+  NotFound          -> Nothing
+  Found _           -> Nothing
+  FoundWithBlob _ b -> Just b
 
 ignoreBlobRef :: Functor f => f (BlobRef m b) -> f ()
 ignoreBlobRef = fmap (const ())


### PR DESCRIPTION
This avoids having to rebuild it and most importantly keeps blob references from becoming invalidated.

