### PR TITLE
`ScheduledMerges`: some renaming and new trace messages

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -1147,6 +1147,7 @@ library prototypes
     , bytestring
     , containers
     , contra-tracer
+    , primitive
     , QuickCheck
     , transformers
 
@@ -1168,6 +1169,8 @@ test-suite prototypes-test
     , containers
     , contra-tracer
     , lsm-tree:prototypes
+    , mtl
+    , primitive
     , QuickCheck
     , quickcheck-dynamic
     , quickcheck-lockstep

--- a/src-prototypes/ScheduledMerges.hs
+++ b/src-prototypes/ScheduledMerges.hs
@@ -33,7 +33,7 @@ module ScheduledMerges (
     newWith,
     LookupResult (..),
     lookup, lookups,
-    Op,
+    Entry,
     Update (..),
     update, updates,
     insert, inserts,
@@ -192,7 +192,7 @@ class Show t => IsMergeType t where
 -- | Different types of merges created as part of a regular (non-union) level.
 --
 -- A last level merge behaves differently from a mid-level merge: last level
--- merges can actually remove delete operations, whereas mid-level merges must
+-- merges can actually remove delete entries, whereas mid-level merges must
 -- preserve them. This is orthogonal to the 'MergePolicyForLevel'.
 data LevelMergeType = MergeMidLevel | MergeLastLevel
   deriving stock (Eq, Show)
@@ -275,8 +275,8 @@ pattern PendingMerge :: TreeMergeType
                      -> PendingMerge s
 pattern PendingMerge mt prs ts <- (pendingContent -> (mt, prs, ts))
 
-type Run    = Map Key Op
-type Buffer = Map Key Op
+type Run    = Map Key Entry
+type Buffer = Map Key Entry
 
 bufferToRun :: Buffer -> Run
 bufferToRun = id
@@ -287,7 +287,7 @@ runSize = Map.size
 bufferSize :: Buffer -> Int
 bufferSize = Map.size
 
-type Op = Update Value Blob
+type Entry = Update Value Blob
 
 newtype Key = K Int
   deriving stock (Eq, Ord, Show)
@@ -897,7 +897,7 @@ mergek t =
 -- | Combines two entries that have been performed after another. Therefore, the
 -- newer one overwrites the old one (or modifies it for 'Mupsert'). Only take a
 -- blob from the left entry.
-combine :: Op -> Op -> Op
+combine :: Entry -> Entry -> Entry
 combine new_ old = case new_ of
     Insert{}  -> new_
     Delete{}  -> new_
@@ -912,7 +912,7 @@ combine new_ old = case new_ of
 -- from the left entry.
 --
 -- See 'MergeUnion'.
-combineUnion :: Op -> Op -> Op
+combineUnion :: Entry -> Entry -> Entry
 combineUnion Delete         (Mupsert v)  = Insert v Nothing
 combineUnion Delete         old          = old
 combineUnion (Mupsert u)    Delete       = Insert u Nothing
@@ -1005,17 +1005,17 @@ data Update v b =
   | Delete
   deriving stock (Eq, Show)
 
-updates :: Tracer (ST s) Event -> LSM s -> [(Key, Op)] -> ST s ()
+updates :: Tracer (ST s) Event -> LSM s -> [(Key, Entry)] -> ST s ()
 updates tr lsm = mapM_ (uncurry (update tr lsm))
 
-update :: Tracer (ST s) Event -> LSM s -> Key -> Op -> ST s ()
-update tr (LSMHandle scr conf lsmr) k op = do
+update :: Tracer (ST s) Event -> LSM s -> Key -> Entry -> ST s ()
+update tr (LSMHandle scr conf lsmr) k entry = do
     sc <- readSTRef scr
     content@(LSMContent wb ls unionLevel) <- readSTRef lsmr
     modifySTRef' scr (+1)
     supplyCreditsLevels (NominalCredit 1) ls
     invariant conf content
-    let wb' = Map.insertWith combine k op wb
+    let wb' = Map.insertWith combine k entry wb
     if bufferSize wb' >= maxWriteBufferSize conf
       then do
         ls' <- increment tr sc conf (bufferToRun wb') ls unionLevel
@@ -1174,11 +1174,11 @@ checkedUnionDebt tree debtRef = do
 -- Lookups
 --
 
-type LookupAcc = Maybe Op
+type LookupAcc = Maybe Entry
 
-updateAcc :: (Op -> Op -> Op) -> LookupAcc -> Op -> LookupAcc
+updateAcc :: (Entry -> Entry -> Entry) -> LookupAcc -> Entry -> LookupAcc
 updateAcc _ Nothing     old = Just old
-updateAcc f (Just new_) old = Just (f new_ old)  -- acc has more recent Op
+updateAcc f (Just new_) old = Just (f new_ old)  -- acc has more recent Entry
 
 mergeAcc :: TreeMergeType -> [LookupAcc] -> LookupAcc
 mergeAcc mt = foldl (updateAcc com) Nothing . catMaybes
@@ -1219,8 +1219,8 @@ doLookup wb runs ul k = do
 -- In a real implementation, this would take all keys at once and be in IO.
 lookupBatch :: LookupAcc -> Key -> [Run] -> LookupAcc
 lookupBatch acc k rs =
-    let ops = [op | r <- rs, Just op <- [Map.lookup k r]]
-    in foldl (updateAcc combine) acc ops
+    let entries = [entry | r <- rs, Just entry <- [Map.lookup k r]]
+    in foldl (updateAcc combine) acc entries
 
 data LookupTree a = LookupBatch a
                   | LookupNode TreeMergeType [LookupTree a]
@@ -1277,7 +1277,7 @@ foldLookupTree = \case
 --
 
 -- | Nominal credit is the credit supplied to each level as we insert update
--- operations, one credit per update operation inserted.
+-- entries, one credit per update entry inserted.
 --
 -- Nominal credit must be supplied up to the 'NominalDebt' to ensure the merge
 -- is complete.
@@ -1285,14 +1285,14 @@ foldLookupTree = \case
 -- Nominal credits are a similar order of magnitude to physical credits (see
 -- 'Credit') but not the same, and we have to scale linearly to convert between
 -- them. Physical credits are the actual number of inputs to the merge, which
--- may be somewhat more or somewhat less than the number of update operations
+-- may be somewhat more or somewhat less than the number of update entries
 -- we will insert before we need the merge to be complete.
 --
 newtype NominalCredit = NominalCredit Credit
   deriving stock Show
 
 -- | The nominal debt for a merging run is the worst case (minimum) number of
--- update operations we expect to insert before we expect the merge to be
+-- update entries we expect to insert before we expect the merge to be
 -- complete.
 --
 -- We require that an equal amount of nominal credit is supplied before we can

--- a/test-prototypes/Test/ScheduledMerges.hs
+++ b/test-prototypes/Test/ScheduledMerges.hs
@@ -177,11 +177,11 @@ test_merge_again_with_incoming =
 --
 
 -- | Supplying enough credits for the remaining debt completes the union merge.
-prop_union :: [[(LSM.Key, LSM.Op)]] -> Property
-prop_union kopss = length (filter (not . null) kopss) > 1 QC.==>
+prop_union :: [[(LSM.Key, LSM.Entry)]] -> Property
+prop_union kess = length (filter (not . null) kess) > 1 QC.==>
     QC.ioProperty $ runWithTracer $ \tr ->
       stToIO $ do
-        ts <- traverse (mkTable tr) kopss
+        ts <- traverse (mkTable tr) kess
         t <- LSM.unions ts
 
         debt@(UnionDebt x) <- LSM.remainingUnionDebt t
@@ -199,7 +199,7 @@ prop_union kopss = length (filter (not . null) kopss) > 1 QC.==>
         MLeaf{} -> True
         MNode{} -> False
 
-mkTable :: Tracer (ST s) Event -> [(LSM.Key, LSM.Op)] -> ST s (LSM s)
+mkTable :: Tracer (ST s) Event -> [(LSM.Key, LSM.Entry)] -> ST s (LSM s)
 mkTable tr ks = do
     t <- LSM.new
     LSM.updates tr t ks

--- a/test-prototypes/Test/ScheduledMerges/RunSizes.hs
+++ b/test-prototypes/Test/ScheduledMerges/RunSizes.hs
@@ -1,6 +1,7 @@
 module Test.ScheduledMerges.RunSizes (tests) where
 
-import           ScheduledMerges
+import qualified ScheduledMerges as Proto
+import           ScheduledMerges hiding (MergePolicyForLevel)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -54,14 +55,14 @@ prop_runSizeFitsInLevel (MergePolicyForLevel mpl) (Config conf) (LevelNo ln) (Ru
   Generators and shrinkers
 -------------------------------------------------------------------------------}
 
-newtype MergePolicyForLevel = MergePolicyForLevel MergePolicy
+newtype MergePolicyForLevel = MergePolicyForLevel Proto.MergePolicyForLevel
   deriving stock (Show, Eq)
 
 instance Arbitrary MergePolicyForLevel where
-  arbitrary = MergePolicyForLevel <$> elements [MergePolicyTiering, MergePolicyLevelling]
+  arbitrary = MergePolicyForLevel <$> elements [Proto.LevelTiering, Proto.LevelLevelling]
   shrink (MergePolicyForLevel x) = MergePolicyForLevel <$> case x of
-      MergePolicyTiering   -> []
-      MergePolicyLevelling -> [MergePolicyTiering]
+      Proto.LevelTiering   -> []
+      Proto.LevelLevelling -> [Proto.LevelTiering]
 
 newtype Config = Config LSMConfig
   deriving stock (Show, Eq)
@@ -105,10 +106,10 @@ levelNumberInvariant
   | ln < 0 = False
   | ln == 0 = True
   | otherwise = case mpl of
-      MergePolicyTiering ->
+       Proto.LevelTiering ->
         toInteger configMaxWriteBufferSize * (toInteger configSizeRatio ^ toInteger (pred ln))
           <= toInteger (maxBound :: Int)
-      MergePolicyLevelling ->
+       Proto.LevelLevelling ->
         toInteger configMaxWriteBufferSize * (toInteger configSizeRatio ^ toInteger ln)
           <= toInteger (maxBound :: Int)
 


### PR DESCRIPTION
Builds on top of #763 to prevent merge conflicts

The renamings were some changes I had lying around on an older branch, and the new trace messages I added to troubleshoot #755. 