### PR TITLE
Add missing `IO` and `ST` specializations

### DIFF
--- a/src/Database/LSMTree/Internal/CRC32C.hs
+++ b/src/Database/LSMTree/Internal/CRC32C.hs
@@ -466,11 +466,10 @@ data FileCorruptedError
 
 {-# SPECIALISE
   expectValidFile ::
-      (MonadThrow m)
-    => FsPath
+       FsPath
     -> FileFormat
     -> Either String a
-    -> m a
+    -> IO a
   #-}
 expectValidFile ::
      (MonadThrow m)

--- a/src/Database/LSMTree/Internal/IncomingRun.hs
+++ b/src/Database/LSMTree/Internal/IncomingRun.hs
@@ -246,6 +246,11 @@ creditThresholdForLevel conf (LevelNo _i) =
 -- This is /not/ itself thread safe. All 'TableContent' update operations are
 -- expected to be serialised by the caller. See concurrency comments for
 -- 'TableContent' for detail.
+{-# SPECIALISE depositNominalCredits ::
+     NominalDebt
+  -> PrimVar RealWorld NominalCredits
+  -> NominalCredits
+  -> IO (NominalCredits, NominalCredits) #-}
 depositNominalCredits ::
      PrimMonad m
   => NominalDebt

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -402,6 +402,10 @@ newtype UnionCache m h = UnionCache {
     cachedTree :: MT.LookupTree (V.Vector (Ref (Run m h)))
   }
 
+{-# SPECIALISE mkUnionCache ::
+     ActionRegistry IO
+  -> Ref (MergingTree IO h)
+  -> IO (UnionCache IO h) #-}
 mkUnionCache ::
      (PrimMonad m, MonadMVar m, MonadMask m)
   => ActionRegistry m
@@ -410,6 +414,10 @@ mkUnionCache ::
 mkUnionCache reg mt =
     UnionCache <$> MT.buildLookupTree reg mt
 
+{-# SPECIALISE duplicateUnionCache ::
+     ActionRegistry IO
+  -> UnionCache IO h
+  -> IO (UnionCache IO h) #-}
 duplicateUnionCache ::
      (PrimMonad m, MonadMask m)
   => ActionRegistry m
@@ -419,6 +427,10 @@ duplicateUnionCache reg (UnionCache mt) =
     UnionCache <$>
       MT.mapMStrict (mapMStrict (\r -> withRollback reg (dupRef r) releaseRef)) mt
 
+{-# SPECIALISE releaseUnionCache ::
+     ActionRegistry IO
+  -> UnionCache IO h
+  -> IO () #-}
 releaseUnionCache ::
      (PrimMonad m, MonadMask m)
   => ActionRegistry m

--- a/src/Database/LSMTree/Internal/MergingTree.hs
+++ b/src/Database/LSMTree/Internal/MergingTree.hs
@@ -532,6 +532,9 @@ supplyCredits hfs hbio resolve runParams threshold root uc = \mt0 c0 -> do
 
 -- | This does /not/ release the reference, but allocates a new reference for
 -- the returned run, which must be released at some point.
+{-# SPECIALISE expectCompleted ::
+     Ref (MergingTree IO h)
+  -> IO (Ref (Run IO h)) #-}
 expectCompleted ::
      (MonadMVar m, MonadSTM m, MonadST m, MonadMask m)
   => Ref (MergingTree m h) -> m (Ref (Run m h))

--- a/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
+++ b/src/Database/LSMTree/Internal/MergingTree/Lookup.hs
@@ -33,6 +33,10 @@ data LookupTree a =
 
 -- | Deriving 'Traversable' leads to functions that are not strict in the
 -- elements of the vector of children. This function avoids that issue.
+{-# SPECIALISE mapMStrict ::
+     (a -> IO b)
+  -> LookupTree a
+  -> IO (LookupTree b) #-}
 mapMStrict :: Monad m => (a -> m b) -> LookupTree a -> m (LookupTree b)
 mapMStrict f = \case
   LookupBatch a  -> LookupBatch <$!> f a


### PR DESCRIPTION
This pull request adds missing `IO` specializations and, in `Database.LSMTree.Internal.Arena`, where `ST` specializations are generally present as well, also missing `ST` specializations.
