### PR TITLE
GHA: fix caching in `lint-generate-readme` job

### DIFF
--- a/.github/actions/generate-readme/action.yml
+++ b/.github/actions/generate-readme/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
     description: "Version of cabal"
   hackage-index-state:
-    required: false
+    required: true
     description: "Timestamp for Hackage index"
 runs:
   using: composite
@@ -25,10 +25,13 @@ runs:
       id: cache-cabal
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: generate-readme-${{ runner.os }}-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-cabal-${{ steps.setup-haskell.outputs.cabal-version }}
+        key: generate-readme-${{ runner.os }}-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-cabal-${{ steps.setup-haskell.outputs.cabal-version }}-input-state-${{ inputs.hackage-index-state }}
 
     - name: 🛠️ Generate README.md
-      run: ./scripts/generate-readme.hs
+      run: |
+        cabal run \
+          ${{ inputs.hackage-index-state && format('--index-state={0}', inputs.hackage-index-state) }} \
+          ./scripts/generate-readme.hs
       shell: sh
 
     - name: 💾 Save Cabal dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,9 +296,6 @@ jobs:
       with:
         ghc-version: ${{ env.DEFAULT_GHC_VERSION }}
         cabal-version: ${{ env.DEFAULT_CABAL_VERSION }}
-        # The index-state is fixed to enable caching and ensure that the version
-        # regardless of the current state of Hackage head.
-        # If you want a newer version of cabal-fmt, use a more recent time.
         hackage-index-state: "2025-05-22T00:00:00Z"
 
     - name: 🎗️ Lint with generate-readme


### PR DESCRIPTION
We should use the index state

