### PR TITLE
`ScheduledMerges`: make the write buffer size configurable

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -885,6 +885,7 @@ test-suite prototypes-test
   other-modules:
     Test.FormatPage
     Test.ScheduledMerges
+    Test.ScheduledMerges.RunSizes
     Test.ScheduledMergesQLS
 
   build-depends:

--- a/test-prototypes/Main.hs
+++ b/test-prototypes/Main.hs
@@ -4,11 +4,13 @@ import           Test.Tasty
 
 import qualified Test.FormatPage
 import qualified Test.ScheduledMerges
+import qualified Test.ScheduledMerges.RunSizes
 import qualified Test.ScheduledMergesQLS
 
 main :: IO ()
 main = defaultMain $ testGroup "prototypes" [
       Test.FormatPage.tests
     , Test.ScheduledMerges.tests
+    , Test.ScheduledMerges.RunSizes.tests
     , Test.ScheduledMergesQLS.tests
     ]

--- a/test-prototypes/Test/ScheduledMerges/RunSizes.hs
+++ b/test-prototypes/Test/ScheduledMerges/RunSizes.hs
@@ -1,0 +1,96 @@
+module Test.ScheduledMerges.RunSizes (tests) where
+
+import           ScheduledMerges
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.ScheduledMerges.RunSizes" [
+      testProperty "prop_roundTrip_levelNumberMaxRunSize" $
+        \mpl conf ln -> levelNumberInvariant mpl conf ln ==>
+            prop_roundTrip_levelNumberMaxRunSize mpl conf ln
+    , testProperty "prop_roundTrip_runSizeLevelNumber" prop_roundTrip_runSizeLevelNumber
+    , testProperty "prop_maxWriteBufferSize" prop_maxWriteBufferSize
+    ]
+
+-- | Test 'levelNumberToMaxRunSize' roundtrips with 'runSizeToLevelNumber'.
+prop_roundTrip_levelNumberMaxRunSize :: MergePolicyForLevel -> Config -> LevelNo -> Property
+prop_roundTrip_levelNumberMaxRunSize (MergePolicyForLevel mpl) (Config conf) (LevelNo ln) =
+    let n = levelNumberToMaxRunSize mpl conf ln
+        ln' = runSizeToLevelNumber mpl conf n
+    in  ln === ln'
+
+-- | Test that 'runSizeToLevelNumber'roundtrips with 'levelNumberToMaxRunSize'.
+prop_roundTrip_runSizeLevelNumber :: MergePolicyForLevel -> Config -> RunSize -> Property
+prop_roundTrip_runSizeLevelNumber (MergePolicyForLevel mpl) (Config conf) (RunSize n) =
+    let ln = runSizeToLevelNumber mpl conf n
+    in  if ln == 0
+        then 0 === n
+        else let n1 = levelNumberToMaxRunSize mpl conf (ln - 1)
+                 n2 = levelNumberToMaxRunSize mpl conf ln
+             in  property (n1 < n && n <= n2)
+
+-- | Test that 'maxWriteBufferSize' equals the configured 'configMaxWriteBufferSize'.
+prop_maxWriteBufferSize :: Config -> Property
+prop_maxWriteBufferSize (Config conf) =
+    configMaxWriteBufferSize conf === maxWriteBufferSize conf
+
+{-------------------------------------------------------------------------------
+  Generators and shrinkers
+-------------------------------------------------------------------------------}
+
+newtype MergePolicyForLevel = MergePolicyForLevel MergePolicy
+  deriving stock (Show, Eq)
+
+instance Arbitrary MergePolicyForLevel where
+  arbitrary = MergePolicyForLevel <$> elements [MergePolicyTiering, MergePolicyLevelling]
+  shrink (MergePolicyForLevel x) = MergePolicyForLevel <$> case x of
+      MergePolicyTiering   -> []
+      MergePolicyLevelling -> [MergePolicyTiering]
+
+newtype Config = Config LSMConfig
+  deriving stock (Show, Eq)
+
+instance Arbitrary Config where
+  arbitrary = Config <$> do
+      bufSize <- (getSmall <$> arbitrary) `suchThat` (>0)
+      pure $ LSMConfig {
+          configMaxWriteBufferSize = bufSize
+        }
+  shrink (Config LSMConfig{..}) =
+      [ Config LSMConfig{configMaxWriteBufferSize = bufSize'}
+      | bufSize' <- shrink configMaxWriteBufferSize
+      , bufSize' > 0
+      ]
+
+newtype LevelNo = LevelNo Int
+  deriving stock (Show, Eq, Ord)
+  deriving Arbitrary via NonNegative Int
+
+-- | The maximum size of a run on a level scales exponentially with the level
+-- number, and linearly with the maximum write buffer size. There is a
+-- possibility for 'Int' overflow primarily because of the exponential factor,
+-- which would make the @ScheduledMerges@ prototype throw an error if using
+-- @fromIntegerChecked@. The 'noOverflow' predicate makes sure that we do not
+-- generate too large level numbers that could cause such overflows. But this
+-- overflow condition also depends on the maximum write buffer size and merge
+-- policy, so both are arguments to this function as well.
+levelNumberInvariant :: MergePolicyForLevel -> Config -> LevelNo -> Bool
+levelNumberInvariant
+  (MergePolicyForLevel mpl)
+  (Config LSMConfig{configMaxWriteBufferSize})
+  (LevelNo ln)
+  | ln < 0 = False
+  | ln == 0 = True
+  | otherwise = case mpl of
+      MergePolicyTiering ->
+        toInteger configMaxWriteBufferSize * (4 ^ toInteger (pred ln))
+          <= toInteger (maxBound :: Int)
+      MergePolicyLevelling ->
+        toInteger configMaxWriteBufferSize * (4 ^ toInteger ln)
+          <= toInteger (maxBound :: Int)
+
+newtype RunSize = RunSize Int
+  deriving stock (Show, Eq, Ord)
+  deriving Arbitrary via NonNegative Int


### PR DESCRIPTION
We'd need to configure the write buffer size in the `ScheduledMerges` prototype if we want to compare traces for the prototype and real implementation (see #445).

This PR also changes the run size calculations to be somewhat closer to the calculations in the real implementation.

This PR builds on top of #715 to reduce the number of merge conflicts