### PR TITLE
feat: hide TableConfig constructor

### DIFF
--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -102,7 +102,15 @@ module Database.LSMTree (
   SnapshotLabel (..),
 
   -- * Table Configuration #table_configuration#
-  TableConfig (..),
+  TableConfig (
+    confMergePolicy,
+    confSizeRatio,
+    confWriteBufferAlloc,
+    confBloomFilterAlloc,
+    confFencePointerIndex,
+    confDiskCachePolicy,
+    confMergeSchedule
+  ),
   defaultTableConfig,
   MergePolicy (LazyLevelling),
   SizeRatio (Four),

--- a/src/Database/LSMTree/Simple.hs
+++ b/src/Database/LSMTree/Simple.hs
@@ -92,7 +92,15 @@ module Database.LSMTree.Simple (
     SnapshotLabel (..),
 
     -- * Table Configuration #table_configuration#
-    TableConfig (..),
+    TableConfig (
+        confMergePolicy,
+        confSizeRatio,
+        confWriteBufferAlloc,
+        confBloomFilterAlloc,
+        confFencePointerIndex,
+        confDiskCachePolicy,
+        confMergeSchedule
+    ),
     MergePolicy (LazyLevelling),
     SizeRatio (Four),
     WriteBufferAlloc (AllocNumEntries),

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -99,6 +99,8 @@ import qualified Database.LSMTree.Class as Class
 import           Database.LSMTree.Extras (showPowersOf)
 import           Database.LSMTree.Extras.Generators (KeyForIndexCompact)
 import           Database.LSMTree.Extras.NoThunks (propNoThunks)
+import qualified Database.LSMTree.Internal.Config as R
+                     (TableConfig (TableConfig))
 import           Database.LSMTree.Internal.Serialise (SerialisedBlob,
                      SerialisedValue)
 import qualified Database.LSMTree.Internal.Types as R.Types

--- a/test/Test/Database/LSMTree/StateMachine/DL.hs
+++ b/test/Test/Database/LSMTree/StateMachine/DL.hs
@@ -13,6 +13,8 @@ import           Control.Tracer
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
 import           Database.LSMTree as R
+import qualified Database.LSMTree.Internal.Config as R
+                     (TableConfig (TableConfig))
 import qualified Database.LSMTree.Model.Session as Model (fromSomeTable, tables)
 import qualified Database.LSMTree.Model.Table as Model (values)
 import           Prelude
@@ -65,7 +67,7 @@ prop_example =
 dl_example :: DL (Lockstep (ModelState R.Table)) ()
 dl_example = do
     -- Create an initial table and fill it with some inserts
-    var3 <- action $ Action Nothing $ NewTableWith (PrettyProxy @((Key, Value, Blob))) (TableConfig {
+    var3 <- action $ Action Nothing $ NewTableWith (PrettyProxy @((Key, Value, Blob))) (R.TableConfig {
           confMergePolicy = LazyLevelling
         , confSizeRatio = Four
         , confWriteBufferAlloc = AllocNumEntries 4


### PR DESCRIPTION
This enables us to add configuration fields in the future without a breaking change.