### PR TITLE
Hide `TraceMerge` from the public API unless compiling in debug mode

### DIFF
--- a/cabal.project.debug
+++ b/cabal.project.debug
@@ -7,7 +7,7 @@ package lsm-tree
   ghc-options: -fno-ignore-asserts
 
   -- there are no cpp-options in cabal.project files
-  ghc-options: -optP -DNO_IGNORE_ASSERTS
+  ghc-options: -optP -DNO_IGNORE_ASSERTS -DDEBUG_TRACES
 
 package blockio
   -- apply this to all components


### PR DESCRIPTION
The `TraceMerge` datatype for trace messages is not very polished, and it exposes quite a few internal datatypes. For now, I think it's best to hide `MergeTrace` from the public API.

We do this using CPP using a macro flag, so that we can still inspect the `MergeTrace` if we want to in development.

One other approach I tried was to create a dedicated trace message datatype for the public API, so that we can map the internal trace types to the public trace types. However, this is quite boilerplatey and also incurs a slight performance cost in allocations. I've also tried type-level tags to differentiate between different severity levels of traces (e.g., debug vs. info), but I'm expecting that to also incur some performance cost.

Since we're planning to change `MergeTrace` at some point anyway, I thought CPP would be the path of least resistance for now.

