### PR TITLE
update Internal.Arena with modern record extensions instead of RecordWildCards #811

### DIFF
--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Revision history for `lsm-tree`
 
-<<<<<<< feature/811-modern-record-extensions
-=======
 ## Unreleased
 
 * PATCH: Support `io-classes ^>=1.9` and `^>=1.10`. See PR [#819](https://github.com/IntersectMBO/lsm-tree/pull/819).
 
->>>>>>> main
 
 ## 1.0.0.1 -- 2025-12-03
 


### PR DESCRIPTION
Pilot for  #811

Replaced `RecordWildCards` with the three modern record extensions recommended
in the [Haskell Unfolder episode #45](https://www.youtube.com/watch?v=9hrDm7xDpig).

This is a pilot pr applying the modern record extensions to one internal module
(`Database.LSMTree.Internal.Arena`) to get feedback on the approach before
expanding to the full codebase.

## Changes

**`Database.LSMTree.Internal.Arena`**
- Removed `{-# LANGUAGE RecordWildCards #-}`
- Added `DuplicateRecordFields`, `NoFieldSelectors`, `OverloadedRecordDot`
- Replaced `Arena {..}` wildcard deconstruction with explicit dot-access
  (`arena.curr`, `arena.free`, `arena.full`) in:
  - `scrambleArena`
  - `resetArena`
  - `allocateFromArena'`
- Replaced `pure Arena {..}` construction with explicit field assignment

No logic change — just refactored with modern record extensions.

## Testing

- `cabal build lsm-tree:lib:core`  : builds successfully
- `cabal test lsm-tree-test --pattern "Arena"` → 2/2 tests pass ✅

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e28a604d-f19e-492e-9ee7-0e620d686079" />
cabal build lsm-tree:lib:core && cabal test lsm-tree-test --test-option=--pattern --test-option="Arena"