### PR TITLE
Update `hackage-index-state`s for GHA lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
     - name: 🛠️ Setup HLint
       uses: haskell-actions/hlint-setup@v2
       with:
-        version: "3.8"
+        version: "3.10"
 
     - name: 🎗️ Lint with HLint
       run: ./scripts/lint-hlint.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         # The index-state is fixed to enable caching and ensure that the version
         # regardless of the current state of Hackage head.
         # If you want a newer version of cabal-fmt, use a more recent time.
-        hackage-index-state: "2024-04-27T12:31:04Z"
+        hackage-index-state: "2025-05-22T00:00:00Z"
 
     - name: 🎗️ Lint with cabal-fmt
       run: ./scripts/format-cabal-fmt.sh && git diff --exit-code
@@ -286,7 +286,7 @@ jobs:
         # The index-state is fixed to enable caching and ensure that the version
         # regardless of the current state of Hackage head.
         # If you want a newer version of cabal-fmt, use a more recent time.
-        hackage-index-state: "2024-04-27T12:31:04Z"
+        hackage-index-state: "2025-05-22T00:00:00Z"
 
     - name: 🎗️ Lint with generate-readme
       run: git diff --exit-code

--- a/scripts/lint-hlint.sh
+++ b/scripts/lint-hlint.sh
@@ -3,7 +3,7 @@
 export LC_ALL=C.UTF-8
 
 # Check for hlint
-hlint_expect_version="3.8"
+hlint_expect_version="3.10"
 if [ "${hlint}" = "" ]; then
     hlint=$(which "hlint")
     if [ "${hlint}" = "" ]; then


### PR DESCRIPTION
They're over a year old, so it probably doesn't hurt to set them to a more recent date.

Also: update the `hlint` version