### PR TITLE
Allow io-classes 1.8.0.1

### DIFF
--- a/blockio/blockio.cabal
+++ b/blockio/blockio.cabal
@@ -74,8 +74,8 @@ library
   build-depends:
     , base        >=4.16  && <4.22
     , deepseq     ^>=1.4  || ^>=1.5
-    , fs-api      ^>=0.3
-    , io-classes  ^>=1.6  || ^>=1.7
+    , fs-api      ^>=0.4
+    , io-classes  ^>=1.6  || ^>=1.7 || ^>=1.8.0.1
     , primitive   ^>=0.9
     , vector      ^>=0.13
 
@@ -131,9 +131,9 @@ library sim
     , base                   >=4.16      && <4.22
     , blockio
     , bytestring             ^>=0.11.4.0 || ^>=0.12.1.0
-    , fs-api                 ^>=0.3
-    , fs-sim                 ^>=0.3
-    , io-classes             ^>=1.6      || ^>=1.7
+    , fs-api                 ^>=0.4
+    , fs-sim                 ^>=0.4
+    , io-classes             ^>=1.6      || ^>=1.7      || ^>=1.8.0.1
     , io-classes:strict-stm
     , primitive              ^>=0.9
 

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -1,7 +1,7 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
   -- unix-2.8.7.0
-  , hackage.haskell.org 2025-05-10T14:12:28Z
+  , hackage.haskell.org 2025-06-03T08:53:00Z
 
 packages:
   .
@@ -27,11 +27,11 @@ allow-newer: regression-simple:base
 -- we could add a conditional on (+serialblockio) to remove this import automatically.
 import: cabal.project.blockio-uring
 
--- bugfix hGetBufExactly and hGetBufExactlyAt
+-- bugfix hGetBufExactly and hGetBufExactlyAt, io-classes-1.8.0.1
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/fs-sim
-  tag: 55efd82e10c2b2d339bdfdc29d8d4bd8484150ba
+  tag: 77e4809fe897330397ddbeaf88ef4bb47477b543
   subdir:
     fs-api
     fs-sim

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -586,8 +586,8 @@ library
     , crc32c                  ^>=0.2.1
     , deepseq                 ^>=1.4      || ^>=1.5
     , filepath
-    , fs-api                  ^>=0.3
-    , io-classes              ^>=1.6      || ^>=1.7
+    , fs-api                  ^>=0.4
+    , io-classes              ^>=1.6      || ^>=1.7      || ^>=1.8.0.1
     , io-classes:strict-mvar
     , lsm-tree:bloomfilter
     , lsm-tree:control
@@ -1163,7 +1163,7 @@ library control
   build-depends:
     , base                   >=4.16 && <4.22
     , deepseq                ^>=1.4 || ^>=1.5
-    , io-classes             ^>=1.6 || ^>=1.7
+    , io-classes             ^>=1.6 || ^>=1.7 || ^>=1.8.0.1
     , io-classes:strict-stm
     , primitive              ^>=0.9
 


### PR DESCRIPTION
This PR allows building `lsm-tree` with `io-classes-1.8.0.1`, which is required to start integrating `lsm-tree` into [IntersectMBO/ouroboros-consensus](https://github.com/IntersectMBO/ouroboros-consensus).

# Checklist

- [ ] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

