### PR TITLE
Allow IOG's contra-tracer

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -613,7 +613,7 @@ library
     , bytestring              ^>=0.11.4.0 || ^>=0.12.1.0
     , cborg                   ^>=0.2.10.0
     , containers              ^>=0.6      || ^>=0.7
-    , contra-tracer           ^>=0.2
+    , contra-tracer           ^>=0.1      || ^>=0.2
     , crc32c                  ^>=0.2.1
     , deepseq                 ^>=1.4      || ^>=1.5
     , filepath

--- a/src/Database/LSMTree/Internal/Unsafe.hs
+++ b/src/Database/LSMTree/Internal/Unsafe.hs
@@ -202,11 +202,16 @@ data TableTrace =
   | TraceSupplyUnionCredits UnionCredits
   deriving stock Show
 
+#if MIN_VERSION_contra_tracer(0,2,0)
 contramapTraceMerge :: Monad m => Tracer m TableTrace -> Tracer m (AtLevel MergeTrace)
 #ifdef DEBUG_TRACES
 contramapTraceMerge t = TraceMerge `contramap` t
 #else
 contramapTraceMerge t = traceMaybe (const Nothing) t
+#endif
+#else
+contramapTraceMerge :: Applicative m => Tracer m TableTrace -> Tracer m (AtLevel MergeTrace)
+contramapTraceMerge _t = nullTracer
 #endif
 
 data CursorTrace =

--- a/test/Test/Database/LSMTree.hs
+++ b/test/Test/Database/LSMTree.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -134,11 +135,16 @@ prop_openSession_restoreSession =
 -- | A tracer that records session open, session new, and session restore
 -- messages in a mutable variable.
 mkSessionOpenModeTracer :: IORef [String] -> Tracer IO LSMTreeTrace
-mkSessionOpenModeTracer var = Tracer $ emit $ \case
-    TraceOpenSession{} -> modifyIORef var ("Open" :)
-    TraceNewSession{} -> modifyIORef var ("New" :)
-    TraceRestoreSession{} -> modifyIORef var ("Restore" :)
-    _ -> pure ()
+mkSessionOpenModeTracer var =
+  Tracer $
+#if MIN_VERSION_contra_tracer(0,2,0)
+    emit $
+#endif
+      \case
+        TraceOpenSession{} -> modifyIORef var ("Open" :)
+        TraceNewSession{} -> modifyIORef var ("New" :)
+        TraceRestoreSession{} -> modifyIORef var ("Restore" :)
+        _ -> pure ()
 
 {-------------------------------------------------------------------------------
   Session: happy path


### PR DESCRIPTION
# Description

A first attempt at integrating this into ouroboros-consensus showed a misalign in the `contra-tracer` version. Changes were sufficiently simple that I think it is reasonable to put some CPPs here and there and be done while someone else figures out how to reconcile our stack with the Hackage contra-tracer.

# Checklist

- [X] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

