### PR TITLE
Updating HLint and making all calls to 'sum' & 'product' strict

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -62,6 +62,7 @@
   - { name: "Data.Vector.Primitive", as: "VP" }
   - { name: "Data.Vector.Primitive.Mutable", as: "VPM" }
   # others
+  - { name: "Data.Foldable", as: "Fold" }
   - { name: "Database.LSMTree.Internal.RawBytes", as: "RB"} # if you import Database.LSMTree.Internal.RawByes qualified, it must be as 'RB'
 #   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
 #
@@ -70,8 +71,6 @@
 
 # Add custom hints for this project
 #
-# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
-# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
 - error:
     name: "Use mkPrimVector"
     lhs: "Data.Vector.Primitive.Vector"
@@ -79,5 +78,14 @@
 
 - ignore: { name: "Use mkPrimVector", within: "Database.LSMTree.Internal.Vector" }
 
-# Define some custom infix operators
-# - fixity: infixr 3 ~^#^~
+- warn:
+    name: Strict sum
+    note: Prefer explicit strict fold to lazy sum. Decreases laziness
+    lhs: sum
+    rhs: foldl' (+) 0
+
+- warn:
+    name: Strict product
+    note: Prefer explicit strict fold to lazy product. Decreases laziness
+    lhs: product
+    rhs: foldl' (*) 1

--- a/bench/macro/lsm-tree-bench-bloomfilter.hs
+++ b/bench/macro/lsm-tree-bench-bloomfilter.hs
@@ -13,6 +13,7 @@ import           Data.BloomFilter (Bloom)
 import qualified Data.BloomFilter as Bloom
 import qualified Data.BloomFilter.Hash as Bloom
 import qualified Data.BloomFilter.Mutable as MBloom
+import qualified Data.Foldable as Fold
 import           Data.Time
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
@@ -206,16 +207,16 @@ lsmStyleBloomFilters l1 requestedBitsPerEntry =
 
 totalNumEntries, totalNumBytes :: [BloomFilterSizeInfo] -> Integer
 totalNumEntries filterSizes =
-    sum [ numEntries | (numEntries, _, _, _) <- filterSizes ]
+    Fold.foldl' (+) 0 [ numEntries | (numEntries, _, _, _) <- filterSizes ]
 
 totalNumBytes filterSizes =
-    sum [ nbits | (_,_,nbits,_) <- filterSizes ] `div` 8
+    Fold.foldl' (+) 0 [ nbits | (_,_,nbits,_) <- filterSizes ] `div` 8
 
 totalNumEntriesSanityCheck :: SizeBase -> [BloomFilterSizeInfo] -> Bool
 totalNumEntriesSanityCheck l1 filterSizes =
     totalNumEntries filterSizes
     ==
-    sum [ 2^l1 * sizeFactor | (_, sizeFactor, _, _) <- filterSizes ]
+    Fold.foldl' (+) 0 [ 2^l1 * sizeFactor | (_, sizeFactor, _, _) <- filterSizes ]
 
 
 -- | Input environment for benchmarking 'Bloom.elemMany'.

--- a/bench/macro/lsm-tree-bench-lookups.hs
+++ b/bench/macro/lsm-tree-bench-lookups.hs
@@ -12,6 +12,7 @@ import           Data.Bits ((.&.))
 import           Data.BloomFilter (Bloom)
 import qualified Data.BloomFilter as Bloom
 import qualified Data.BloomFilter.Internal as Bloom
+import qualified Data.Foldable as Fold
 import           Data.Time
 import qualified Data.Vector as V
 import           Data.Vector.Algorithms.Merge as Merge
@@ -295,13 +296,13 @@ lsmStyleRuns l1 =
 -- 111804416
 totalNumEntries :: [RunSizeInfo] -> Int
 totalNumEntries runSizes =
-    sum [ numEntries | (numEntries, _) <- runSizes ]
+    Fold.foldl' (+) 0 [ numEntries | (numEntries, _) <- runSizes ]
 
 totalNumEntriesSanityCheck :: SizeBase -> [RunSizeInfo] -> Bool
 totalNumEntriesSanityCheck l1 runSizes =
     totalNumEntries runSizes
     ==
-    sum [ 2^l1 * sizeFactor | (_, sizeFactor) <- runSizes ]
+    Fold.foldl' (+) 0 [ 2^l1 * sizeFactor | (_, sizeFactor) <- runSizes ]
 
 withFS ::
      (FS.HasFS IO FS.HandleIO -> FS.HasBlockIO IO FS.HandleIO -> IO a)

--- a/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
@@ -5,7 +5,7 @@ import           Criterion.Main (Benchmark, bench, bgroup)
 import qualified Criterion.Main as Cr
 import           Data.Bifunctor (first)
 import qualified Data.BloomFilter.Hash as Hash
-import           Data.Foldable (traverse_)
+import qualified Data.Foldable as Fold
 import           Data.IORef
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
@@ -215,7 +215,7 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
 
     distributed :: Int -> [Double] -> [Int]
     n `distributed` weights =
-      let total = sum weights
+      let total = Fold.foldl' (+) 0 weights
       in [ round (fromIntegral n * w / total)
          | w <- weights
          ]
@@ -382,7 +382,7 @@ mergeEnvCleanup ::
      )
   -> IO ()
 mergeEnvCleanup (tmpDir, _hasFS, hasBlockIO, runs) = do
-    traverse_ releaseRef runs
+    Fold.traverse_ releaseRef runs
     removeDirectoryRecursive tmpDir
     FS.close hasBlockIO
 

--- a/prototypes/FormatPage.hs
+++ b/prototypes/FormatPage.hs
@@ -53,6 +53,7 @@ module FormatPage (
 ) where
 
 import           Data.Bits
+import qualified Data.Foldable as Fold
 import           Data.Function (on)
 import qualified Data.List as List
 import           Data.Maybe (fromJust, fromMaybe)
@@ -312,8 +313,8 @@ encodePage dpgsz kops = do
     } <- calcPageSizeOffsets
            dpgsz
            pageNumKeys pageNumBlobs
-           (sum [ BS.length k | Key   k <- keys ])
-           (sum [ BS.length v | Value v <- values ])
+           (Fold.foldl' (+) 0 [ BS.length k | Key   k <- keys ])
+           (Fold.foldl' (+) 0 [ BS.length v | Value v <- values ])
 
     let pageBlobRefBitmap = [ opHasBlobRef op | (_,op) <- kops ]
         pageOperations    = [ toOperationEnum op | (_,op) <- kops ]

--- a/src-extras/Database/LSMTree/Extras/Random.hs
+++ b/src-extras/Database/LSMTree/Extras/Random.hs
@@ -15,6 +15,7 @@ module Database.LSMTree.Extras.Random (
   ) where
 
 import qualified Data.ByteString as BS
+import qualified Data.Foldable as Fold
 import           Data.List (unfoldr)
 import qualified Data.Set as Set
 import qualified System.Random as R
@@ -74,7 +75,7 @@ withReplacement rng0 n0 sample =
 -------------------------------------------------------------------------------}
 
 -- | Chooses one of the given generators, with a weighted random distribution.
--- The input list must be non-empty, weights should be non-negative, and the sum
+-- The input list must be non-empty, weights should be non-negative, and the Fold.foldl' (+) 0
 -- of weights should be non-zero (i.e., at least one weight should be positive).
 --
 -- Based on the implementation in @QuickCheck@.
@@ -86,7 +87,7 @@ frequency xs0 g
  where
   (i, g') = uniformR (1, tot) g
 
-  tot = sum (map fst xs0)
+  tot = Fold.foldl' (+) 0 (map fst xs0)
 
   pick n ((k,x):xs)
     | n <= k    = x g'

--- a/src/Database/LSMTree/Internal/Chunk.hs
+++ b/src/Database/LSMTree/Internal/Chunk.hs
@@ -22,6 +22,7 @@ import           Prelude hiding (length)
 import           Control.Exception (assert)
 import           Control.Monad.ST.Strict (ST)
 import           Data.ByteString (ByteString)
+import qualified Data.Foldable as Fold
 import           Data.List (scanl')
 import           Data.Primitive.PrimVar (PrimVar, newPrimVar, readPrimVar,
                      writePrimVar)
@@ -79,7 +80,7 @@ feedBaler blocks (Baler buffer remnantSizeRef) = do
     let
 
         inputSize :: Int
-        !inputSize = sum (map length blocks)
+        !inputSize = Fold.foldl' (+) 0 (map length blocks)
 
         totalSize :: Int
         !totalSize = remnantSize + inputSize

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -28,7 +28,7 @@ import           Data.BloomFilter (Bloom)
 import qualified Data.BloomFilter as Bloom
 import           Data.Coerce (coerce)
 import           Data.Either (rights)
-import qualified Data.Foldable as F
+import qualified Data.Foldable as Fold
 import qualified Data.List as List
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -385,7 +385,7 @@ instance Arbitrary a => Arbitrary (SmallList a) where
   shrink = fmap SmallList . shrink . getSmallList
 
 conjoinF :: (Testable prop, Foldable f) => f prop -> Property
-conjoinF = conjoin . F.toList
+conjoinF = conjoin . Fold.toList
 
 ioopPageSpan :: IOOp s h -> PageSpan
 ioopPageSpan ioop =

--- a/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -9,6 +9,7 @@ import           Codec.CBOR.Read
 import           Codec.CBOR.Write
 import           Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Foldable as Fold
 import           Data.Proxy
 import qualified Data.Text as Text
 import           Data.Typeable
@@ -460,7 +461,7 @@ genPendingTreeMerge gas =
               0 -> 1
               depth ->
                 let sub = recursiveOptions branching $ depth - 1
-                in  sum $ (sub ^) <$> [ 0 .. branching ]
+                in  Fold.foldl' (+) 0 $ (sub ^) <$> [ 0 .. branching ]
             probability e =
               let basis = recursiveOptions branchingLimit nextGas
               in  (basis ^ e, vectorOf e subGen)


### PR DESCRIPTION
A pretty simple update to the `.hlint.yaml` file to warn about calls to `sum` and `product` and suggest instead using a strict fold. 

Additionally, the PR updates the code-base to make all the suggested replacements.