### PR TITLE
Bump `s-r-p` for `blockio-uring`

### DIFF
--- a/blockio/src-linux/System/FS/BlockIO/Async.hs
+++ b/blockio/src-linux/System/FS/BlockIO/Async.hs
@@ -100,7 +100,7 @@ submitIO hasFS ioctx ioops = do
           IOOpRead{}  -> "IOOpRead"
           IOOpWrite{} -> "IOOpWrite"
 
-ioopConv :: IOOp RealWorld HandleIO -> IO (I.IOOp IO)
+ioopConv :: IOOp RealWorld HandleIO -> IO (I.IOOp RealWorld)
 ioopConv (IOOpRead h off buf bufOff c) = handleFd h >>= \fd ->
     pure (I.IOOpRead  fd off buf (unBufferOffset bufOff) c)
 ioopConv (IOOpWrite h off buf bufOff c) = handleFd h >>= \fd ->

--- a/cabal.project.blockio-uring
+++ b/cabal.project.blockio-uring
@@ -2,5 +2,4 @@ if(os(linux))
   source-repository-package
     type: git
     location: https://github.com/well-typed/blockio-uring
-    -- liburing-2.9
-    tag: c01dbf68de237a63b8b3ed9d357526fb6eeb6b1c
+    tag: c7b550063b5ce2c859db50b2ebf66d41a4f24844

--- a/src-extras/Database/LSMTree/Extras/Random.hs
+++ b/src-extras/Database/LSMTree/Extras/Random.hs
@@ -10,12 +10,15 @@ module Database.LSMTree.Extras.Random (
   , withReplacement
     -- * Sampling from multiple distributions
   , frequency
+    -- * Shuffling
+  , shuffle
     -- * Generators for specific data types
   , randomByteStringR
   ) where
 
 import qualified Data.ByteString as BS
-import           Data.List (unfoldr)
+import           Data.List (sortBy, unfoldr)
+import           Data.Ord (comparing)
 import qualified Data.Set as Set
 import qualified System.Random as R
 import           System.Random (StdGen, Uniform, uniform, uniformR)
@@ -92,6 +95,18 @@ frequency xs0 g
     | n <= k    = x g'
     | otherwise = pick (n-k) xs
   pick _ _  = error "frequency: pick used with empty list"
+
+{-------------------------------------------------------------------------------
+  Shuffling
+-------------------------------------------------------------------------------}
+
+-- | Create a random permutation of a list.
+--
+-- Based on the implementation in @QuickCheck@.
+shuffle :: [a] -> StdGen -> [a]
+shuffle xs g =
+    let ns = R.randoms @Int g
+    in  map snd (sortBy (comparing fst) (zip ns xs))
 
 {-------------------------------------------------------------------------------
   Generators for specific data types


### PR DESCRIPTION
And as a bonus, use a random shuffle implementation with a fixed seed in the micro-benchmarks. This should make them a little more reproducible. I made these changes when experimenting with unboxed `IOOp` vectors, but in the end we scrapped unboxed `IOOp` vectors. It's still useful to include