### PR TITLE
Move `IsList` and `IsString` instances for `RawBytes` to extras

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -729,6 +729,7 @@ library extras
     Database.LSMTree.Extras.NoThunks
     Database.LSMTree.Extras.Orphans
     Database.LSMTree.Extras.Random
+    Database.LSMTree.Extras.RawBytes
     Database.LSMTree.Extras.ReferenceImpl
     Database.LSMTree.Extras.RunData
     Database.LSMTree.Extras.UTxO

--- a/src-extras/Database/LSMTree/Extras/RawBytes.hs
+++ b/src-extras/Database/LSMTree/Extras/RawBytes.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Database.LSMTree.Extras.RawBytes () where
+
+import           Data.Word
+import           Database.LSMTree.Internal.RawBytes
+import           GHC.Exts
+
+{- |
+@'fromList'@: \(O(n)\).
+
+@'toList'@: \(O(n)\).
+-}
+instance IsList RawBytes where
+  type Item RawBytes = Word8
+
+  fromList :: [Item RawBytes] -> RawBytes
+  fromList = pack
+
+  toList :: RawBytes -> [Item RawBytes]
+  toList = unpack
+
+{- |
+@'fromString'@: \(O(n)\).
+
+__Warning:__ 'fromString' truncates multi-byte characters to octets. e.g. \"枯朶に烏のとまりけり秋の暮\" becomes \"�6k�nh~�Q��n�\".
+-}
+instance IsString RawBytes where
+    fromString = fromByteString . fromString

--- a/src/Database/LSMTree/Internal/RawBytes.hs
+++ b/src/Database/LSMTree/Internal/RawBytes.hs
@@ -129,28 +129,6 @@ instance Hashable RawBytes where
 hash :: Word64 -> RawBytes -> Word64
 hash salt (RawBytes (VP.Vector off len ba)) = hashByteArray ba off len salt
 
-{- |
-@'fromList'@: \(O(n)\).
-
-@'toList'@: \(O(n)\).
--}
-instance IsList RawBytes where
-  type Item RawBytes = Word8
-
-  fromList :: [Item RawBytes] -> RawBytes
-  fromList = pack
-
-  toList :: RawBytes -> [Item RawBytes]
-  toList = unpack
-
-{- |
-@'fromString'@: \(O(n)\).
-
-__Warning:__ 'fromString' truncates multi-byte characters to octets. e.g. \"枯朶に烏のとまりけり秋の暮\" becomes \"�6k�nh~�Q��n�\".
--}
-instance IsString RawBytes where
-    fromString = fromByteString . fromString
-
 {-------------------------------------------------------------------------------
   Accessors
 -------------------------------------------------------------------------------}

--- a/test/Test/Database/LSMTree/Internal/RawPage.hs
+++ b/test/Test/Database/LSMTree/Internal/RawPage.hs
@@ -22,6 +22,7 @@ import           Test.Tasty.HUnit (testCase, (@=?))
 import           Test.Tasty.QuickCheck
 import           Test.Util.RawPage
 
+import           Database.LSMTree.Extras.RawBytes ()
 import qualified Database.LSMTree.Extras.ReferenceImpl as Ref
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import qualified Database.LSMTree.Internal.Entry as Entry


### PR DESCRIPTION
I think their main use case is as utilities for testing -- using them in production code would probably be bad for performance, and there are probably not a lot of use cases for it.

I also think the `Semigroup` and `Monoid` instances are iffy, but it's too much of hassle to remove those now.

