### PR TITLE
Drop support for `ghc-8.10`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
-        ghc-version: ["8.10", "9.2", "9.4", "9.6", "9.8", "9.10", "9.12"]
+        ghc-version: ["9.2", "9.4", "9.6", "9.8", "9.10", "9.12"]
         cabal-version: ["3.12"]
         # The inclusion of these default keys in the matrix ensures that any
         # entry under include that assigns these keys creates a new matrix entry
@@ -166,16 +166,8 @@ jobs:
         cabal-project-file: [""]
         cabal-documentation: [false]
 
-        exclude:
-          # GHC 8.10 is not supported on macOS wit ARM CPU
-          - ghc-version: "8.10"
-            os: "macOS-latest"
-
         include:
           # Include builds for various special cases
-          - name: "Build on macOS with Intel CPU and GHC 8.10"
-            os: "macOS-13"
-            ghc-version: "8.10"
           - name: "Build with +serialblockio"
             os: "ubuntu-latest"
             cabal-flags: "+serialblockio"

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -22,11 +22,6 @@ constraints: bloomfilter <0
 -- we could add a conditional on (+serialblockio) to remove this import automatically.
 import: cabal.project.blockio-uring
 
--- TODO: fix assembly error in text-2.1.2
-if (impl(ghc < 9.0) && os(windows))
-  package text
-    flags: -simdutf
-
 -- bugfix hGetBufExactly and hGetBufExactlyAt
 source-repository-package
   type: git

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -208,7 +208,7 @@ copyright:
 category:           Database
 build-type:         Simple
 tested-with:
-  GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
+  GHC ==9.2 || ==9.4 || ==9.6 || ==9.8 || ==9.10 || ==9.12
 
 extra-doc-files:    CHANGELOG.md
 extra-source-files:
@@ -239,64 +239,7 @@ common wno-x-partial
     ghc-options: -Wno-x-partial
 
 common language
-  -- This is at the top-level so that `cabal check` does not complain.
-  default-language:   Haskell2010
-
-  -- For newer GHC's, override Haskell2010 with GHC2021
-  if impl(ghc >=9.2.1)
-    default-language: GHC2021
-
-  else
-    -- NOTE: FieldSelectors is not supported on ghc-8.10.7, so it is the only
-    -- language extension that is missing compared to GHC2021
-    default-extensions:
-      BangPatterns
-      BinaryLiterals
-      ConstrainedClassMethods
-      ConstraintKinds
-      DeriveDataTypeable
-      DeriveFoldable
-      DeriveFunctor
-      DeriveGeneric
-      DeriveLift
-      DeriveTraversable
-      DoAndIfThenElse
-      EmptyCase
-      EmptyDataDecls
-      EmptyDataDeriving
-      ExistentialQuantification
-      ExplicitForAll
-      FlexibleContexts
-      FlexibleInstances
-      ForeignFunctionInterface
-      GADTSyntax
-      GeneralisedNewtypeDeriving
-      HexFloatLiterals
-      ImplicitPrelude
-      ImportQualifiedPost
-      InstanceSigs
-      KindSignatures
-      MonomorphismRestriction
-      MultiParamTypeClasses
-      NamedFieldPuns
-      NamedWildCards
-      NoExplicitNamespaces
-      NumericUnderscores
-      PatternGuards
-      PolyKinds
-      PostfixOperators
-      RankNTypes
-      RelaxedPolyRec
-      ScopedTypeVariables
-      StandaloneDeriving
-      StandaloneKindSignatures
-      StarIsType
-      TraditionalRecordSyntax
-      TupleSections
-      TypeApplications
-      TypeOperators
-      TypeSynonymInstances
-
+  default-language:   GHC2021
   default-extensions:
     DeriveAnyClass
     DerivingStrategies
@@ -382,7 +325,7 @@ library
     Database.LSMTree.Simple
 
   build-depends:
-    , base                    >=4.14      && <4.22
+    , base                    >=4.16      && <4.22
     , bitvec                  ^>=1.1
     , bytestring              ^>=0.11.4.0 || ^>=0.12.1.0
     , cborg                   ^>=0.2.10.0
@@ -454,7 +397,7 @@ library bloomfilter
   visibility:      private
   hs-source-dirs:  bloomfilter/src
   build-depends:
-    , base             >=4.5       && <5
+    , base             >=4.16      && <5
     , bitvec           ^>=1.1.5.0
     , bytestring       >=0.9
     , data-array-byte
@@ -528,7 +471,7 @@ library extras
     Database.LSMTree.Extras.UTxO
 
   build-depends:
-    , base                    >=4.14 && <4.22
+    , base                    >=4.16 && <4.22
     , bitvec
     , bytestring
     , containers
@@ -811,7 +754,7 @@ benchmark rocksdb-bench-wp8
   hs-source-dirs: bench/macro
   main-is:        rocksdb-bench-wp8.hs
 
-  if !((os(linux) && flag(rocksdb)) && impl(ghc >=9.2.0))
+  if !(os(linux) && flag(rocksdb))
     buildable: False
 
   build-depends:
@@ -836,7 +779,7 @@ library rocksdb
   exposed-modules: RocksDB
   other-modules:   RocksDB.FFI
 
-  if !((os(linux) && flag(rocksdb)) && impl(ghc >=9.2.0))
+  if !(os(linux) && flag(rocksdb))
     buildable: False
 
   -- Ubuntu 22.04 doesn't have pkgconfig files for rocksdb
@@ -864,7 +807,7 @@ test-suite kmerge-test
   hs-source-dirs: test
   main-is:        kmerge-test.hs
   build-depends:
-    , base              >=4.14 && <4.22
+    , base              >=4.16 && <4.22
     , deepseq
     , heaps
     , lsm-tree:kmerge
@@ -883,7 +826,7 @@ benchmark kmerge-bench
   main-is:        kmerge-test.hs
   cpp-options:    -DKMERGE_BENCHMARKS
   build-depends:
-    , base              >=4.14 && <4.22
+    , base              >=4.16 && <4.22
     , deepseq
     , heaps
     , lsm-tree:kmerge
@@ -901,7 +844,7 @@ test-suite map-range-test
   hs-source-dirs: test
   main-is:        map-range-test.hs
   build-depends:
-    , base              >=4.14 && <4.22
+    , base              >=4.16 && <4.22
     , bytestring
     , containers
     , lsm-tree
@@ -963,7 +906,7 @@ library blockio-api
     System.FS.BlockIO.Serial
 
   build-depends:
-    , base        >=4.14  && <4.22
+    , base        >=4.16  && <4.22
     , deepseq     ^>=1.4  || ^>=1.5
     , fs-api      ^>=0.3
     , io-classes  ^>=1.6  || ^>=1.7
@@ -1004,7 +947,7 @@ test-suite blockio-api-test
   main-is:        Main.hs
   build-depends:
     , async
-    , base                  >=4.14      && <4.22
+    , base                  >=4.16      && <4.22
     , bytestring
     , fs-api
     , lsm-tree:blockio-api
@@ -1024,7 +967,7 @@ library blockio-sim
   hs-source-dirs:  blockio-sim/src
   exposed-modules: System.FS.BlockIO.Sim
   build-depends:
-    , base                   >=4.14 && <4.22
+    , base                   >=4.16 && <4.22
     , bytestring
     , fs-api                 ^>=0.3
     , fs-sim                 ^>=0.3
@@ -1039,7 +982,7 @@ test-suite blockio-sim-test
   hs-source-dirs: blockio-sim/test
   main-is:        Main.hs
   build-depends:
-    , base                   >=4.14 && <4.22
+    , base                   >=4.16 && <4.22
     , fs-api
     , fs-sim
     , io-classes:strict-stm
@@ -1068,7 +1011,7 @@ library control
     Control.RefCount
 
   build-depends:
-    , base                   >=4.14 && <4.22
+    , base                   >=4.16 && <4.22
     , deepseq                ^>=1.4 || ^>=1.5
     , io-classes             ^>=1.6 || ^>=1.7
     , io-classes:strict-stm

--- a/scripts/generate-readme.hs
+++ b/scripts/generate-readme.hs
@@ -1,7 +1,7 @@
 #!/usr/bin/env cabal
 {- cabal:
 build-depends:
-    , base          >=4.12
+    , base          >=4.16
     , bytestring    >=0.11
     , Cabal-syntax ^>=3.10  || ^>=3.12
     , pandoc       ^>=3.6.4

--- a/src-control/Control/RefCount.hs
+++ b/src-control/Control/RefCount.hs
@@ -252,9 +252,7 @@ releaseRef ref@Ref{refobj} = do
     decrementRefCounter (getRefCounter refobj)
 
 {-# COMPLETE DeRef #-}
-#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
 {-# INLINE DeRef #-}
-#endif
 -- | Get the object in a 'Ref'. Be careful with retaining the object for too
 -- long, since the object must not be used after 'releaseRef' is called.
 --

--- a/src/Database/LSMTree/Internal/BloomFilterQuery1.hs
+++ b/src/Database/LSMTree/Internal/BloomFilterQuery1.hs
@@ -42,37 +42,13 @@ type RunIx = Int
 --
 newtype RunIxKeyIx = MkRunIxKeyIx Word32
   deriving stock Eq
-#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
   deriving newtype P.Prim
-#else
-instance P.Prim RunIxKeyIx where
-    sizeOfType# _ = 4#
-    alignmentOfType# _ = 4#
-
-    indexByteArray# ba i =
-      MkRunIxKeyIx (P.indexByteArray# ba i)
-    readByteArray# ba i s =
-      case P.readByteArray# ba i s of
-        (# s', w #) -> (# s', MkRunIxKeyIx w #)
-    writeByteArray# ba i (MkRunIxKeyIx w) s =
-      P.writeByteArray# ba i w s
-
-    indexOffAddr# ba i =
-      MkRunIxKeyIx (P.indexOffAddr# ba i)
-    readOffAddr# ba i s =
-      case P.readOffAddr# ba i s of
-        (# s', w #) -> (# s', MkRunIxKeyIx w #)
-    writeOffAddr# ba i (MkRunIxKeyIx w) s =
-      P.writeOffAddr# ba i w s
-#endif
 
 pattern RunIxKeyIx :: RunIx -> KeyIx -> RunIxKeyIx
 pattern RunIxKeyIx r k <- (unpackRunIxKeyIx -> (r, k))
   where
     RunIxKeyIx r k = packRunIxKeyIx r k
-#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
 {-# INLINE RunIxKeyIx #-}
-#endif
 {-# COMPLETE RunIxKeyIx #-}
 
 packRunIxKeyIx :: Int -> Int -> RunIxKeyIx

--- a/src/Database/LSMTree/Internal/IncomingRun.hs
+++ b/src/Database/LSMTree/Internal/IncomingRun.hs
@@ -2,11 +2,6 @@
 {-# LANGUAGE MagicHash     #-}
 {-# LANGUAGE UnboxedTuples #-}
 
-#if !(MIN_VERSION_GLASGOW_HASKELL(9,0,0,0))
--- Fix for ghc 8.10.x with deriving newtype Prim
-{-# LANGUAGE DataKinds     #-}
-#endif
-
 module Database.LSMTree.Internal.IncomingRun (
     IncomingRun (..)
   , MergePolicyForLevel (..)

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -3,11 +3,6 @@
 {-# LANGUAGE UnboxedTuples #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
-#if !(MIN_VERSION_GLASGOW_HASKELL(9,0,0,0))
--- Fix for ghc 8.10.x with deriving newtype Prim
-{-# LANGUAGE DataKinds     #-}
-#endif
-
 -- TODO: establish that this implementation matches up with the ScheduledMerges
 -- prototype. See lsm-tree#445.
 module Database.LSMTree.Internal.MergeSchedule (

--- a/src/Database/LSMTree/Internal/MergingRun.hs
+++ b/src/Database/LSMTree/Internal/MergingRun.hs
@@ -479,9 +479,7 @@ pattern CreditsPair :: SpentCredits -> UnspentCredits -> Int
 pattern CreditsPair sc uc <- (unpackCreditsPair -> (sc, uc))
   where
     CreditsPair sc uc = packCreditsPair sc uc
-#if MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)
 {-# INLINE CreditsPair #-}
-#endif
 {-# COMPLETE CreditsPair #-}
 
 {-# INLINE packCreditsPair #-}

--- a/xxhash/src/XXH3.hs
+++ b/xxhash/src/XXH3.hs
@@ -35,11 +35,7 @@ import           FFI
 
 {-# INLINE withFP #-}
 withFP :: ForeignPtr a -> (P.Ptr a -> IO b) -> IO b
-#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
 withFP = unsafeWithForeignPtr
-#else
-withFP = withForeignPtr
-#endif
 
 -------------------------------------------------------------------------------
 -- OneShot


### PR DESCRIPTION
Recently, `cardano-node` releases have started using `ghc-9.6` instead of `ghc-8.10`. Dropping support for `ghc-8.10` in `lsm-tree` makes our lives a bit easier, because we can use less conditional compilation in our codebase. We'll now support versions `ghc-9.2` and up, because we weren't explicitly supporting `ghc-9.0` anyway