### PR TITLE
ScheduledMerges: allow empty levels

### DIFF
--- a/lsm-tree/src-prototypes/ScheduledMerges.hs
+++ b/lsm-tree/src-prototypes/ScheduledMerges.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE UnboxedTuples   #-}
 
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -Wno-partial-fields #-}
 
 -- | A prototype of an LSM with explicitly scheduled incremental merges.
@@ -924,7 +923,7 @@ newMergingRun mergeType runs = do
     assertST $ length runs > 1
     -- in some cases, no merging is required at all
     (debt, state) <- case filter (\r -> runSize r > 0) runs of
-      []  -> let (r:_) = runs -- just reuse the empty input
+      []  -> let r = head runs -- just reuse the empty input
               in pure (runSize r, CompletedMerge r)
       [r] -> pure (runSize r, CompletedMerge r)
       rs  -> do
@@ -1369,11 +1368,12 @@ newtype NominalDebt = NominalDebt Credit
 -- inserting without calling 'supplyUnionCredits'.
 supplyCreditsLevels :: NominalCredit -> Levels s -> ST s ()
 supplyCreditsLevels nominalDeposit =
-  traverse_ $ \(Level ir _rs) -> do
-    case ir of
-      Single{} -> pure ()
-      Merging _mp nominalDebt nominalCreditVar
-              mr@(MergingRun _  physicalDebt _) -> do
+  traverse_ $ \lvl -> do
+    case lvl of
+      EmptyLevel -> pure ()
+      Level Single{} _ -> pure ()
+      Level (Merging _mp nominalDebt nominalCreditVar
+                     mr@(MergingRun _  physicalDebt _)) _ -> do
 
         nominalCredit       <- depositNominalCredit
                                  nominalDebt nominalCreditVar nominalDeposit
@@ -1675,8 +1675,9 @@ contentToMergingTree (LSMContent wb ls ul) =
       | writeBufferSize wb == 0 = Nothing
       | otherwise               = Just (PreExistingRun (flushWriteBuffer wb))
 
-    levels = flip concatMap ls $ \(Level ir rs) ->
-               toPreExisting ir : map PreExistingRun rs
+    levels = flip concatMap ls $ \case
+               EmptyLevel  -> []
+               Level ir rs -> toPreExisting ir : map PreExistingRun rs
 
     toPreExisting (Single         r) = PreExistingRun r
     toPreExisting (Merging _ _ _ mr) = PreExistingMergingRun mr


### PR DESCRIPTION
Builds on top of #814.

This can generally be useful, but the main motivation now is to allow migration of the union level into the regular levels as soon as the merging tree is completed.

So far, we always required an `IncomingRun` to be present on each level, but already had a special case for where this could be a plain `Run` that doesn't require any merging. Instead, we can make the presence of the `IncomingRun` itself optional, which allows us to have no runs on a level at all. The resulting changes are minor, but we should perhaps think about more suitable terms for `IncomingRun` and/or the `Maybe IncomingRun` (which might deserve its own data type), at least in the real implementation).