### PR TITLE
Make `InvalidSnapshotNameError` an instance of `Eq`

### DIFF
--- a/src/Database/LSMTree/Internal/Paths.hs
+++ b/src/Database/LSMTree/Internal/Paths.hs
@@ -104,7 +104,7 @@ instance IsString SnapshotName where
 
 data InvalidSnapshotNameError
   = ErrInvalidSnapshotName !String
-  deriving stock (Show)
+  deriving stock (Show, Eq)
   deriving anyclass (Exception)
 
 -- | Check if a 'String' would be a valid snapshot name.


### PR DESCRIPTION
This pull request makes `InvalidSnapshotNameError` and instance of `Eq`,
because apparently all other error types are instances of `Eq` already.
