### PR TITLE
`ScheduledMerges`: fix a bug in `maxPhysicalDebt` and `invariant`

### DIFF
--- a/src-prototypes/ScheduledMerges.hs
+++ b/src-prototypes/ScheduledMerges.hs
@@ -353,7 +353,7 @@ invariant conf@LSMConfig{..} (LSMContent _ levels ul) = do
         -- levelling run becomes too large and is promoted, in that case
         -- initially there's no merge, but it is still represented as an
         -- 'IncomingRun', using 'Single'. Thus there are no other resident runs.
-        MergePolicyLevelling -> assertST $ null rs
+        MergePolicyLevelling -> assertST $ null rs && null ls
         -- Runs in tiering levels usually fit that size, but they can be one
         -- larger, if a run has been held back (creating a (T+1)-way merge).
         MergePolicyTiering   -> assertST $ all (\r -> runToLevelNumber MergePolicyTiering conf r `elem` [ln, ln+1]) rs
@@ -383,18 +383,19 @@ invariant conf@LSMConfig{..} (LSMContent _ levels ul) = do
             (_, CompletedMerge r) ->
               assertST $ runToLevelNumber MergePolicyLevelling conf r <= ln+1
 
-            -- An ongoing merge for levelling should have T incoming runs of
-            -- the right size for the level below (or slightly larger due to
-            -- holding back underfull runs), and 1 run from this level,
-            -- but the run from this level can be of almost any size for the
-            -- same reasons as above. Although if this is the first merge for
-            -- a new level, it'll have only T runs.
+            -- An ongoing merge for levelling should have T incoming runs of the
+            -- right size for the level below (or slightly larger due to holding
+            -- back underfull runs), and at most 1 run from this level. The run
+            -- from this level can be of almost any size for the same reasons as
+            -- above. Although if this is the first merge for a new level, it'll
+            -- have only T runs.
             (_, OngoingMerge _ rs _) -> do
               assertST $ length rs `elem` [configSizeRatio, configSizeRatio + 1]
               assertST $ all (\r -> runSize r > 0) rs  -- don't merge empty runs
               let incoming = take configSizeRatio rs
               let resident = drop configSizeRatio rs
               assertST $ all (\r -> runToLevelNumber MergePolicyTiering conf r `elem` [ln-1, ln]) incoming
+              assertST $ length resident `elem` [0, 1]
               assertST $ all (\r -> runToLevelNumber MergePolicyLevelling conf r <= ln+1) resident
 
         MergePolicyTiering ->
@@ -421,13 +422,19 @@ invariant conf@LSMConfig{..} (LSMContent _ levels ul) = do
             (_, CompletedMerge r, MergeMidLevel) ->
               assertST $ runToLevelNumber MergePolicyTiering conf r `elem` [ln-1, ln, ln+1]
 
-            -- An ongoing merge for tiering should have T incoming runs of
-            -- the right size for the level below, and at most 1 run held back
-            -- due to being too small (which would thus also be of the size of
-            -- the level below).
+            -- An ongoing merge for tiering should have T incoming runs of the
+            -- right size for the level below (or slightly larger due to holding
+            -- back underfull runs), and at most 1 run held back due to being
+            -- too small (which would thus also be of the size of the level
+            -- below).
             (_, OngoingMerge _ rs _, _) -> do
-              assertST $ length rs == configSizeRatio || length rs == configSizeRatio + 1
-              assertST $ all (\r -> runToLevelNumber MergePolicyTiering conf r == ln-1) rs
+              assertST $ length rs `elem` [configSizeRatio, configSizeRatio + 1]
+              assertST $ all (\r -> runSize r > 0) rs  -- don't merge empty runs
+              let incoming = take configSizeRatio rs
+              let heldBack = drop configSizeRatio rs
+              assertST $ all (\r -> runToLevelNumber MergePolicyTiering conf r `elem` [ln-1, ln]) incoming
+              assertST $ length heldBack `elem` [0, 1]
+              assertST $ all (\r -> runToLevelNumber MergePolicyTiering conf r == ln-1) heldBack
 
 -- We don't make many assumptions apart from what the types already enforce.
 -- In particular, there are no invariants on the progress of the merges,
@@ -1499,15 +1506,24 @@ newLevelMerge tr conf@LSMConfig{..} level mergePolicy mergeType rs = do
     -- such that we pay off the physical and nominal debts at the same time.
     --
     -- We can bound the worst case physical debt: this is the maximum amount of
-    -- steps a merge at this level could need. Note that for levelling this is
-    -- includes the single run in the current level.
+    -- steps a merge at this level could need. See the
+    -- 'expectedMergingRunLengths' where-clause of the 'invariant' function for
+    -- the full reasoning.
     maxPhysicalDebt =
       case mergePolicy of
         MergePolicyLevelling ->
-          configSizeRatio * levelNumberToMaxRunSize MergePolicyTiering conf (level-1)
+          -- Incoming runs, which may be slightly overfull with respect to the
+          -- previous level
+          configSizeRatio * levelNumberToMaxRunSize MergePolicyTiering conf level
+              -- The single run that was already on this level
             + levelNumberToMaxRunSize MergePolicyLevelling conf level
         MergePolicyTiering   ->
-          length rs * levelNumberToMaxRunSize MergePolicyTiering conf (level-1)
+          -- Incoming runs, which may be slightly overfull with respect to the
+          -- previous level
+          configSizeRatio * levelNumberToMaxRunSize MergePolicyTiering conf level
+              -- Held back run that is underfull with respect to the current
+              -- level
+            + levelNumberToMaxRunSize MergePolicyTiering conf (level - 1)
 
 -------------------------------------------------------------------------------
 -- MergingTree abstraction

--- a/src/Database/LSMTree/Internal/MergeSchedule.hs
+++ b/src/Database/LSMTree/Internal/MergeSchedule.hs
@@ -959,6 +959,8 @@ supplyCredits conf deposit levels =
       -- supplyCreditsIncomingRun could easily return the supplied credits
       -- before & after, which may be useful for tracing.
 
+-- | See 'maxPhysicalDebt' in 'newLevelMerge' in the 'ScheduledMerges'
+-- prototype.
 maxMergeDebt :: TableConfig -> MergePolicyForLevel -> LevelNo -> MergeDebt
 maxMergeDebt TableConfig {
                confWriteBufferAlloc = AllocNumEntries (NumEntries -> bufferSize),
@@ -968,16 +970,13 @@ maxMergeDebt TableConfig {
     case mergePolicy of
       LevelLevelling ->
         MergeDebt . MergeCredits $
-          sizeRatio * maxRunSizeTiering sizeRatio bufferSize (pred ln)
+          sizeRatio * maxRunSizeTiering sizeRatio bufferSize ln
                     + maxRunSizeLevelling sizeRatio bufferSize ln
 
       LevelTiering   ->
         MergeDebt . MergeCredits $
-          maxRuns * maxRunSizeTiering sizeRatio bufferSize (pred ln)
-        where
-          -- We can hold back underfull runs, so sometimes the are n+1 runs,
-          -- rather than the typical n at a tiering level (n = LSM size ratio).
-          maxRuns = sizeRatio + 1
+          sizeRatio * maxRunSizeTiering sizeRatio bufferSize ln
+                    + maxRunSizeTiering sizeRatio bufferSize (pred ln)
 
 -- | The nominal debt equals the minimum of credits we will supply before we
 -- expect the merge to complete. This is the same as the number of updates

--- a/test-prototypes/Test/ScheduledMergesQLS.hs
+++ b/test-prototypes/Test/ScheduledMergesQLS.hs
@@ -5,7 +5,6 @@
 
 module Test.ScheduledMergesQLS (tests) where
 
-import           Control.Monad (void)
 import           Control.Monad.ST
 import           Control.Tracer (Tracer, nullTracer)
 import           Data.Constraint (Dict (..))
@@ -19,11 +18,9 @@ import           Prelude hiding (lookup)
 import           ScheduledMerges as LSM
 
 import           Test.QuickCheck
-import qualified Test.QuickCheck.DynamicLogic as DL
 import           Test.QuickCheck.StateModel hiding (lookUpVar)
 import           Test.QuickCheck.StateModel.Lockstep hiding (ModelOp)
 import qualified Test.QuickCheck.StateModel.Lockstep.Defaults as Lockstep
-import           Test.QuickCheck.StateModel.Lockstep.Op.Identity (Op (OpId))
 import qualified Test.QuickCheck.StateModel.Lockstep.Run as Lockstep
 import           Test.Tasty
 import           Test.Tasty.QuickCheck (testProperty)
@@ -31,31 +28,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 tests :: TestTree
 tests = testGroup "Test.ScheduledMergesQLS" [
       testProperty "ScheduledMerges vs model" $ mapSize (*10) prop_LSM  -- still <10s
-    , testProperty "propRegression_issue755" $
-        let scenario = do
-              var1 <- DL.action $ ANew (LSMConfig {configMaxWriteBufferSize = 1, configSizeRatio = 2})
-              void $ DL.action $ AInsert (unsafeMkGVar var1 OpId) (Right (K 0)) (V 0) Nothing
-              var16 <- DL.action $ AUnions [unsafeMkGVar var1 OpId]
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 0)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 1)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 0)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 0)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 1)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 2)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 0)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 0)) (V 0) Nothing
-              void $ DL.action $ AInsert (unsafeMkGVar var16 OpId) (Right (K 0)) (V 0) Nothing
-        in DL.forAllDL scenario prop_LSM
-        {-
-          The scenario above is a manually modified version of output produced by:
-
-          cabal run prototypes-test -- \
-            --quickcheck-replay="(SMGen 3702524042292853426 14344574976030159473,92)" \
-            -p '/ScheduledMerges vs model/'
-        -}
     ]
-
-instance DL.DynLogicModel (Lockstep Model) where
 
 -- TODO: add tagging, e.g. how often ASupplyUnion makes progress or completes a
 -- union merge.


### PR DESCRIPTION
Resolves #755 

The prototype had a bug in the calculation of `maxPhysicalDebt` where it was not
considering that incoming runs that are inputs to a merge can be overfull. Runs
can be overfull because we hold back runs that are underfull. However, runs
should only be overfull in the sense that they are too large for their current
level. They can't be overfull with respect to the next level too.

This same bug occurred in `invariant`, where a similar change was made to
consider overfull runs properly.

Some other minor changes to `invariant` were made to make the checked invariant
a little more precise.



Note that the assertion failures only started appearing on CI runs after #716 and #717 were merged. I realised that it's a relatively rare scenario to create underfull and overfull runs, but less so if the size ratio and write buffer size are small. That's probably why we only just now started seeing the assertion failures.