### PR TITLE
GHA: use `cabal-3.12`

### DIFF
--- a/.github/actions/setup-cabal-docspec/action.yaml
+++ b/.github/actions/setup-cabal-docspec/action.yaml
@@ -7,8 +7,8 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         mkdir -p "${{ github.workspace }}/.cabal-docspec/bin"
-        curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20240414/cabal-docspec-0.0.0.20240414-x86_64-linux.xz > "${{ runner.temp }}/cabal-docspec.xz"
-        echo '2d18a3f79619e8ec5f11870f926f6dc2616e02a6c889315b7f82044b95a1adb9  ${{ runner.temp }}/cabal-docspec.xz' | sha256sum -c -
+        curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20240703/cabal-docspec-0.0.0.20240703-x86_64-linux.xz > "${{ runner.temp }}/cabal-docspec.xz"
+        echo '48bf3b7fd2f7f0caa6162afee57a755be8523e7f467b694900eb420f5f9a7b76  ${{ runner.temp }}/cabal-docspec.xz' | sha256sum -c -
         xz -d < "${{ runner.temp }}/cabal-docspec.xz" > "${{ github.workspace }}/.cabal-docspec/bin/cabal-docspec"
         chmod a+x "${{ github.workspace }}/.cabal-docspec/bin/cabal-docspec"
       shell: sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ defaults:
 # Set the default GHC and Cabal versions.
 env:
   DEFAULT_GHC_VERSION: "9.6"
-  DEFAULT_CABAL_VERSION: "3.10"
+  DEFAULT_CABAL_VERSION: "3.12"
   DEFAULT_CABAL_PROJECT_FILE: "cabal.project.debug"
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
   ################################################################################
   build:
     name: |
-      ${{ matrix.name 
+      ${{ matrix.name
        || format(
             'Build on {0}{1}{2}',
             startsWith(matrix.os, 'ubuntu-') && 'Linux' || startsWith(matrix.os, 'macOS-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows',
@@ -159,13 +159,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
         ghc-version: ["8.10", "9.2", "9.4", "9.6", "9.8", "9.10", "9.12"]
-        cabal-version: ["3.10"]
+        cabal-version: ["3.12"]
         # The inclusion of these default keys in the matrix ensures that any
         # entry under include that assigns these keys creates a new matrix entry
         cabal-flags: [""]
         cabal-project-file: [""]
         cabal-documentation: [false]
-      
+
         exclude:
           # GHC 8.10 is not supported on macOS wit ARM CPU
           - ghc-version: "8.10"
@@ -188,7 +188,7 @@ jobs:
             cabal-skip-tests: true
             cabal-skip-benchmarks: true
             cabal-documentation: true
-  
+
   ################################################################################
   # Lint with actionlint
   ################################################################################
@@ -230,7 +230,7 @@ jobs:
 
     - name: 🎗️ Lint with cabal-fmt
       run: ./scripts/format-cabal-fmt.sh && git diff --exit-code
-  
+
   ################################################################################
   # Lint with cabal
   ################################################################################
@@ -298,7 +298,7 @@ jobs:
 
     - name: 🎗️ Lint with generate-readme
       run: git diff --exit-code
-  
+
   ################################################################################
   # Lint with HLint
   ################################################################################
@@ -317,7 +317,7 @@ jobs:
 
     - name: 🎗️ Lint with HLint
       run: ./scripts/lint-hlint.sh
-  
+
   ################################################################################
   # Publish documentation
   ################################################################################

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -77,7 +77,7 @@ description:
 
       [@AllocFixed bitsPerPhysicalEntry@]:
           The total size of all Bloom filters is the number of bits per physical entry multiplied by the number of physical entries.
-      [@AllocRequestFPR requestedFPR@]:      
+      [@AllocRequestFPR requestedFPR@]:
           TODO: How does one determine the bloom filter size using @AllocRequestFPR@?
 
   *   The worst-case size of the indexes is \(O(n)\).
@@ -148,6 +148,10 @@ common wno-x-partial
     ghc-options: -Wno-x-partial
 
 common language
+  -- This is at the top-level so that `cabal check` does not complain.
+  default-language:   Haskell2010
+
+  -- For newer GHC's, override Haskell2010 with GHC2021
   if impl(ghc >=9.2.1)
     default-language: GHC2021
 
@@ -337,7 +341,7 @@ library xxhash
   other-modules:   FFI
   hs-source-dirs:  xxhash/src
   build-depends:
-    , base
+    , base        <5
     , bytestring
     , primitive   ^>=0.9
 
@@ -347,7 +351,7 @@ test-suite xxhash-tests
   hs-source-dirs: xxhash/tests
   main-is:        xxhash-tests.hs
   build-depends:
-    , base
+    , base              <5
     , bytestring
     , lsm-tree:xxhash
     , primitive
@@ -389,7 +393,7 @@ test-suite bloomfilter-tests
   main-is:        bloomfilter-tests.hs
   other-modules:  QCSupport
   build-depends:
-    , base
+    , base                  <5
     , bytestring
     , lsm-tree:bloomfilter
     , QuickCheck
@@ -405,7 +409,7 @@ test-suite bloomfilter-primes
   hs-source-dirs: bloomfilter/tests
   main-is:        primes.hs
   build-depends:
-    , base
+    , base    <5
     , primes  ^>=0.2.1.0
 
 test-suite bloomfilter-spell
@@ -529,7 +533,7 @@ test-suite lsm-tree-test
   build-depends:
     , ansi-terminal
     , barbies
-    , base
+    , base                    <5
     , bitvec
     , bytestring
     , cborg
@@ -602,7 +606,7 @@ benchmark lsm-tree-micro-bench
     Bench.Database.LSMTree.Normal
 
   build-depends:
-    , base
+    , base                  <5
     , bytestring
     , containers
     , contra-tracer
@@ -628,7 +632,7 @@ benchmark lsm-tree-bench-bloomfilter
   hs-source-dirs: bench/macro
   main-is:        lsm-tree-bench-bloomfilter.hs
   build-depends:
-    , base
+    , base                  <5
     , lsm-tree
     , lsm-tree:bloomfilter
     , lsm-tree:extras
@@ -645,7 +649,7 @@ benchmark lsm-tree-bench-lookups
   hs-source-dirs: bench/macro
   main-is:        lsm-tree-bench-lookups.hs
   build-depends:
-    , base
+    , base                  <5
     , deepseq
     , fs-api
     , io-classes
@@ -667,7 +671,7 @@ library mcg
   hs-source-dirs:  src-mcg
   exposed-modules: MCG
   build-depends:
-    , base
+    , base    <5
     , primes
 
 flag measure-batch-latency
@@ -688,7 +692,7 @@ benchmark lsm-tree-bench-wp8
   main-is:        lsm-tree-bench-wp8.hs
   build-depends:
     , async
-    , base
+    , base                  <5
     , bytestring
     , clock
     , containers
@@ -723,7 +727,7 @@ benchmark rocksdb-bench-wp8
     buildable: False
 
   build-depends:
-    , base
+    , base                  <5
     , binary
     , bytestring
     , clock
@@ -750,7 +754,7 @@ library rocksdb
   -- Ubuntu 22.04 doesn't have pkgconfig files for rocksdb
   extra-libraries: rocksdb
   build-depends:
-    , base
+    , base                 <5
     , bytestring
     , indexed-traversable
 
@@ -762,7 +766,7 @@ library kmerge
     KMerge.LoserTree
 
   build-depends:
-    , base
+    , base                 <5
     , indexed-traversable
     , primitive
 
@@ -828,7 +832,7 @@ library prototypes
     ScheduledMergesTestQLS
 
   build-depends:
-    , base
+    , base                 <5
     , binary
     , bytestring
     , constraints
@@ -993,7 +997,7 @@ test-suite control-test
     Test.Control.RefCount
 
   build-depends:
-    , base
+    , base              <5
     , io-classes
     , io-sim
     , lsm-tree:control

--- a/scripts/test-cabal-docspec.sh
+++ b/scripts/test-cabal-docspec.sh
@@ -21,6 +21,7 @@ if [ "${SKIP_CABAL_BUILD}" = "" ]; then
 fi
 cabal-docspec \
     --extra-package directory \
+    --extra-package primitive \
     --extra-package lsm-tree:prototypes \
     -XOverloadedStrings \
     -XNumericUnderscores \


### PR DESCRIPTION
`cabal-3.10` has a bug in `cabal haddock-project`, which leads to bad hyperlinks in our published haddocks

Also: my editor automatically removed trailing whitespace in the workflow file