### PR TITLE
Remove internal trace types from the public API

### DIFF
--- a/src/Database/LSMTree.hs
+++ b/src/Database/LSMTree.hs
@@ -189,19 +189,9 @@ module Database.LSMTree (
   SessionTrace (..),
   TableTrace (..),
   CursorTrace (..),
-  MergeTrace (..),
   SessionId (..),
   TableId (..),
   CursorId (..),
-  AtLevel (..),
-  LevelNo (..),
-  NumEntries (..),
-  RunNumber (..),
-  MergePolicyForLevel (..),
-  LevelMergeType (..),
-  RunParams (..),
-  RunDataCaching (..),
-  IndexType (..),
 ) where
 
 import           Control.Concurrent.Class.MonadMVar.Strict (MonadMVar)
@@ -227,24 +217,18 @@ import qualified Database.LSMTree.Internal.BlobRef as Internal
 import           Database.LSMTree.Internal.Config
                      (BloomFilterAlloc (AllocFixed, AllocRequestFPR),
                      DiskCachePolicy (..), FencePointerIndexType (..),
-                     LevelNo (..), MergeBatchSize (..), MergePolicy (..),
-                     MergeSchedule (..), SizeRatio (..), TableConfig (..),
-                     WriteBufferAlloc (..), defaultTableConfig)
+                     MergeBatchSize (..), MergePolicy (..), MergeSchedule (..),
+                     SizeRatio (..), TableConfig (..), WriteBufferAlloc (..),
+                     defaultTableConfig)
 import           Database.LSMTree.Internal.Config.Override
                      (TableConfigOverride (..), noTableConfigOverride)
-import           Database.LSMTree.Internal.Entry (NumEntries (..))
 import qualified Database.LSMTree.Internal.Entry as Entry
-import           Database.LSMTree.Internal.Merge (LevelMergeType (..))
-import           Database.LSMTree.Internal.MergeSchedule (AtLevel (..),
-                     MergePolicyForLevel (..), MergeTrace (..))
 import           Database.LSMTree.Internal.Paths (SnapshotName,
                      isValidSnapshotName, toSnapshotName)
 import           Database.LSMTree.Internal.Range (Range (..))
 import           Database.LSMTree.Internal.RawBytes (RawBytes (..))
-import           Database.LSMTree.Internal.RunBuilder (IndexType (..),
-                     RunDataCaching (..), RunParams (..))
 import           Database.LSMTree.Internal.RunNumber (CursorId (..),
-                     RunNumber (..), TableId (..))
+                     TableId (..))
 import qualified Database.LSMTree.Internal.Serialise as Internal
 import           Database.LSMTree.Internal.Serialise.Class (SerialiseKey (..),
                      SerialiseKeyOrderPreserving, SerialiseValue (..),


### PR DESCRIPTION
They are hidden behind a debug flag now.