### PR TITLE
Do not expose `NumEntries` from the public API

### DIFF
--- a/bench/macro/lsm-tree-bench-wp8.hs
+++ b/bench/macro/lsm-tree-bench-wp8.hs
@@ -240,7 +240,6 @@ runOptsP = pure RunOpts
 
 deriving stock instance Read LSM.DiskCachePolicy
 deriving stock instance Read LSM.BloomFilterAlloc
-deriving stock instance Read LSM.NumEntries
 
 -------------------------------------------------------------------------------
 -- measurements

--- a/bench/micro/Bench/Database/LSMTree.hs
+++ b/bench/micro/Bench/Database/LSMTree.hs
@@ -78,7 +78,7 @@ instance ResolveValue V3 where
 
 benchConfig :: TableConfig
 benchConfig = defaultTableConfig
-    { confWriteBufferAlloc  = AllocNumEntries (NumEntries 20000)
+    { confWriteBufferAlloc  = AllocNumEntries 20000
     , confFencePointerIndex = CompactIndex
     }
 
@@ -247,7 +247,7 @@ benchInsertBatches =
 
       _benchConfig :: TableConfig
       _benchConfig = benchConfig {
-          confWriteBufferAlloc = AllocNumEntries (NumEntries 1000)
+          confWriteBufferAlloc = AllocNumEntries 1000
         }
 
       randomInserts :: Int -> V.Vector (K, V2, Maybe Void)

--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -107,7 +107,6 @@ module Database.LSMTree (
   MergePolicy (MergePolicyLazyLevelling),
   SizeRatio (Four),
   WriteBufferAlloc (AllocNumEntries),
-  NumEntries (..),
   BloomFilterAlloc (AllocFixed, AllocRequestFPR),
   defaultBloomFilterAlloc,
   FencePointerIndexType (OrdinaryIndex, CompactIndex),
@@ -198,7 +197,6 @@ import           Database.LSMTree.Internal.Config
                      defaultBloomFilterAlloc, defaultTableConfig)
 import           Database.LSMTree.Internal.Config.Override
                      (OverrideDiskCachePolicy (..))
-import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import qualified Database.LSMTree.Internal.Entry as Entry
 import           Database.LSMTree.Internal.Paths (SnapshotName,
                      isValidSnapshotName, toSnapshotName)

--- a/src/Database/LSMTree/Internal/Config.hs
+++ b/src/Database/LSMTree/Internal/Config.hs
@@ -31,7 +31,6 @@ module Database.LSMTree.Internal.Config (
 
 import           Control.DeepSeq (NFData (..))
 import           Data.Word (Word64)
-import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import           Database.LSMTree.Internal.Index (IndexType)
 import qualified Database.LSMTree.Internal.Index as Index
                      (IndexType (Compact, Ordinary))
@@ -85,7 +84,7 @@ defaultTableConfig =
     TableConfig
       { confMergePolicy       = MergePolicyLazyLevelling
       , confSizeRatio         = Four
-      , confWriteBufferAlloc  = AllocNumEntries (NumEntries 20_000)
+      , confWriteBufferAlloc  = AllocNumEntries 20_000
       , confBloomFilterAlloc  = defaultBloomFilterAlloc
       , confFencePointerIndex = OrdinaryIndex
       , confDiskCachePolicy   = DiskCacheAll
@@ -141,7 +140,7 @@ data WriteBufferAlloc =
     --
     -- NOTE: if the sizes of values vary greatly, this can lead to wonky runs on
     -- disk, and therefore unpredictable performance.
-    AllocNumEntries !NumEntries
+    AllocNumEntries !Int
   deriving stock (Show, Eq)
 
 instance NFData WriteBufferAlloc where

--- a/src/Database/LSMTree/Internal/IncomingRun.hs
+++ b/src/Database/LSMTree/Internal/IncomingRun.hs
@@ -36,7 +36,6 @@ import           Data.Primitive (Prim)
 import           Data.Primitive.PrimVar
 import           Database.LSMTree.Internal.Assertions (assert)
 import           Database.LSMTree.Internal.Config
-import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import           Database.LSMTree.Internal.MergingRun (MergeCredits (..),
                      MergeDebt (..), MergingRun)
 import qualified Database.LSMTree.Internal.MergingRun as MR
@@ -227,7 +226,7 @@ supplyCreditsIncomingRun conf ln (Merging _ nominalDebt nominalCreditsVar mr)
 -- maybe co-prime?
 creditThresholdForLevel :: TableConfig -> LevelNo -> MR.CreditThreshold
 creditThresholdForLevel conf (LevelNo _i) =
-    let AllocNumEntries (NumEntries x) = confWriteBufferAlloc conf
+    let AllocNumEntries x = confWriteBufferAlloc conf
     in  MR.CreditThreshold (MR.UnspentCredits (MergeCredits x))
 
 -- | Deposit nominal credits in the local credits var, ensuring the total

--- a/src/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/src/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -33,7 +33,6 @@ import qualified Data.Vector as V
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.CRC32C
 import qualified Database.LSMTree.Internal.CRC32C as FS
-import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.MergeSchedule
 import qualified Database.LSMTree.Internal.MergingRun as MR
 import           Database.LSMTree.Internal.RunBuilder (IndexType (..),
@@ -342,23 +341,15 @@ instance Encode WriteBufferAlloc where
   encode (AllocNumEntries numEntries) =
          encodeListLen 2
       <> encodeWord 0
-      <> encode numEntries
+      <> encodeInt numEntries
 
 instance DecodeVersioned WriteBufferAlloc where
-  decodeVersioned v@V0 = do
+  decodeVersioned V0 = do
       _ <- decodeListLenOf 2
       tag <- decodeWord
       case tag of
-        0 -> AllocNumEntries <$> decodeVersioned v
+        0 -> AllocNumEntries <$> decodeInt
         _ -> fail ("[WriteBufferAlloc] Unexpected tag: " <> show tag)
-
--- NumEntries
-
-instance Encode NumEntries where
-  encode (NumEntries x) = encodeInt x
-
-instance DecodeVersioned NumEntries where
-  decodeVersioned V0 = NumEntries <$> decodeInt
 
 -- RunParams and friends
 

--- a/src/Database/LSMTree/Internal/Unsafe.hs
+++ b/src/Database/LSMTree/Internal/Unsafe.hs
@@ -113,7 +113,7 @@ import           Database.LSMTree.Internal.Config.Override
 import           Database.LSMTree.Internal.CRC32C (FileCorruptedError (..),
                      FileFormat (..))
 import qualified Database.LSMTree.Internal.Cursor as Cursor
-import           Database.LSMTree.Internal.Entry (Entry, NumEntries (..))
+import           Database.LSMTree.Internal.Entry (Entry)
 import           Database.LSMTree.Internal.IncomingRun (IncomingRun (..))
 import           Database.LSMTree.Internal.Lookup (TableCorruptedError (..),
                      lookupsIO, lookupsIOWithWriteBuffer)
@@ -1734,7 +1734,7 @@ supplyUnionCredits resolve t credits = do
             pure (max 0 credits)  -- all leftovers (but never negative)
           Union mt _ -> do
             let conf = tableConfig t
-            let AllocNumEntries (NumEntries x) = confWriteBufferAlloc conf
+            let AllocNumEntries x = confWriteBufferAlloc conf
             -- We simply use the write buffer size as merge credit threshold, as
             -- the regular level merges also do.
             -- TODO: pick a more suitable threshold or make configurable?

--- a/test/Test/Database/LSMTree/Internal.hs
+++ b/test/Test/Database/LSMTree/Internal.hs
@@ -48,7 +48,7 @@ testTableConfig :: TableConfig
 testTableConfig = defaultTableConfig {
       -- Write buffer size is small on purpose, so that the test actually
       -- flushes and merges.
-      confWriteBufferAlloc = AllocNumEntries (NumEntries 3)
+      confWriteBufferAlloc = AllocNumEntries 3
     }
 
 newSession ::
@@ -62,7 +62,7 @@ newSession (Positive (Small bufferSize)) es =
       withTable session conf (updates const es')
   where
     conf = testTableConfig {
-        confWriteBufferAlloc = AllocNumEntries (NumEntries bufferSize)
+        confWriteBufferAlloc = AllocNumEntries bufferSize
       }
     es' = fmap (bimap serialiseKey (bimap serialiseValue serialiseBlob)) es
 
@@ -79,7 +79,7 @@ restoreSession (Positive (Small bufferSize)) es =
         withTable session2 conf (updates const es')
   where
     conf = testTableConfig {
-        confWriteBufferAlloc = AllocNumEntries (NumEntries bufferSize)
+        confWriteBufferAlloc = AllocNumEntries bufferSize
       }
     es' = fmap (bimap serialiseKey (bimap serialiseValue serialiseBlob)) es
 

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -15,7 +15,6 @@ import           Data.Typeable
 import qualified Data.Vector as V
 import           Database.LSMTree.Extras.Generators ()
 import           Database.LSMTree.Internal.Config
-import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.MergeSchedule
 import           Database.LSMTree.Internal.MergingRun
 import           Database.LSMTree.Internal.RunBuilder (IndexType (..),
@@ -159,7 +158,6 @@ testAll test = [
     , test (Proxy @MergePolicy)
     , test (Proxy @SizeRatio)
     , test (Proxy @WriteBufferAlloc)
-    , test (Proxy @NumEntries)
     , test (Proxy @BloomFilterAlloc)
     , test (Proxy @FencePointerIndexType)
     , test (Proxy @DiskCachePolicy)

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec/Golden.hs
@@ -15,7 +15,6 @@ import           Database.LSMTree.Internal.Config (BloomFilterAlloc (..),
                      MergePolicy (..), MergeSchedule (..), SizeRatio (..),
                      TableConfig (..), WriteBufferAlloc (..),
                      defaultTableConfig)
-import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import           Database.LSMTree.Internal.MergeSchedule
                      (MergePolicyForLevel (..), NominalCredits (..),
                      NominalDebt (..))
@@ -212,7 +211,7 @@ enumerateTableConfig =
       )
     | (_, policy) <- [(blank, MergePolicyLazyLevelling)]
     , (_, ratio ) <- [(blank, Four)]
-    , (_, allocs) <- fmap (AllocNumEntries . NumEntries) <$> [(blank, magicNumber1)]
+    , (_, allocs) <- fmap AllocNumEntries <$> [(blank, magicNumber1)]
     , (d, bloom ) <- enumerateBloomFilterAlloc
     , (e, fence ) <- [("I0", CompactIndex), ("I1", OrdinaryIndex)]
     , (f, cache ) <- enumerateDiskCachePolicy

--- a/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
@@ -206,7 +206,7 @@ prop_flipSnapshotBit (Positive (Small bufferSize)) es pickFileBit =
     namedSnapDir = namedSnapshotDir (SessionRoot root) snapName
 
     conf = defaultTableConfig {
-        confWriteBufferAlloc  = AllocNumEntries (NumEntries bufferSize)
+        confWriteBufferAlloc  = AllocNumEntries bufferSize
       , confFencePointerIndex = CompactIndex
       }
     es' = fmap (bimap serialiseKey (bimap serialiseValue serialiseBlob)) es

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -275,10 +275,10 @@ instance Arbitrary R.TableConfig where
 instance Arbitrary R.WriteBufferAlloc where
   arbitrary = QC.scale (max 30) $ do
       QC.Positive x <- QC.arbitrary
-      pure (R.AllocNumEntries (R.NumEntries x))
+      pure (R.AllocNumEntries x)
 
-  shrink (R.AllocNumEntries (R.NumEntries x)) =
-      [ R.AllocNumEntries (R.NumEntries x')
+  shrink (R.AllocNumEntries x) =
+      [ R.AllocNumEntries x'
       | QC.Positive x' <- QC.shrink (QC.Positive x)
       ]
 

--- a/test/Test/Database/LSMTree/StateMachine/DL.hs
+++ b/test/Test/Database/LSMTree/StateMachine/DL.hs
@@ -68,7 +68,7 @@ dl_example = do
     var3 <- action $ Action Nothing $ New (PrettyProxy @((Key, Value, Blob))) (TableConfig {
           confMergePolicy = MergePolicyLazyLevelling
         , confSizeRatio = Four
-        , confWriteBufferAlloc = AllocNumEntries (NumEntries 4)
+        , confWriteBufferAlloc = AllocNumEntries 4
         , confBloomFilterAlloc = AllocFixed 10
         , confFencePointerIndex = OrdinaryIndex
         , confDiskCachePolicy = DiskCacheNone

--- a/test/Test/Database/LSMTree/UnitTests.hs
+++ b/test/Test/Database/LSMTree/UnitTests.hs
@@ -96,7 +96,7 @@ unit_twoTableTypes =
     withSession nullTracer hfs hbio (FS.mkFsPath []) $ \sess -> do
       let tableConfig =
             defaultTableConfig {
-              confWriteBufferAlloc = AllocNumEntries (NumEntries 10)
+              confWriteBufferAlloc = AllocNumEntries 10
             }
       table1 <- newTableWith @_ @Key1 @Value1 @Blob1 tableConfig sess
       table2 <- newTableWith @_ @Key2 @Value2 @Blob2 tableConfig sess
@@ -239,7 +239,7 @@ unit_union_blobref_invalidation =
       return ()
   where
     config = defaultTableConfig {
-        confWriteBufferAlloc = AllocNumEntries (NumEntries 4)
+        confWriteBufferAlloc = AllocNumEntries 4
       }
 
 ignoreBlobRef :: Functor f => f (BlobRef m b) -> f ()


### PR DESCRIPTION
In the public API it is only used inside the `AllocWriteBuffer` config option. It is mostly inconvenient that a user has to wrap an `Int` in a `NumEntries`, and there are no clear benefits from the newtype.

`NumEntries` is probably still useful as an internal newtype to ensure some type safety, and to serve as documentation, so I kept it in the library internals.

