### PR TITLE
rename: ErrSnapshotNameInvalid -> ErrInvalidSnapshotName

### DIFF
--- a/src/Database/LSMTree/Internal/Paths.hs
+++ b/src/Database/LSMTree/Internal/Paths.hs
@@ -103,7 +103,7 @@ instance IsString SnapshotName where
   fromString = toSnapshotName
 
 data InvalidSnapshotNameError
-  = ErrSnapshotNameInvalid !String
+  = ErrInvalidSnapshotName !String
   deriving stock (Show)
   deriving anyclass (Exception)
 
@@ -173,7 +173,7 @@ isValidSnapshotName str =
 toSnapshotName :: String -> SnapshotName
 toSnapshotName str
   | isValidSnapshotName str = SnapshotName str
-  | otherwise = throw (ErrSnapshotNameInvalid str)
+  | otherwise = throw (ErrInvalidSnapshotName str)
 
 snapshotsDir :: SessionRoot -> FsPath
 snapshotsDir (SessionRoot dir) = dir </> mkFsPath ["snapshots"]

--- a/src/Database/LSMTree/Internal/Unsafe.hs
+++ b/src/Database/LSMTree/Internal/Unsafe.hs
@@ -1420,7 +1420,7 @@ listSnapshots sesh = do
       pure $ catMaybes snaps
   where
     checkSnapshot hfs root s = do
-      -- TODO: rethrow 'ErrSnapshotNameInvalid' as 'ErrSnapshotDirCorrupted'
+      -- TODO: rethrow 'ErrInvalidSnapshotName' as 'ErrSnapshotDirCorrupted'
       let snap = Paths.toSnapshotName s
       -- check that it is a directory
       b <- FS.doesDirectoryExist hfs


### PR DESCRIPTION
This PR renames ErrSnapshotNameInvalid -> ErrInvalidSnapshotName for consistency with other errors.