### PR TITLE
Consistently use type ResolveSerialisedValue, avoid mappend terminology

### DIFF
--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -36,8 +36,8 @@ import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..))
 import           Database.LSMTree.Internal.RunBuilder (RunParams (..))
 import qualified Database.LSMTree.Internal.RunBuilder as RunBuilder
 import           Database.LSMTree.Internal.RunNumber
-import           Database.LSMTree.Internal.Serialise (SerialisedKey,
-                     serialiseKey, serialiseValue)
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue,
+                     SerialisedKey, serialiseKey, serialiseValue)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import qualified Database.LSMTree.Internal.WriteBufferBlobs as WBB
 import           Debug.Trace (traceMarkerIO)

--- a/src-extras/Database/LSMTree/Extras/MergingRunData.hs
+++ b/src-extras/Database/LSMTree/Extras/MergingRunData.hs
@@ -23,7 +23,6 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.Extras.RunData
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.MergingRun (MergingRun)
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.Paths

--- a/src-extras/Database/LSMTree/Extras/MergingTreeData.hs
+++ b/src-extras/Database/LSMTree/Extras/MergingTreeData.hs
@@ -24,7 +24,6 @@ import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.Extras.MergingRunData
 import           Database.LSMTree.Extras.RunData
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.MergingTree (MergingTree)
 import qualified Database.LSMTree.Internal.MergingTree as MT

--- a/src-extras/Database/LSMTree/Extras/RunData.hs
+++ b/src-extras/Database/LSMTree/Extras/RunData.hs
@@ -48,7 +48,6 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Extras (showPowersOf10)
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.Internal.Entry
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.MergeSchedule (addWriteBufferEntries)
 import           Database.LSMTree.Internal.Paths
 import qualified Database.LSMTree.Internal.Paths as Paths

--- a/src/Database/LSMTree/Internal.hs
+++ b/src/Database/LSMTree/Internal.hs
@@ -118,9 +118,8 @@ import           Database.LSMTree.Internal.CRC32C (FileCorruptedError (..),
 import qualified Database.LSMTree.Internal.Cursor as Cursor
 import           Database.LSMTree.Internal.Entry (Entry, NumEntries (..))
 import           Database.LSMTree.Internal.IncomingRun (IncomingRun (..))
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue,
-                     TableCorruptedError (..), lookupsIO,
-                     lookupsIOWithWriteBuffer)
+import           Database.LSMTree.Internal.Lookup (TableCorruptedError (..),
+                     lookupsIO, lookupsIOWithWriteBuffer)
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun (TableTooLargeError (..))
 import qualified Database.LSMTree.Internal.MergingRun as MR
@@ -137,8 +136,8 @@ import qualified Database.LSMTree.Internal.Readers as Readers
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
 import           Database.LSMTree.Internal.RunNumber
-import           Database.LSMTree.Internal.Serialise (SerialisedBlob (..),
-                     SerialisedKey, SerialisedValue)
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue,
+                     SerialisedBlob (..), SerialisedKey, SerialisedValue)
 import           Database.LSMTree.Internal.Snapshot
 import           Database.LSMTree.Internal.Snapshot.Codec
 import           Database.LSMTree.Internal.UniqCounter

--- a/src/Database/LSMTree/Internal/Cursor.hs
+++ b/src/Database/LSMTree/Internal/Cursor.hs
@@ -14,11 +14,10 @@ import           Database.LSMTree.Internal.BlobRef (RawBlobRef,
 import qualified Database.LSMTree.Internal.BlobRef as BlobRef
 import           Database.LSMTree.Internal.Entry (Entry)
 import qualified Database.LSMTree.Internal.Entry as Entry
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import qualified Database.LSMTree.Internal.Readers as Readers
 import qualified Database.LSMTree.Internal.RunReader as Reader
-import           Database.LSMTree.Internal.Serialise (SerialisedKey,
-                     SerialisedValue)
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue,
+                     SerialisedKey, SerialisedValue)
 import qualified Database.LSMTree.Internal.Vector as V
 
 {-# INLINE readEntriesWhile #-}

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -2,8 +2,7 @@
 {-# OPTIONS_HADDOCK not-home #-}
 
 module Database.LSMTree.Internal.Lookup (
-    ResolveSerialisedValue
-  , LookupAcc
+    LookupAcc
   , lookupsIOWithWriteBuffer
   , lookupsIO
     -- * Errors
@@ -111,9 +110,6 @@ indexSearches !arena !indexes !kopsFiles !ks !rkixs = V.generateM n $ \i -> do
               (getNumPages size * 4096)
   where
     !n = VP.length rkixs
-
--- | Value resolve function: what to do when resolving two @Mupdate@s
-type ResolveSerialisedValue = SerialisedValue -> SerialisedValue -> SerialisedValue
 
 type LookupAcc m h = V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m h)))
 

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -66,7 +66,6 @@ import           Database.LSMTree.Internal.Entry (Entry, NumEntries (..),
                      unNumEntries)
 import           Database.LSMTree.Internal.IncomingRun
 import           Database.LSMTree.Internal.Index (Index)
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.MergingRun (MergeCredits (..),
                      MergeDebt (..), MergingRun, RunParams (..))
 import qualified Database.LSMTree.Internal.MergingRun as MR
@@ -78,8 +77,8 @@ import qualified Database.LSMTree.Internal.Paths as Paths
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
 import           Database.LSMTree.Internal.RunNumber
-import           Database.LSMTree.Internal.Serialise (SerialisedBlob,
-                     SerialisedKey, SerialisedValue)
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue,
+                     SerialisedBlob, SerialisedKey, SerialisedValue)
 import           Database.LSMTree.Internal.UniqCounter
 import           Database.LSMTree.Internal.Vector (forMStrict, mapMStrict,
                      mapStrict)

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -66,7 +66,6 @@ import           Data.Primitive.PrimVar
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.Assertions (assert)
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.Merge (IsMergeType (..),
                      LevelMergeType (..), Merge, RunParams (..),
                      StepResult (..), TreeMergeType (..))
@@ -74,6 +73,7 @@ import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.Paths (RunFsPaths (..))
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue)
 import qualified Database.LSMTree.Internal.Vector as V
 import           GHC.Stack (HasCallStack, callStack)
 import           System.FS.API (HasFS)

--- a/src/Database/LSMTree/Internal/MergingTree.hs
+++ b/src/Database/LSMTree/Internal/MergingTree.hs
@@ -37,7 +37,6 @@ import           Data.List (foldl')
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
 import           Database.LSMTree.Internal.Entry (NumEntries (..))
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.MergingRun (MergeDebt (..),
                      MergingRun)
 import qualified Database.LSMTree.Internal.MergingRun as MR
@@ -45,6 +44,7 @@ import           Database.LSMTree.Internal.Paths (SessionRoot)
 import qualified Database.LSMTree.Internal.Paths as Paths
 import           Database.LSMTree.Internal.Run (Run)
 import qualified Database.LSMTree.Internal.Run as Run
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.UniqCounter
 import           System.FS.API (HasFS)
 import           System.FS.BlockIO.API (HasBlockIO)

--- a/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
+++ b/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
@@ -17,11 +17,11 @@ import           Control.Monad.Primitive
 import           Control.RefCount
 import qualified Data.Vector as V
 import qualified Database.LSMTree.Internal.Entry as Entry
-import           Database.LSMTree.Internal.Lookup (LookupAcc,
-                     ResolveSerialisedValue)
+import           Database.LSMTree.Internal.Lookup (LookupAcc)
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import qualified Database.LSMTree.Internal.MergingTree as MT
 import           Database.LSMTree.Internal.Run (Run)
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue)
 import qualified Database.LSMTree.Internal.Vector as V
 
 -- | A simplified representation of the shape of a 'MT.MergingTree'.

--- a/src/Database/LSMTree/Internal/Serialise.hs
+++ b/src/Database/LSMTree/Internal/Serialise.hs
@@ -28,6 +28,7 @@ module Database.LSMTree.Internal.Serialise (
   , sizeofValue32
   , sizeofValue64
   , serialisedValue
+  , ResolveSerialisedValue
     -- * Blobs
   , SerialisedBlob (SerialisedBlob, SerialisedBlob')
   , serialiseBlob
@@ -144,6 +145,9 @@ sizeofValue64 = fromIntegral . sizeofValue
 {-# LANGUAGE serialisedValue #-}
 serialisedValue :: SerialisedValue -> BB.Builder
 serialisedValue (SerialisedValue rb) = RB.builder rb
+
+type ResolveSerialisedValue =
+  SerialisedValue -> SerialisedValue -> SerialisedValue
 
 {-------------------------------------------------------------------------------
   Blobs

--- a/src/Database/LSMTree/Internal/Snapshot.hs
+++ b/src/Database/LSMTree/Internal/Snapshot.hs
@@ -53,7 +53,6 @@ import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.CRC32C (checkCRC)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
 import           Database.LSMTree.Internal.IncomingRun
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule
 import qualified Database.LSMTree.Internal.MergingRun as MR
@@ -67,6 +66,7 @@ import           Database.LSMTree.Internal.Paths (ActiveDir (..), ForBlob (..),
 import           Database.LSMTree.Internal.Run (Run, RunParams)
 import qualified Database.LSMTree.Internal.Run as Run
 import           Database.LSMTree.Internal.RunNumber
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.UniqCounter (UniqCounter,
                      incrUniqCounter, uniqueToInt, uniqueToRunNumber)
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -59,7 +59,7 @@ toMap = unWB
 
 -- | \( O(n \log n) \)
 fromList ::
-     (SerialisedValue -> SerialisedValue -> SerialisedValue) -- ^ merge function
+     ResolveSerialisedValue  -- ^ merge function
   -> [(SerialisedKey, Entry SerialisedValue BlobSpan)]
   -> WriteBuffer
 fromList f es = WB $ Map.fromListWith (combine f) es
@@ -73,7 +73,7 @@ toList (WB m) = Map.assocs m
 -------------------------------------------------------------------------------}
 
 addEntry ::
-     (SerialisedValue -> SerialisedValue -> SerialisedValue) -- ^ merge function
+     ResolveSerialisedValue  -- ^ merge function
   -> SerialisedKey
   -> Entry SerialisedValue BlobSpan
   -> WriteBuffer

--- a/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferBlobs.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-partial-fields #-}
 {-# OPTIONS_HADDOCK not-home #-}
 

--- a/src/Database/LSMTree/Internal/WriteBufferReader.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferReader.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_HADDOCK not-home #-}
 
--- | A write buffer that is being read incrementally.
+-- | A persisted write buffer that is being read incrementally from disk.
 --
 module Database.LSMTree.Internal.WriteBufferReader (
     readWriteBuffer
@@ -21,13 +21,13 @@ import           Database.LSMTree.Internal.BlobFile (BlobFile)
 import           Database.LSMTree.Internal.BlobRef (RawBlobRef (..),
                      mkRawBlobRef)
 import qualified Database.LSMTree.Internal.Entry as E
-import           Database.LSMTree.Internal.Lookup (ResolveSerialisedValue)
 import           Database.LSMTree.Internal.Paths
 import           Database.LSMTree.Internal.RawPage
 import           Database.LSMTree.Internal.RunReader (Entry (..), Result (..),
                      mkEntryOverflow, readDiskPage, readOverflowPages,
                      toFullEntry)
-import           Database.LSMTree.Internal.Serialise (SerialisedValue)
+import           Database.LSMTree.Internal.Serialise (ResolveSerialisedValue,
+                     SerialisedValue)
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import qualified System.FS.API as FS


### PR DESCRIPTION
We re-defined the `ResolveSerialisedValue` type synonym in a few places, sometimes with a different name. Moving it to `Internal.Serialise` allows us to simply import it wherever we want to use it. This is done in preparation for making cursors support merging trees.