### PR TITLE
`StateMachine`: fix a test failure where an injected error is swallowed

### DIFF
--- a/test/Test/Database/LSMTree/Internal/WriteBufferReader/FS.hs
+++ b/test/Test/Database/LSMTree/Internal/WriteBufferReader/FS.hs
@@ -22,7 +22,7 @@ import qualified System.FS.Sim.MockFS as MockFS
 import qualified System.FS.Sim.Stream as Stream
 import           Test.Tasty
 import           Test.Tasty.QuickCheck as QC
-import           Test.Util.FS
+import           Test.Util.FS as FS
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.WriteBufferReader.FS" [
@@ -70,11 +70,7 @@ prop_fault_WriteBufferReader (NoCleanupErrors readErrors) rdata =
 
     -- TODO: fix, see the TODO on readDiskPage
     readErrors' = readErrors {
-          hGetBufSomeE = Stream.filter (not . isFsReachedEOF) (hGetBufSomeE readErrors)
+          hGetBufSomeE = Stream.filter (not . isFsReachedEOFError) (hGetBufSomeE readErrors)
         }
 
-    isFsReachedEOF Nothing = False
-    isFsReachedEOF (Just (Left e)) = case e of
-        FsReachedEOF -> True
-        _            -> False
-    isFsReachedEOF (Just (Right _)) = False
+    isFsReachedEOFError = maybe False (either isFsReachedEOF (const False))

--- a/test/Test/Database/LSMTree/StateMachine.hs
+++ b/test/Test/Database/LSMTree/StateMachine.hs
@@ -67,12 +67,7 @@ import           Data.Bifunctor (Bifunctor (..))
 import           Data.Constraint (Dict (..))
 import           Data.Either (partitionEithers)
 import           Data.Kind (Type)
-#if MIN_VERSION_base(4,20,0)
-import           Data.List (nub)
-#else
-import           Data.List (foldl', nub)
-                 -- foldl' is included in the Prelude from base 4.20 onwards
-#endif
+import qualified Data.List as List
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
@@ -2503,7 +2498,8 @@ updateStats action@(Action _merrs action') lookUp modelBefore modelAfter result 
                              -> Model.Table k v b -> Stats -> Stats
     insertParentTableDerived ptblVars tbl stats =
       let uptblIds :: [Model.TableID] -- the set of ultimate parent table ids
-          uptblIds = nub [ uptblId
+          uptblIds = List.nub [
+                           uptblId
                          | ptblVar <- ptblVars
                            -- immediate and ultimate parent table id:
                          , let iptblId = getTableId (lookUp ptblVar)
@@ -2558,9 +2554,10 @@ updateStats action@(Action _merrs action') lookUp modelBefore modelAfter result 
         updateLastActionLog :: GVar Op (WrapTable h IO k v b) -> Stats
         updateLastActionLog tableVar =
           stats {
-            dupTableActionLog = foldl' (flip (Map.alter extendLog))
-                                       (dupTableActionLog stats)
-                                       (parentTable stats Map.! thid)
+            dupTableActionLog = List.foldl'
+                                  (flip (Map.alter extendLog))
+                                  (dupTableActionLog stats)
+                                  (parentTable stats Map.! thid)
           }
           where
             thid = getTableId (lookUp tableVar)

--- a/test/Test/Database/LSMTree/StateMachine/DL.hs
+++ b/test/Test/Database/LSMTree/StateMachine/DL.hs
@@ -34,6 +34,7 @@ import qualified Test.QuickCheck.StateModel.Lockstep.Defaults as QLS
 import           Test.QuickCheck.StateModel.Variables
 import           Test.Tasty (TestTree, testGroup, withResource)
 import qualified Test.Tasty.QuickCheck as QC
+import           Test.Util.FS
 import           Test.Util.PrettyProxy
 
 tests :: TestTree
@@ -246,14 +247,10 @@ arbitraryErrors = do
     -- TODO: there is one case where an 'FsReachEOF' error is swallowed. Is that
     -- valid behaviour, or should we change it?
     filterErrors errs = errs {
-          hGetBufSomeE = Stream.filter (not . isFsReachedEOF) (hGetBufSomeE errs)
+          hGetBufSomeE = Stream.filter (not . isFsReachedEOFError) (hGetBufSomeE errs)
         }
 
-    isFsReachedEOF Nothing = False
-    isFsReachedEOF (Just (Left e)) = case e of
-        FsReachedEOF -> True
-        _            -> False
-    isFsReachedEOF (Just (Right _)) = False
+    isFsReachedEOFError = maybe False (either isFsReachedEOF (const False))
 
 -- | Shrink each error stream and all error stream elements.
 --

--- a/test/Test/Util/FS.hs
+++ b/test/Test/Util/FS.hs
@@ -38,6 +38,8 @@ module Test.Util.FS (
   , noHCloseE
   , noRemoveFileE
   , noRemoveDirectoryRecursiveE
+  , filterHGetBufSomeE
+  , isFsReachedEOF
     -- * Arbitrary
   , FsPathComponent (..)
   , fsPathComponentFsPath
@@ -480,6 +482,15 @@ noRemoveFileE errs = errs { removeFileE = Stream.empty }
 
 noRemoveDirectoryRecursiveE :: Errors -> Errors
 noRemoveDirectoryRecursiveE errs = errs { removeDirectoryRecursiveE = Stream.empty }
+
+filterHGetBufSomeE :: (Maybe (Either FsErrorType Partial) -> Bool) -> Errors -> Errors
+filterHGetBufSomeE p e = e {
+      hGetBufSomeE = Stream.filter p (hGetBufSomeE e)
+    }
+
+isFsReachedEOF :: FsErrorType -> Bool
+isFsReachedEOF FsReachedEOF = True
+isFsReachedEOF _            = False
 
 {-------------------------------------------------------------------------------
   Arbitrary


### PR DESCRIPTION
Failure found in https://github.com/IntersectMBO/lsm-tree/actions/runs/15140425104/job/42562757365?pr=683

The test failure can be reproduced using the following seed:

```
cabal run lsm-tree-test -- \
  -p '$0=="lsm-tree.Test.Database.LSMTree.StateMachine.propLockstep_RealImpl_MockFS_IO"' \
  --quickcheck-replay="(SMGen 11798857835899383018 1561550946174790845,97)"
```

The test fails because an injected error with an `FsReachedEOF` type is
swallowed by the `openTableFromSnapshot` public API function. We fix the test
failure (for now) by not generating errors of that type.

At some point we should think of a more principled approach to this type of
swallowed error. `FsReachedEOF` is not an error type that any of the `HasFS`
primitives can throw in practice when using the real file system, but `fs-sim`
error injection *can* throw this error type. Maybe `fs-sim` shouldn't inject
this type of error.