### PR TITLE
fix: remove `Show` instance for `BlobRef`

### DIFF
--- a/src/Database/LSMTree/Internal/Types.hs
+++ b/src/Database/LSMTree/Internal/Types.hs
@@ -4,6 +4,7 @@ module Database.LSMTree.Internal.Types (
     Session (..),
     Table (..),
     BlobRef (..),
+    showsPrecBlobRef,
     Cursor (..),
     ResolveValue (..),
     resolveCompatibility,
@@ -80,9 +81,9 @@ data BlobRef m b
     (Typeable h) =>
     BlobRef !(Unsafe.WeakBlobRef m h)
 
-instance Show (BlobRef m b) where
-  showsPrec :: Int -> BlobRef m b -> ShowS
-  showsPrec d (BlobRef b) = showsPrec d b
+showsPrecBlobRef :: Int -> BlobRef m b -> ShowS
+showsPrecBlobRef p (BlobRef weakBlobRef) =
+  showParen (p>10) (showString "BlobRef " . showsPrec 11 weakBlobRef)
 
 {- |
 A cursor is a stable read-only iterator for a table.

--- a/test/Test/Database/LSMTree/UnitTests.hs
+++ b/test/Test/Database/LSMTree/UnitTests.hs
@@ -4,6 +4,7 @@
 module Test.Database.LSMTree.UnitTests (tests) where
 
 import           Control.Tracer (nullTracer)
+import           Data.Bifunctor (Bifunctor (second))
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import           Data.Foldable (for_)
@@ -47,7 +48,7 @@ unit_blobs info =
       inserts table [("key1", ResolveAsFirst "value1", Just "blob1")]
 
       res <- lookups table ["key1"]
-      info (show res)
+      info (show . fmap (second (const ())) $ res)
 
       case res of
         [FoundWithBlob val bref] -> do


### PR DESCRIPTION
Removing the `Show` instance for `BlobRef` is painless, except for a single use in the unit tests for debugging, which I've fixed by masking out the unshowable `BlobRef` with a unit.