### PR TITLE
Change `SPECIALIZE` to `SPECIALISE`

### DIFF
--- a/bloomfilter/src/Data/BloomFilter.hs
+++ b/bloomfilter/src/Data/BloomFilter.hs
@@ -142,7 +142,7 @@ singleton hash numBits elt = create hash numBits (\mb -> insert mb elt)
 -- /still/ some possibility that @True@ will be returned.
 elem :: (Hashes h, Hashable a) => a -> Bloom' h a -> Bool
 elem elt ub = elemHashes (makeHashes elt) ub
-{-# SPECIALIZE elem :: Hashable a => a -> Bloom a -> Bool #-}
+{-# SPECIALISE elem :: Hashable a => a -> Bloom a -> Bool #-}
 
 -- | Query an immutable Bloom filter for membership using already constructed 'Hashes' value.
 elemHashes :: Hashes h => h a -> Bloom' h a -> Bool
@@ -160,7 +160,7 @@ elemHashes !ch !ub = go 0 where
             if V.unsafeIndex (bitArray ub) idx
               then go (i + 1)
               else False
-{-# SPECIALIZE elemHashes :: CheapHashes a -> Bloom a -> Bool #-}
+{-# SPECIALISE elemHashes :: CheapHashes a -> Bloom a -> Bool #-}
 
 -- | Query an immutable Bloom filter for non-membership.  If the value
 -- /is/ present, return @False@.  If the value is not present, there

--- a/bloomfilter/src/Data/BloomFilter/Easy.hs
+++ b/bloomfilter/src/Data/BloomFilter/Easy.hs
@@ -43,7 +43,7 @@ easyList :: Hashable a
          => Double              -- ^ desired false positive rate (0 < /ε/ < 1)
          -> [a]                 -- ^ values to populate with
          -> Bloom a
-{-# SPECIALIZE easyList :: Double -> [SB.ByteString] -> Bloom SB.ByteString #-}
+{-# SPECIALISE easyList :: Double -> [SB.ByteString] -> Bloom SB.ByteString #-}
 easyList errRate xs = B.fromList numHashes numBits xs
   where
     capacity = length xs

--- a/bloomfilter/src/Data/BloomFilter/Hash.hs
+++ b/bloomfilter/src/Data/BloomFilter/Hash.hs
@@ -293,5 +293,5 @@ evalCheapHashes (CheapHashes h1 h2) i = h1 + (h2 `unsafeShiftR` i)
 -- It's simply hashes the value twice using seed 0 and 1.
 makeCheapHashes :: Hashable a => a -> CheapHashes a
 makeCheapHashes v = CheapHashes (hashSalt64 0 v) (hashSalt64 1 v)
-{-# SPECIALIZE makeCheapHashes :: BS.ByteString -> CheapHashes BS.ByteString #-}
+{-# SPECIALISE makeCheapHashes :: BS.ByteString -> CheapHashes BS.ByteString #-}
 {-# INLINEABLE makeCheapHashes #-}

--- a/src-kmerge/KMerge/Heap.hs
+++ b/src-kmerge/KMerge/Heap.hs
@@ -71,9 +71,9 @@ replaceRoot (MH sizeRef arr) val = do
         x <- readSmallArray arr 0
         return x
 
-{-# SPECIALIZE replaceRoot :: forall a.   Ord a => MutableHeap RealWorld a -> a -> IO          a #-}
-{-# SPECIALIZE replaceRoot :: forall a s. Ord a => MutableHeap s         a -> a -> Strict.ST s a #-}
-{-# SPECIALIZE replaceRoot :: forall a s. Ord a => MutableHeap s         a -> a -> Lazy.ST   s a #-}
+{-# SPECIALISE replaceRoot :: forall a.   Ord a => MutableHeap RealWorld a -> a -> IO          a #-}
+{-# SPECIALISE replaceRoot :: forall a s. Ord a => MutableHeap s         a -> a -> Strict.ST s a #-}
+{-# SPECIALISE replaceRoot :: forall a s. Ord a => MutableHeap s         a -> a -> Lazy.ST   s a #-}
 
 -- | Extract the next minimum value.
 extract :: forall a m. (PrimMonad m, Ord a) => MutableHeap (PrimState m) a -> m (Maybe a)
@@ -90,9 +90,9 @@ extract (MH sizeRef arr) = do
         writeSmallArray arr (size - 1) placeholder
         return $! Just x
 
-{-# SPECIALIZE extract :: forall a.   Ord a => MutableHeap RealWorld a -> IO          (Maybe a) #-}
-{-# SPECIALIZE extract :: forall a s. Ord a => MutableHeap s         a -> Strict.ST s (Maybe a) #-}
-{-# SPECIALIZE extract :: forall a s. Ord a => MutableHeap s         a -> Lazy.ST   s (Maybe a) #-}
+{-# SPECIALISE extract :: forall a.   Ord a => MutableHeap RealWorld a -> IO          (Maybe a) #-}
+{-# SPECIALISE extract :: forall a s. Ord a => MutableHeap s         a -> Strict.ST s (Maybe a) #-}
+{-# SPECIALISE extract :: forall a s. Ord a => MutableHeap s         a -> Lazy.ST   s (Maybe a) #-}
 
 {-------------------------------------------------------------------------------
   Internal operations
@@ -113,9 +113,9 @@ siftUp !arr !x = loop where
               writeSmallArray arr idx    p
               loop parent
 
-{-# SPECIALIZE siftUp :: forall a.   Ord a => SmallMutableArray RealWorld a -> a -> Int -> IO          () #-}
-{-# SPECIALIZE siftUp :: forall a s. Ord a => SmallMutableArray s         a -> a -> Int -> Strict.ST s () #-}
-{-# SPECIALIZE siftUp :: forall a s. Ord a => SmallMutableArray s         a -> a -> Int -> Lazy.ST   s () #-}
+{-# SPECIALISE siftUp :: forall a.   Ord a => SmallMutableArray RealWorld a -> a -> Int -> IO          () #-}
+{-# SPECIALISE siftUp :: forall a s. Ord a => SmallMutableArray s         a -> a -> Int -> Strict.ST s () #-}
+{-# SPECIALISE siftUp :: forall a s. Ord a => SmallMutableArray s         a -> a -> Int -> Lazy.ST   s () #-}
 
 siftDown :: forall a m. (PrimMonad m, Ord a) => SmallMutableArray (PrimState m) a -> Int -> a -> Int -> m ()
 siftDown !arr !size !x = loop where
@@ -164,9 +164,9 @@ siftDown !arr !size !x = loop where
         !lft = doubleOf idx + 1
         !rgt = doubleOf idx + 2
 
-{-# SPECIALIZE siftDown :: forall a.   Ord a => SmallMutableArray RealWorld a -> Int -> a -> Int -> IO          () #-}
-{-# SPECIALIZE siftDown :: forall a s. Ord a => SmallMutableArray s         a -> Int -> a -> Int -> Strict.ST s () #-}
-{-# SPECIALIZE siftDown :: forall a s. Ord a => SmallMutableArray s         a -> Int -> a -> Int -> Lazy.ST   s () #-}
+{-# SPECIALISE siftDown :: forall a.   Ord a => SmallMutableArray RealWorld a -> Int -> a -> Int -> IO          () #-}
+{-# SPECIALISE siftDown :: forall a s. Ord a => SmallMutableArray s         a -> Int -> a -> Int -> Strict.ST s () #-}
+{-# SPECIALISE siftDown :: forall a s. Ord a => SmallMutableArray s         a -> Int -> a -> Int -> Lazy.ST   s () #-}
 
 {-------------------------------------------------------------------------------
   Helpers

--- a/src-kmerge/KMerge/LoserTree.hs
+++ b/src-kmerge/KMerge/LoserTree.hs
@@ -99,21 +99,21 @@ newLoserTree (x0 :| xs0) = do
                         writeSmallArray arr j x
                         sift ids arr idxY (parentOf j) y idx0 xs
 
-{-# SPECIALIZE newLoserTree :: forall a.   Ord a => NonEmpty a -> IO          (MutableLoserTree RealWorld a, a) #-}
-{-# SPECIALIZE newLoserTree :: forall a s. Ord a => NonEmpty a -> Strict.ST s (MutableLoserTree s         a, a) #-}
-{-# SPECIALIZE newLoserTree :: forall a s. Ord a => NonEmpty a -> Lazy.ST   s (MutableLoserTree s         a, a) #-}
+{-# SPECIALISE newLoserTree :: forall a.   Ord a => NonEmpty a -> IO          (MutableLoserTree RealWorld a, a) #-}
+{-# SPECIALISE newLoserTree :: forall a s. Ord a => NonEmpty a -> Strict.ST s (MutableLoserTree s         a, a) #-}
+{-# SPECIALISE newLoserTree :: forall a s. Ord a => NonEmpty a -> Lazy.ST   s (MutableLoserTree s         a, a) #-}
 
 {-------------------------------------------------------------------------------
   Updates
 -------------------------------------------------------------------------------}
 
-{-# SPECIALIZE replace :: forall a.   Ord a => MutableLoserTree RealWorld a -> a -> IO          a #-}
-{-# SPECIALIZE replace :: forall a s. Ord a => MutableLoserTree s         a -> a -> Strict.ST s a #-}
-{-# SPECIALIZE replace :: forall a s. Ord a => MutableLoserTree s         a -> a -> Lazy.ST s   a #-}
+{-# SPECIALISE replace :: forall a.   Ord a => MutableLoserTree RealWorld a -> a -> IO          a #-}
+{-# SPECIALISE replace :: forall a s. Ord a => MutableLoserTree s         a -> a -> Strict.ST s a #-}
+{-# SPECIALISE replace :: forall a s. Ord a => MutableLoserTree s         a -> a -> Lazy.ST s   a #-}
 
-{-# SPECIALIZE remove :: forall a.   Ord a => MutableLoserTree RealWorld a -> IO          (Maybe a) #-}
-{-# SPECIALIZE remove :: forall a s. Ord a => MutableLoserTree s         a -> Strict.ST s (Maybe a) #-}
-{-# SPECIALIZE remove :: forall a s. Ord a => MutableLoserTree s         a -> Lazy.ST s   (Maybe a) #-}
+{-# SPECIALISE remove :: forall a.   Ord a => MutableLoserTree RealWorld a -> IO          (Maybe a) #-}
+{-# SPECIALISE remove :: forall a s. Ord a => MutableLoserTree s         a -> Strict.ST s (Maybe a) #-}
+{-# SPECIALISE remove :: forall a s. Ord a => MutableLoserTree s         a -> Lazy.ST s   (Maybe a) #-}
 
 -- | Don't fill the winner "hole". Return a next winner of (smaller) tournament.
 remove :: forall a m. (PrimMonad m, Ord a) => MutableLoserTree (PrimState m) a -> m (Maybe a)
@@ -156,9 +156,9 @@ replace (MLT sizeRef holeRef ids arr) val = do
         hole <- readPrimVar holeRef
         siftUp ids arr holeRef hole hole val
 
-{-# SPECIALIZE siftUp :: forall a.   Ord a => MutablePrimArray RealWorld Int -> SmallMutableArray RealWorld a -> PrimVar RealWorld Int -> Int -> Int -> a -> IO          a #-}
-{-# SPECIALIZE siftUp :: forall a s. Ord a => MutablePrimArray s Int         -> SmallMutableArray s         a -> PrimVar s         Int -> Int -> Int -> a -> Strict.ST s a #-}
-{-# SPECIALIZE siftUp :: forall a s. Ord a => MutablePrimArray s Int         -> SmallMutableArray s         a -> PrimVar s         Int -> Int -> Int -> a -> Lazy.ST s   a #-}
+{-# SPECIALISE siftUp :: forall a.   Ord a => MutablePrimArray RealWorld Int -> SmallMutableArray RealWorld a -> PrimVar RealWorld Int -> Int -> Int -> a -> IO          a #-}
+{-# SPECIALISE siftUp :: forall a s. Ord a => MutablePrimArray s Int         -> SmallMutableArray s         a -> PrimVar s         Int -> Int -> Int -> a -> Strict.ST s a #-}
+{-# SPECIALISE siftUp :: forall a s. Ord a => MutablePrimArray s Int         -> SmallMutableArray s         a -> PrimVar s         Int -> Int -> Int -> a -> Lazy.ST s   a #-}
 
 siftUp :: forall a m. (PrimMonad m, Ord a) => MutablePrimArray (PrimState m) Int -> SmallMutableArray (PrimState m) a -> PrimVar (PrimState m) Int -> Int -> Int -> a -> m a
 siftUp ids arr holeRef = sift

--- a/src/Database/LSMTree/Internal/Arena.hs
+++ b/src/Database/LSMTree/Internal/Arena.hs
@@ -61,10 +61,10 @@ type Alignment = Int
 blockSize :: Int
 blockSize = 0x100000
 
-{-# SPECIALIZE
+{-# SPECIALISE
     newBlock :: ST s (Block s)
   #-}
-{-# SPECIALIZE
+{-# SPECIALISE
     newBlock :: IO (Block RealWorld)
   #-}
 newBlock :: PrimMonad m => m (Block (PrimState m))
@@ -81,10 +81,10 @@ withArena am f = do
     closeArena am a
     pure x
 
-{-# SPECIALIZE
+{-# SPECIALISE
     newArena :: ArenaManager s -> ST s (Arena s)
   #-}
-{-# SPECIALIZE
+{-# SPECIALISE
     newArena :: ArenaManager RealWorld -> IO (Arena RealWorld)
   #-}
 newArena :: PrimMonad m => ArenaManager (PrimState m) -> m (Arena (PrimState m))
@@ -101,10 +101,10 @@ newArena (ArenaManager arenas) = do
             full <- newMutVar []
             return Arena {..}
 
-{-# SPECIALIZE
+{-# SPECIALISE
     closeArena :: ArenaManager s -> Arena s -> ST s ()
   #-}
-{-# SPECIALIZE
+{-# SPECIALISE
     closeArena :: ArenaManager RealWorld -> Arena RealWorld -> IO ()
   #-}
 closeArena :: PrimMonad m => ArenaManager (PrimState m) -> Arena (PrimState m) -> m ()
@@ -133,10 +133,10 @@ scrambleBlock (Block _ mba) = do
     setByteArray mba 0 size (0x77 :: Word8)
 #endif
 
-{-# SPECIALIZE
+{-# SPECIALISE
     resetArena :: Arena s -> ST s ()
   #-}
-{-# SPECIALIZE
+{-# SPECIALISE
     resetArena :: Arena RealWorld -> IO ()
   #-}
 -- | Reset arena, i.e. return used blocks to free list.
@@ -162,7 +162,7 @@ withUnmanagedArena k = do
     mgr <- newArenaManager
     withArena mgr k
 
-{-# SPECIALIZE
+{-# SPECIALISE
     allocateFromArena :: Arena s -> Size -> Alignment -> ST s (Offset, MutableByteArray s)
   #-}
 -- | Allocate a slice of mutable byte array from the arena.
@@ -172,7 +172,7 @@ allocateFromArena !arena !size !alignment =
     assert (size <= blockSize) $ -- not too large allocations
     allocateFromArena' arena size alignment
 
-{-# SPECIALIZE
+{-# SPECIALISE
     allocateFromArena' :: Arena s -> Size -> Alignment -> ST s (Offset, MutableByteArray s)
   #-}
 -- TODO!? this is not async exception safe
@@ -206,7 +206,7 @@ allocateFromArena' arena@Arena { .. } !size !alignment = do
         -- * go again
         allocateFromArena' arena size alignment
 
-{-# SPECIALIZE newBlockWithFree :: MutVar s [Block s] -> ST s (Block s) #-}
+{-# SPECIALISE newBlockWithFree :: MutVar s [Block s] -> ST s (Block s) #-}
 -- | Allocate new block, possibly taking it from a free list
 newBlockWithFree :: PrimMonad m => MutVar (PrimState m) [Block (PrimState m)] -> m (Block (PrimState m))
 newBlockWithFree free = do

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -113,7 +113,7 @@ indexSearches !arena !indexes !kopsFiles !ks !rkixs = V.generateM n $ \i -> do
 
 type LookupAcc m h = V.Vector (Maybe (Entry SerialisedValue (WeakBlobRef m h)))
 
-{-# SPECIALIZE lookupsIOWithWriteBuffer ::
+{-# SPECIALISE lookupsIOWithWriteBuffer ::
        HasBlockIO IO h
     -> ArenaManager RealWorld
     -> ResolveSerialisedValue
@@ -155,7 +155,7 @@ lookupsIOWithWriteBuffer !hbio !mgr !resolveV !wb !wbblobs !rs !blooms !indexes 
       assert (V.length rs == V.length kopsFiles) $
       True
 
-{-# SPECIALIZE lookupsIO ::
+{-# SPECIALISE lookupsIO ::
        HasBlockIO IO h
     -> ArenaManager RealWorld
     -> ResolveSerialisedValue
@@ -196,7 +196,7 @@ lookupsIO !hbio !mgr !resolveV !rs !blooms !indexes !kopsFiles !ks =
       assert (V.length rs == V.length kopsFiles) $
       True
 
-{-# SPECIALIZE intraPageLookupsWithWriteBuffer ::
+{-# SPECIALISE intraPageLookupsWithWriteBuffer ::
        ResolveSerialisedValue
     -> WB.WriteBuffer
     -> Ref (WBB.WriteBufferBlobs IO h)
@@ -243,7 +243,7 @@ data TableCorruptedError
     deriving stock (Show, Eq)
     deriving anyclass (Exception)
 
-{-# SPECIALIZE intraPageLookupsOn ::
+{-# SPECIALISE intraPageLookupsOn ::
        ResolveSerialisedValue
     -> LookupAcc IO h
     -> V.Vector (Ref (Run IO h))

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -81,7 +81,7 @@ isCompatible otherVersion = do
   Writing and reading files
 -------------------------------------------------------------------------------}
 
-{-# SPECIALIZE
+{-# SPECIALISE
   writeFileSnapshotMetaData ::
        HasFS IO h
     -> FsPath
@@ -112,7 +112,7 @@ writeFileSnapshotMetaData hfs contentPath checksumPath snapMetaData = do
 encodeSnapshotMetaData :: SnapshotMetaData -> ByteString
 encodeSnapshotMetaData = toLazyByteString . encode . Versioned
 
-{-# SPECIALIZE
+{-# SPECIALISE
   readFileSnapshotMetaData ::
        HasFS IO h
     -> FsPath

--- a/src/Database/LSMTree/Internal/WriteBufferWriter.hs
+++ b/src/Database/LSMTree/Internal/WriteBufferWriter.hs
@@ -152,7 +152,7 @@ unsafeFinalise dropCaches WriteBufferWriter {..} = do
   return (writerHasFS, writerHasBlockIO, writerFsPaths)
 
 
-{-# SPECIALIZE
+{-# SPECIALISE
   addKeyOp ::
        WriteBufferWriter IO h
     -> SerialisedKey


### PR DESCRIPTION
This pull request changes the American-style pragma name `SPECIALIZE` to the equivalent British-style pragma name `SPECIALISE`.
