### PR TITLE
Revisit `SerialiseKey` and `SerialiseValue` classes

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -343,6 +343,7 @@ library
     , lsm-tree:kmerge
     , primitive               ^>=0.9
     , text                    ^>=2.1.1
+    , utf8-string             ^>=1.0
     , vector                  ^>=0.13
     , vector-algorithms       ^>=0.9
 

--- a/src-extras/Database/LSMTree/Extras/Orphans.hs
+++ b/src-extras/Database/LSMTree/Extras/Orphans.hs
@@ -49,6 +49,8 @@ instance SerialiseKey Word256 where
     requireBytesExactly "Word256" 32 len $
       byteSwapWord256 $ indexWord8ArrayAsWord256 ba off
 
+instance SerialiseKeyOrderPreserving Word256
+
 instance SerialiseValue Word256 where
   serialiseValue w256 =
     RB.RawBytes $ mkPrimVector 0 32 $ P.runByteArray $ do
@@ -105,6 +107,8 @@ instance SerialiseKey Word128 where
   deserialiseKey (RawBytes (VP.Vector off len ba)) =
     requireBytesExactly "Word128" 16 len $
       byteSwapWord128 $ indexWord8ArrayAsWord128 ba off
+
+instance SerialiseKeyOrderPreserving Word128
 
 instance SerialiseValue Word128 where
   serialiseValue w128 =

--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -126,11 +126,13 @@ module Database.LSMTree (
   -- * Key\/Value Serialisation #key_value_serialisation#
   RawBytes (RawBytes),
   SerialiseKey (serialiseKey, deserialiseKey),
+  SerialiseKeyOrderPreserving,
   SerialiseValue (serialiseValue, deserialiseValue),
 
   -- ** Key\/Value Serialisation Property Tests #key_value_serialisation_property_tests#
   serialiseKeyIdentity,
   serialiseKeyIdentityUpToSlicing,
+  serialiseKeyPreservesOrdering,
   serialiseKeyMinimalSize,
   serialiseValueIdentity,
   serialiseValueIdentityUpToSlicing,
@@ -205,9 +207,11 @@ import           Database.LSMTree.Internal.Range (Range (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
 import qualified Database.LSMTree.Internal.Serialise as Internal
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey (..),
-                     SerialiseValue (..), packSlice, serialiseKeyIdentity,
+                     SerialiseKeyOrderPreserving, SerialiseValue (..),
+                     packSlice, serialiseKeyIdentity,
                      serialiseKeyIdentityUpToSlicing, serialiseKeyMinimalSize,
-                     serialiseValueIdentity, serialiseValueIdentityUpToSlicing)
+                     serialiseKeyPreservesOrdering, serialiseValueIdentity,
+                     serialiseValueIdentityUpToSlicing)
 import           Database.LSMTree.Internal.Snapshot (SnapshotLabel (..))
 import qualified Database.LSMTree.Internal.Snapshot as Internal
 import           Database.LSMTree.Internal.Types (BlobRef (..), Cursor (..),

--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -134,6 +134,7 @@ module Database.LSMTree (
   serialiseKeyMinimalSize,
   serialiseValueIdentity,
   serialiseValueIdentityUpToSlicing,
+  packSlice,
 
   -- * Monoidal Value Resolution #monoidal_value_resolution#
   ResolveValue (..),
@@ -204,7 +205,7 @@ import           Database.LSMTree.Internal.Range (Range (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
 import qualified Database.LSMTree.Internal.Serialise as Internal
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey (..),
-                     SerialiseValue (..), serialiseKeyIdentity,
+                     SerialiseValue (..), packSlice, serialiseKeyIdentity,
                      serialiseKeyIdentityUpToSlicing, serialiseKeyMinimalSize,
                      serialiseValueIdentity, serialiseValueIdentityUpToSlicing)
 import           Database.LSMTree.Internal.Snapshot (SnapshotLabel (..))

--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -197,7 +197,8 @@ import           Database.LSMTree.Internal.Config
                      DiskCachePolicy (..), FencePointerIndexType (..),
                      MergePolicy (..), MergeSchedule (..), SizeRatio (..),
                      TableConfig (..), WriteBufferAlloc (..),
-                     defaultBloomFilterAlloc, defaultTableConfig)
+                     defaultBloomFilterAlloc, defaultTableConfig,
+                     serialiseKeyMinimalSize)
 import           Database.LSMTree.Internal.Config.Override
                      (OverrideDiskCachePolicy (..))
 import qualified Database.LSMTree.Internal.Entry as Entry
@@ -209,7 +210,7 @@ import qualified Database.LSMTree.Internal.Serialise as Internal
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey (..),
                      SerialiseKeyOrderPreserving, SerialiseValue (..),
                      packSlice, serialiseKeyIdentity,
-                     serialiseKeyIdentityUpToSlicing, serialiseKeyMinimalSize,
+                     serialiseKeyIdentityUpToSlicing,
                      serialiseKeyPreservesOrdering, serialiseValueIdentity,
                      serialiseValueIdentityUpToSlicing)
 import           Database.LSMTree.Internal.Snapshot (SnapshotLabel (..))

--- a/src/Database/LSMTree/Internal/ByteString.hs
+++ b/src/Database/LSMTree/Internal/ByteString.hs
@@ -129,6 +129,7 @@ unsafePinnedByteArrayToByteString off@(I# off#) len ba@(ByteArray ba#) =
     addr# = plusAddr# (byteArrayContents# ba#) off#
     fp = Foreign.ForeignPtr addr# (Foreign.PlainPtr (unsafeCoerce# ba#))
 
+-- | \( O(1) \) conversion.
 byteArrayToSBS :: ByteArray -> ShortByteString
 #if MIN_VERSION_bytestring(0,12,0)
 byteArrayToSBS ba             = SBS.ShortByteString ba

--- a/src/Database/LSMTree/Internal/Primitive.hs
+++ b/src/Database/LSMTree/Internal/Primitive.hs
@@ -1,16 +1,163 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
 {-# LANGUAGE MagicHash    #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
+-- | Primitive operations lifted into boxed types
 module Database.LSMTree.Internal.Primitive (
-    indexWord8ArrayAsWord16
+    -- * Byte swaps
+    byteSwapInt16
+  , byteSwapInt32
+  , byteSwapInt64
+  , byteSwapInt
+  , byteSwapWord16
+  , byteSwapWord32
+  , byteSwapWord64
+  , byteSwapWord
+    -- * Indexing byte arrays
+  , indexInt8Array
+  , indexWord8ArrayAsInt16
+  , indexWord8ArrayAsInt32
+  , indexWord8ArrayAsInt64
+  , indexWord8ArrayAsInt
+  , indexWord8Array
+  , indexWord8ArrayAsWord16
   , indexWord8ArrayAsWord32
   , indexWord8ArrayAsWord64
+  , indexWord8ArrayAsWord
   ) where
 
 import           Data.Primitive.ByteArray (ByteArray (..))
 import           GHC.Exts
+import           GHC.Int
 import           GHC.Word
+
+{-------------------------------------------------------------------------------
+  Conversions
+-------------------------------------------------------------------------------}
+
+{-# INLINE wordToInt16# #-}
+wordToInt16# :: Word# -> Int16#
+wordToInt16# w# = intToInt16# (word2Int# w#)
+
+{-# INLINE int16ToWord# #-}
+int16ToWord# :: Int16# -> Word#
+int16ToWord# i# = int2Word# (int16ToInt# i#)
+
+{-# INLINE wordToInt32# #-}
+wordToInt32# :: Word# -> Int32#
+wordToInt32# w# = intToInt32# (word2Int# w#)
+
+{-# INLINE int32ToWord# #-}
+int32ToWord# :: Int32# -> Word#
+int32ToWord# i# = int2Word# (int32ToInt# i#)
+
+#if MIN_VERSION_base(4,17,0)
+
+{-# INLINE wordToInt64# #-}
+wordToInt64# :: Word# -> Int64#
+wordToInt64# w# = intToInt64# (word2Int# w#)
+
+{-# INLINE int64ToWord# #-}
+int64ToWord# :: Int64# -> Word#
+int64ToWord# i# = int2Word# (int64ToInt# i#)
+
+#endif
+
+{-------------------------------------------------------------------------------
+  Conversions: shims
+-------------------------------------------------------------------------------}
+
+{-# INLINE wordToInt64Shim# #-}
+{-# INLINE int64ToWordShim# #-}
+
+#if MIN_VERSION_base(4,17,0)
+
+wordToInt64Shim# :: Word# -> Int64#
+wordToInt64Shim# = wordToInt64#
+
+int64ToWordShim# :: Int64# -> Word#
+int64ToWordShim# = int64ToWord#
+
+#else
+
+wordToInt64Shim# :: Word# -> Int#
+wordToInt64Shim# = word2Int#
+
+int64ToWordShim# :: Int# -> Word#
+int64ToWordShim# = int2Word#
+
+#endif
+
+{-------------------------------------------------------------------------------
+  Byte swaps
+-------------------------------------------------------------------------------}
+
+{-# INLINE byteSwapInt16 #-}
+byteSwapInt16 :: Int16 -> Int16
+byteSwapInt16 (I16# i#) = I16# (wordToInt16# (byteSwap16# (int16ToWord# i#)))
+
+{-# INLINE byteSwapInt32 #-}
+byteSwapInt32 :: Int32 -> Int32
+byteSwapInt32 (I32# i#) = I32# (wordToInt32# (byteSwap32# (int32ToWord# i#)))
+
+{-# INLINE byteSwapInt64 #-}
+byteSwapInt64 :: Int64 -> Int64
+byteSwapInt64 (I64# i#) = I64# (wordToInt64Shim# (byteSwap# (int64ToWordShim# i#)))
+
+{-# INLINE byteSwapInt #-}
+byteSwapInt :: Int -> Int
+byteSwapInt (I# i#) = I# (word2Int# (byteSwap# (int2Word# i#)))
+
+{-# INLINE byteSwapWord16 #-}
+byteSwapWord16 :: Word16 -> Word16
+byteSwapWord16 = byteSwap16
+
+{-# INLINE byteSwapWord32 #-}
+byteSwapWord32 :: Word32 -> Word32
+byteSwapWord32 = byteSwap32
+
+{-# INLINE byteSwapWord64 #-}
+byteSwapWord64 :: Word64 -> Word64
+byteSwapWord64 = byteSwap64
+
+{-# INLINE byteSwapWord #-}
+byteSwapWord :: Word -> Word
+byteSwapWord (W# w#) = W# (byteSwap# w#)
+
+{-------------------------------------------------------------------------------
+  Indexing byte arrays
+-------------------------------------------------------------------------------}
+
+{-# INLINE indexInt8Array #-}
+indexInt8Array :: ByteArray -> Int -> Int8
+indexInt8Array (ByteArray !ba#) (I# !off#) =
+  I8# (indexInt8Array# ba# off#)
+
+{-# INLINE indexWord8ArrayAsInt16 #-}
+indexWord8ArrayAsInt16 :: ByteArray -> Int -> Int16
+indexWord8ArrayAsInt16 (ByteArray !ba#) (I# !off#) =
+  I16# (indexWord8ArrayAsInt16# ba# off#)
+
+{-# INLINE indexWord8ArrayAsInt32 #-}
+indexWord8ArrayAsInt32 :: ByteArray -> Int -> Int32
+indexWord8ArrayAsInt32 (ByteArray !ba#) (I# !off#) =
+  I32# (indexWord8ArrayAsInt32# ba# off#)
+
+{-# INLINE indexWord8ArrayAsInt64 #-}
+indexWord8ArrayAsInt64 :: ByteArray -> Int -> Int64
+indexWord8ArrayAsInt64 (ByteArray !ba#) (I# !off#) =
+  I64# (indexWord8ArrayAsInt64# ba# off#)
+
+{-# INLINE indexWord8ArrayAsInt #-}
+indexWord8ArrayAsInt :: ByteArray -> Int -> Int
+indexWord8ArrayAsInt (ByteArray !ba#) (I# !off#) =
+  I# (indexWord8ArrayAsInt# ba# off#)
+
+{-# INLINE indexWord8Array #-}
+indexWord8Array :: ByteArray -> Int -> Word8
+indexWord8Array (ByteArray !ba#) (I# !off#) =
+  W8# (indexWord8Array# ba# off#)
 
 {-# INLINE indexWord8ArrayAsWord16 #-}
 indexWord8ArrayAsWord16 :: ByteArray -> Int -> Word16
@@ -26,3 +173,8 @@ indexWord8ArrayAsWord32 (ByteArray !ba#) (I# !off#) =
 indexWord8ArrayAsWord64 :: ByteArray -> Int -> Word64
 indexWord8ArrayAsWord64 (ByteArray !ba#) (I# !off#) =
   W64# (indexWord8ArrayAsWord64# ba# off#)
+
+{-# INLINE indexWord8ArrayAsWord #-}
+indexWord8ArrayAsWord :: ByteArray -> Int -> Word
+indexWord8ArrayAsWord (ByteArray !ba#) (I# !off#) =
+  W# (indexWord8ArrayAsWord# ba# off#)

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -25,13 +25,14 @@ import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short.Internal as SBS
+import           Data.Int (Int16, Int32, Int64, Int8)
 import           Data.Monoid (Sum (..))
 import qualified Data.Primitive as P
 import qualified Data.Vector.Primitive as VP
 import           Data.Void (Void, absurd)
-import           Data.Word
+import           Data.Word (Word16, Word32, Word64, Word8)
 import           Database.LSMTree.Internal.ByteString (byteArrayToSBS)
-import           Database.LSMTree.Internal.Primitive (indexWord8ArrayAsWord64)
+import           Database.LSMTree.Internal.Primitive
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           Database.LSMTree.Internal.Vector
@@ -143,20 +144,143 @@ requireBytesExactly tyName expected actual x
       $ ""
 
 {-------------------------------------------------------------------------------
-  Word64
+  Int
 -------------------------------------------------------------------------------}
 
-instance SerialiseKey Word64 where
-  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwap64 x
+instance SerialiseKey Int8 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim x
 
   deserialiseKey (RawBytes (VP.Vector off len ba)) =
-    requireBytesExactly "Word64" 8 len $ byteSwap64 (indexWord8ArrayAsWord64 ba off)
+    requireBytesExactly "Int8" 1 len $ indexInt8Array ba off
+
+instance SerialiseValue Int8 where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int8" 1 len $ indexInt8Array ba off
+
+instance SerialiseKey Int16 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapInt16 x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int16" 2 len $ byteSwapInt16 (indexWord8ArrayAsInt16 ba off)
+
+instance SerialiseValue Int16 where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int16" 2 len $ indexWord8ArrayAsInt16 ba off
+
+instance SerialiseKey Int32 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapInt32 x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int32" 4 len $ byteSwapInt32 (indexWord8ArrayAsInt32 ba off)
+
+instance SerialiseValue Int32 where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int32" 4 len $ indexWord8ArrayAsInt32 ba off
+
+instance SerialiseKey Int64 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapInt64 x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int64" 8 len $ byteSwapInt64 (indexWord8ArrayAsInt64 ba off)
+
+instance SerialiseValue Int64 where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int64" 8 len $ indexWord8ArrayAsInt64 ba off
+
+instance SerialiseKey Int where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapInt x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int" 8 len $ byteSwapInt (indexWord8ArrayAsInt ba off)
+
+instance SerialiseValue Int where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Int" 8 len $ indexWord8ArrayAsInt ba off
+
+{-------------------------------------------------------------------------------
+  Word
+-------------------------------------------------------------------------------}
+
+instance SerialiseKey Word8 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim  x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word8" 1 len  (indexWord8Array ba off)
+
+instance SerialiseKeyOrderPreserving Word8
+
+instance SerialiseValue Word8 where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word8" 1 len $ indexWord8Array ba off
+
+
+instance SerialiseKey Word16 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapWord16 x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word16" 2 len $ byteSwapWord16 (indexWord8ArrayAsWord16 ba off)
+
+instance SerialiseKeyOrderPreserving Word16
+
+instance SerialiseValue Word16 where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word16" 2 len $ indexWord8ArrayAsWord16 ba off
+
+instance SerialiseKey Word32 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapWord32 x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word32" 4 len $ byteSwapWord32 (indexWord8ArrayAsWord32 ba off)
+
+instance SerialiseKeyOrderPreserving Word32
+
+instance SerialiseValue Word32 where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word32" 4 len $ indexWord8ArrayAsWord32 ba off
+
+instance SerialiseKey Word64 where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapWord64 x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word64" 8 len $ byteSwapWord64 (indexWord8ArrayAsWord64 ba off)
+
+instance SerialiseKeyOrderPreserving Word64
 
 instance SerialiseValue Word64 where
   serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
 
   deserialiseValue (RawBytes (VP.Vector off len ba)) =
     requireBytesExactly "Word64" 8 len $ indexWord8ArrayAsWord64 ba off
+
+instance SerialiseKey Word where
+  serialiseKey x = RB.RawBytes $ byteVectorFromPrim $ byteSwapWord x
+
+  deserialiseKey (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word" 8 len $ byteSwapWord (indexWord8ArrayAsWord ba off)
+
+instance SerialiseKeyOrderPreserving Word
+
+instance SerialiseValue Word where
+  serialiseValue x = RB.RawBytes $ byteVectorFromPrim $ x
+
+  deserialiseValue (RawBytes (VP.Vector off len ba)) =
+    requireBytesExactly "Word" 8 len $ indexWord8ArrayAsWord ba off
 
 {-------------------------------------------------------------------------------
   String

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -22,9 +22,9 @@ module Database.LSMTree.Internal.Serialise.Class (
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as B
-import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short.Internal as SBS
+import qualified Data.ByteString.UTF8 as UTF8
 import           Data.Int (Int16, Int32, Int64, Int8)
 import           Data.Monoid (Sum (..))
 import qualified Data.Primitive as P
@@ -287,20 +287,22 @@ instance SerialiseValue Word where
 -------------------------------------------------------------------------------}
 
 -- | \( O(n) \) (de-)serialisation, where \(n\) is the number of characters in
--- the string.
+-- the string. The string is encoded using UTF8.
 --
 -- TODO: optimise, it's \( O(n) + O(n) \) where it could be \( O(n) \).
 instance SerialiseKey String where
-  serialiseKey = serialiseKey . BSC.pack
-  deserialiseKey = BSC.unpack . deserialiseKey
+  serialiseKey = serialiseKey . UTF8.fromString
+  deserialiseKey = UTF8.toString . deserialiseKey
+
+instance SerialiseKeyOrderPreserving String
 
 -- | \( O(n) \) (de-)serialisation, where \(n\) is the number of characters in
 -- the string.
 --
 -- TODO: optimise, it's \( O(n) + O(n) \) where it could be \( O(n) \).
 instance SerialiseValue String where
-  serialiseValue = serialiseValue . BSC.pack
-  deserialiseValue = BSC.unpack . deserialiseValue
+  serialiseValue = serialiseValue . UTF8.fromString
+  deserialiseValue = UTF8.toString . deserialiseValue
 
 {-------------------------------------------------------------------------------
   ByteString

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -7,7 +7,6 @@ module Database.LSMTree.Internal.Serialise.Class (
     SerialiseKey (..)
   , serialiseKeyIdentity
   , serialiseKeyIdentityUpToSlicing
-  , serialiseKeyMinimalSize
   , SerialiseKeyOrderPreserving
   , serialiseKeyPreservesOrdering
     -- * SerialiseValue
@@ -66,10 +65,6 @@ serialiseKeyIdentityUpToSlicing ::
   => RawBytes -> k -> RawBytes -> Bool
 serialiseKeyIdentityUpToSlicing prefix x suffix =
     deserialiseKey (packSlice prefix (serialiseKey x) suffix) == x
-
--- | Test the __Minimal size__ law for the 'SerialiseKey' class.
-serialiseKeyMinimalSize :: SerialiseKey k => k -> Bool
-serialiseKeyMinimalSize x = RB.size (serialiseKey x) >= 8
 
 -- | Order-preserving serialisation of keys
 --

--- a/src/Database/LSMTree/Simple.hs
+++ b/src/Database/LSMTree/Simple.hs
@@ -114,11 +114,13 @@ module Database.LSMTree.Simple (
     -- * Key\/Value Serialisation #key_value_serialisation#
     RawBytes (RawBytes),
     SerialiseKey (serialiseKey, deserialiseKey),
+    SerialiseKeyOrderPreserving,
     SerialiseValue (serialiseValue, deserialiseValue),
 
     -- ** Key\/Value Serialisation Property Tests #key_value_serialisation_property_tests#
     serialiseKeyIdentity,
     serialiseKeyIdentityUpToSlicing,
+    serialiseKeyPreservesOrdering,
     serialiseKeyMinimalSize,
     serialiseValueIdentity,
     serialiseValueIdentityUpToSlicing,
@@ -168,9 +170,11 @@ import           Database.LSMTree.Internal.Range (Range (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
 import qualified Database.LSMTree.Internal.Serialise as Internal
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey (..),
-                     SerialiseValue (..), packSlice, serialiseKeyIdentity,
+                     SerialiseKeyOrderPreserving, SerialiseValue (..),
+                     packSlice, serialiseKeyIdentity,
                      serialiseKeyIdentityUpToSlicing, serialiseKeyMinimalSize,
-                     serialiseValueIdentity, serialiseValueIdentityUpToSlicing)
+                     serialiseKeyPreservesOrdering, serialiseValueIdentity,
+                     serialiseValueIdentityUpToSlicing)
 import           Database.LSMTree.Internal.Snapshot (SnapshotLabel (..))
 import qualified Database.LSMTree.Internal.Snapshot as Internal
 import           Database.LSMTree.Internal.Unsafe (BlobRefInvalidError (..),

--- a/src/Database/LSMTree/Simple.hs
+++ b/src/Database/LSMTree/Simple.hs
@@ -122,6 +122,7 @@ module Database.LSMTree.Simple (
     serialiseKeyMinimalSize,
     serialiseValueIdentity,
     serialiseValueIdentityUpToSlicing,
+    packSlice,
 
     -- * Errors #errors#
     SessionDirDoesNotExistError (..),
@@ -167,7 +168,7 @@ import           Database.LSMTree.Internal.Range (Range (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
 import qualified Database.LSMTree.Internal.Serialise as Internal
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey (..),
-                     SerialiseValue (..), serialiseKeyIdentity,
+                     SerialiseValue (..), packSlice, serialiseKeyIdentity,
                      serialiseKeyIdentityUpToSlicing, serialiseKeyMinimalSize,
                      serialiseValueIdentity, serialiseValueIdentityUpToSlicing)
 import           Database.LSMTree.Internal.Snapshot (SnapshotLabel (..))

--- a/src/Database/LSMTree/Simple.hs
+++ b/src/Database/LSMTree/Simple.hs
@@ -160,7 +160,7 @@ import           Database.LSMTree.Internal.Config
                      DiskCachePolicy (..), FencePointerIndexType (..),
                      MergePolicy (..), MergeSchedule (..), SizeRatio (..),
                      TableConfig (..), WriteBufferAlloc (..),
-                     defaultTableConfig)
+                     defaultTableConfig, serialiseKeyMinimalSize)
 import           Database.LSMTree.Internal.Config.Override
                      (OverrideDiskCachePolicy (..))
 import qualified Database.LSMTree.Internal.Entry as Entry
@@ -172,7 +172,7 @@ import qualified Database.LSMTree.Internal.Serialise as Internal
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey (..),
                      SerialiseKeyOrderPreserving, SerialiseValue (..),
                      packSlice, serialiseKeyIdentity,
-                     serialiseKeyIdentityUpToSlicing, serialiseKeyMinimalSize,
+                     serialiseKeyIdentityUpToSlicing,
                      serialiseKeyPreservesOrdering, serialiseValueIdentity,
                      serialiseValueIdentityUpToSlicing)
 import           Database.LSMTree.Internal.Snapshot (SnapshotLabel (..))

--- a/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
@@ -7,6 +7,9 @@ module Test.Database.LSMTree.Internal.Serialise.Class (tests) where
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Lazy (LazyByteString)
 import           Data.ByteString.Short (ShortByteString)
+import           Data.Constraint (Dict (..))
+import           Data.Int
+import           Data.Monoid (Sum)
 import           Data.Primitive (ByteArray)
 import           Data.WideWord (Word128, Word256)
 import           Data.Word
@@ -17,30 +20,60 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 tests :: TestTree
-tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class"
-    [ testGroup "Word64"          (allProperties @Word64 True)
-    , testGroup "ByteString"      (allProperties @ByteString True)
-    , testGroup "LazyByteString"  (allProperties @LazyByteString True)
-    , testGroup "ShortByteString" (allProperties @ShortByteString True)
-    , testGroup "ByteArray"       (valueProperties @ByteArray)
-    , testGroup "Word128"         (allProperties @Word128 True)
-    , testGroup "Word256"         (allProperties @Word256 True)
-    , testGroup "UTxOKey"         (keyProperties @UTxOKey False)
-    , testGroup "UTxOValue"       (valueProperties @UTxOValue)
+tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class" [
+      testGroup "String" (allProperties @String Nothing)
+
+      -- Int
+    , testGroup "Int8"  (allProperties @Int8  Nothing)
+    , testGroup "Int16" (allProperties @Int16 Nothing)
+    , testGroup "Int32" (allProperties @Int32 Nothing)
+    , testGroup "Int64" (allProperties @Int64 Nothing)
+    , testGroup "Int"   (allProperties @Int   Nothing)
+
+      -- Word
+    , testGroup "Word8"  (allProperties @Word8  (Just Dict))
+    , testGroup "Word16" (allProperties @Word16 (Just Dict))
+    , testGroup "Word32" (allProperties @Word32 (Just Dict))
+    , testGroup "Word64" (allProperties @Word64 (Just Dict))
+    , testGroup "Word"   (allProperties @Word   (Just Dict))
+
+      -- ByteString
+    , testGroup "ByteString"      (allProperties @ByteString      (Just Dict))
+    , testGroup "LazyByteString"  (allProperties @LazyByteString  (Just Dict))
+    , testGroup "ShortByteString" (allProperties @ShortByteString (Just Dict))
+    , testGroup "ByteArray"       (allProperties @ByteArray       Nothing    )
+
+      -- UTXO
+    , testGroup "Word128"         (allProperties   @Word128   (Just Dict))
+    , testGroup "Word256"         (allProperties   @Word256   (Just Dict))
+    , testGroup "UTxOKey"         (keyProperties   @UTxOKey   Nothing    )
+    , testGroup "UTxOValue"       (valueProperties @UTxOValue            )
+
+      -- Modifiers
+    , testGroup "Sum Word" (valueProperties @(Sum Word))
     ]
 
-allProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a, SerialiseValue a) => Bool -> [TestTree]
+allProperties ::
+     forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a, SerialiseValue a)
+  => Maybe (Dict (SerialiseKeyOrderPreserving a))
+  -> [TestTree]
 allProperties orderPreserving = keyProperties @a orderPreserving <> valueProperties @a
 
-keyProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a) => Bool -> [TestTree]
+keyProperties ::
+     forall a. (Ord a, Show a, Arbitrary a, SerialiseKey a)
+  => Maybe (Dict (SerialiseKeyOrderPreserving a))
+  -> [TestTree]
 keyProperties orderPreserving =
     [ testProperty "prop_roundtripSerialiseKey" $
         prop_roundtripSerialiseKey @a
     , testProperty "prop_roundtripSerialiseKeyUpToSlicing" $
         prop_roundtripSerialiseKeyUpToSlicing @a
     , testProperty "prop_orderPreservationSerialiseKey" $ \k1 k2 ->
-        (if orderPreserving then id else expectFailure)
-          (prop_orderPreservationSerialiseKey @a k1 k2)
+        let modifier = case orderPreserving of
+              Just Dict -> id
+              Nothing   -> expectFailure
+        in  modifier $ prop_orderPreservationSerialiseKey @a k1 k2
+
     ]
 
 valueProperties :: forall a. (Ord a, Show a, Arbitrary a, SerialiseValue a) => [TestTree]

--- a/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise/Class.hs
@@ -21,7 +21,7 @@ import           Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.Serialise.Class" [
-      testGroup "String" (allProperties @String Nothing)
+      testGroup "String" (allProperties @String (Just Dict))
 
       -- Int
     , testGroup "Int8"  (allProperties @Int8  Nothing)


### PR DESCRIPTION
The intent of this PR is to clean up and improve these classes a bit, since they're now exported from the public API