### PR TITLE
Allow filepath 1.4

### DIFF
--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -627,7 +627,7 @@ library core
     , contra-tracer           ^>=0.1      || ^>=0.2
     , crc32c                  ^>=0.2.1
     , deepseq                 ^>=1.4      || ^>=1.5
-    , filepath                ^>=1.5
+    , filepath                ^>=1.4      || ^>=1.5
     , fs-api                  ^>=0.4
     , io-classes              ^>=1.6      || ^>=1.7      || ^>=1.8.0.1
     , io-classes:strict-mvar


### PR DESCRIPTION
# Description

If some package fixes the dependency of `ghc` then all base libraries are fixed. By allowing filepath 1.4 we open up the possibility of depending on `ghc` 9.6.7 and still using the `lsm-tree` package.

# Checklist

- [ ] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

