### PR TITLE
ScheduledMerges: migrate union level early (as soon as merging tree is completed)

### DIFF
--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -1099,6 +1099,7 @@ test-suite prototypes-test
     Test.FormatPage
     Test.ScheduledMerges
     Test.ScheduledMerges.RunSizes
+    Test.ScheduledMergesDL
     Test.ScheduledMergesQLS
 
   build-depends:

--- a/lsm-tree/src-prototypes/ScheduledMerges.hs
+++ b/lsm-tree/src-prototypes/ScheduledMerges.hs
@@ -175,7 +175,16 @@ data Level s = Level !(IncomingRun s) ![Run]
 data IncomingRun s = Merging !MergePolicyForLevel
                              !NominalDebt !(STRef s NominalCredit)
                              !(MergingRun LevelMergeType s)
-                   | Single  !Run
+                   | Single  !SingleRunOrigin !Run
+
+-- | Additional information about the origin of a 'Single' run. This allows us
+-- to have stronger invariants.
+data SingleRunOrigin = FromWriteBuffer
+                     | FromLevellingLevel
+                       -- | A former union level that was completed (merged down
+                       -- to a single run) and became the last regular level.
+                     | FromMigratedUnion
+  deriving stock (Eq, Show)
 
 -- | The merge policy for a LSM level can be either tiering or levelling.
 -- In this design we use levelling for the last level, and tiering for
@@ -363,7 +372,7 @@ invariant conf@LSMConfig{..} (LSMContent _ levels ul) = do
 
     levelsInvariant !ln (Level ir rs : ls) = do
       mrs <- case ir of
-        Single r ->
+        Single _ r ->
           pure (CompletedMerge r)
         Merging mp _ _ (MergingRun mt _ ref) -> do
           assertST $ ln > 1  -- no merges on level 1
@@ -422,10 +431,16 @@ invariant conf@LSMConfig{..} (LSMContent _ levels ul) = do
             -- 2. when the union level gets migrated.
             --
             -- In the latter case, it can be arbitrarily small.
-            (Single r, m) -> do
+            (Single origin r, m) -> do
               assertST $ case m of CompletedMerge{} -> True
                                    OngoingMerge{}   -> False
-              assertST $ runToLevelNumber LevelLevelling conf r <= ln
+              case origin of
+                FromWriteBuffer ->
+                  assertST False  -- we don't flush to levelling levels
+                FromLevellingLevel ->
+                  assertST $ runToLevelNumber LevelLevelling conf r == ln
+                FromMigratedUnion ->
+                  assertST $ runToLevelNumber LevelLevelling conf r <= ln
 
             -- A completed merge for levelling can be of almost any size at all!
             -- It can be smaller, due to deletions in the last level. But it
@@ -452,9 +467,10 @@ invariant conf@LSMConfig{..} (LSMContent _ levels ul) = do
           case (ir, mrs, mergeTypeForLevel ls ul) of
             -- A single incoming run (which thus didn't need merging) must be
             -- of the expected size already
-            (Single r, m, _) -> do
+            (Single origin r, m, _) -> do
               assertST $ case m of CompletedMerge{} -> True
                                    OngoingMerge{}   -> False
+              assertST $ origin == FromWriteBuffer
               assertST $ runToLevelNumber LevelTiering conf r == ln
 
             -- A completed last level run can be of almost any smaller size due
@@ -1267,7 +1283,8 @@ migrateUnionLevel tr sc conf ls ul@(Union t _) =
                                -- Run must not be too large for the level.
               ]
         let emptyLevels = replicate (levelNo - 1 - length ls) EmptyLevel
-        let levels = ls ++ emptyLevels ++ [Level (Single r) []]
+        let level = Level (Single FromMigratedUnion r) []
+        let levels = ls ++ emptyLevels ++ [level]
         assertST $ length levels == levelNo
         traceWith tr $ EventAt sc levelNo $ UnionLevelMigratedEvent r
         pure (levels, NoUnion)
@@ -1531,7 +1548,7 @@ increment tr sc conf run0 ls0 ul = do
 
     go !ln incoming (Level ir rs : ls) = do
       r <- case ir of
-        Single r -> do
+        Single _ r -> do
           traceWith tr' $ SingleRunCompletedEvent r
           pure r
         Merging mergePolicy _ _ mr -> do
@@ -1602,10 +1619,18 @@ newLevelMerge :: Tracer (ST s) EventDetail
               -> LSMConfig
               -> Int -> MergePolicyForLevel -> LevelMergeType
               -> [Run] -> ST s (IncomingRun s)
-newLevelMerge tr _ _ _ _ [r] =  do
+newLevelMerge tr _ ln mergePolicy _ [r] = do
+    origin <-
+      if ln <= 1
+        then do
+          assertST $ ln == 1
+          pure FromWriteBuffer
+        else do
+          assertST $ mergePolicy == LevelLevelling
+          pure FromLevellingLevel
     traceWith tr $ NewSingleRunEvent r
-    pure (Single r)
-newLevelMerge tr conf@LSMConfig{..} level mergePolicy mergeType rs = do
+    pure (Single origin r)
+newLevelMerge tr conf@LSMConfig{..} ln mergePolicy mergeType rs = do
     mergingRun@(MergingRun _ physicalDebt _) <- newMergingRun mergeType rs
     traceWith tr NewLevelMergeEvent {
                    mergePolicy,
@@ -1621,7 +1646,7 @@ newLevelMerge tr conf@LSMConfig{..} level mergePolicy mergeType rs = do
     -- The nominal debt equals the minimum of credits we will supply before we
     -- expect the merge to complete. This is the same as the number of updates
     -- in a run that gets moved to this level.
-    nominalDebt = NominalDebt (levelNumberToMaxRunSize LevelTiering conf level)
+    nominalDebt = NominalDebt (levelNumberToMaxRunSize LevelTiering conf ln)
 
     -- The physical debt is the number of actual merge steps we will need to
     -- perform before the merge is complete. This is always the sum of the
@@ -1639,16 +1664,16 @@ newLevelMerge tr conf@LSMConfig{..} level mergePolicy mergeType rs = do
         LevelLevelling ->
           -- Incoming runs, which may be slightly overfull with respect to the
           -- previous level
-          configSizeRatio * levelNumberToMaxRunSize LevelTiering conf level
+          configSizeRatio * levelNumberToMaxRunSize LevelTiering conf ln
               -- The single run that was already on this level
-            + levelNumberToMaxRunSize LevelLevelling conf level
+            + levelNumberToMaxRunSize LevelLevelling conf ln
         LevelTiering   ->
           -- Incoming runs, which may be slightly overfull with respect to the
           -- previous level
-          configSizeRatio * levelNumberToMaxRunSize LevelTiering conf level
+          configSizeRatio * levelNumberToMaxRunSize LevelTiering conf ln
               -- Held back run that is underfull with respect to the current
               -- level
-            + levelNumberToMaxRunSize LevelTiering conf (level - 1)
+            + levelNumberToMaxRunSize LevelTiering conf (ln - 1)
 
 -------------------------------------------------------------------------------
 -- MergingTree abstraction
@@ -1726,7 +1751,7 @@ contentToMergingTree (LSMContent wb ls ul) =
                EmptyLevel  -> []
                Level ir rs -> toPreExisting ir : map PreExistingRun rs
 
-    toPreExisting (Single         r) = PreExistingRun r
+    toPreExisting (Single  _      r) = PreExistingRun r
     toPreExisting (Merging _ _ _ mr) = PreExistingMergingRun mr
 
     trees = case ul of
@@ -1914,7 +1939,7 @@ flattenLevel (Level ir rs) = (++ rs) <$> flattenIncomingRun ir
 
 flattenIncomingRun :: IncomingRun s -> ST s [Run]
 flattenIncomingRun = \case
-    Single r         -> pure [r]
+    Single _ r       -> pure [r]
     Merging _ _ _ mr -> flattenMergingRun mr
 
 flattenMergingRun :: MergingRun t s -> ST s [Run]
@@ -1980,7 +2005,7 @@ dumpRepresentation (LSMHandle _ _ _conf lsmr) = do
 dumpLevel :: Level s -> ST s LevelRepresentation
 dumpLevel EmptyLevel =
     pure (Nothing, [])
-dumpLevel (Level (Single r) rs) =
+dumpLevel (Level (Single _ r) rs) =
     pure (Nothing, (r:rs))
 dumpLevel (Level (Merging mp nd ncv (MergingRun mt _ ref)) rs) = do
     mrs <- readSTRef ref

--- a/lsm-tree/src-prototypes/ScheduledMerges.hs
+++ b/lsm-tree/src-prototypes/ScheduledMerges.hs
@@ -415,12 +415,17 @@ invariant conf@LSMConfig{..} (LSMContent _ levels ul) = do
       case mergePolicyForLevel ln ls ul of
         LevelLevelling -> do
           case (ir, mrs) of
-            -- A single incoming run (which thus didn't need merging) must be
-            -- of the expected size range already
+            -- A single incoming run (which didn't need merging) in a levelling
+            -- level can be created one of two ways:
+            -- 1. when a levelling level is full, so the run gets promoted to
+            --    the new last level
+            -- 2. when the union level gets migrated.
+            --
+            -- In the latter case, it can be arbitrarily small.
             (Single r, m) -> do
               assertST $ case m of CompletedMerge{} -> True
                                    OngoingMerge{}   -> False
-              assertST $ runToLevelNumber LevelLevelling conf r == ln
+              assertST $ runToLevelNumber LevelLevelling conf r <= ln
 
             -- A completed merge for levelling can be of almost any size at all!
             -- It can be smaller, due to deletions in the last level. But it
@@ -1060,20 +1065,23 @@ update :: Tracer (ST s) Event -> LSM s -> Key -> Entry -> ST s ()
 update tr (LSMHandle tid scr conf lsmr) k entry = do
     traceWith tr $ UpdateEvent tid k entry
     sc <- readSTRef scr
-    content@(LSMContent wb ls unionLevel) <- readSTRef lsmr
+    content@(LSMContent wb ls ul) <- readSTRef lsmr
     modifySTRef' scr (+1)
     supplyCreditsLevels (NominalCredit 1) ls
     invariant conf content
     let wb' = insertWriteBuffer k entry wb
     if writeBufferSize wb' >= maxWriteBufferSize conf
       then do
+        -- The merging tree might have become completed. If so, we want to
+        -- migrate it now, so it can become part of new merges.
+        (ls', ul') <- migrateUnionLevel (LevelEvent tid >$< tr) sc conf ls ul
         let r = flushWriteBuffer wb'
-        ls' <- increment (LevelEvent tid >$< tr) sc conf r ls unionLevel
-        let content' = LSMContent emptyWriteBuffer ls' unionLevel
+        ls'' <- increment (LevelEvent tid >$< tr) sc conf r ls' ul'
+        let content' = LSMContent emptyWriteBuffer ls'' ul'
         invariant conf content'
         writeSTRef lsmr content'
       else
-        writeSTRef lsmr (LSMContent wb' ls unionLevel)
+        writeSTRef lsmr (LSMContent wb' ls ul)
 
 supplyMergeCredits :: LSM s -> NominalCredit -> ST s ()
 supplyMergeCredits (LSMHandle _ scr conf lsmr) credits = do
@@ -1151,12 +1159,17 @@ newtype UnionDebt = UnionDebt Debt
 
 -- | Return the current union debt. This debt can be reduced until it is paid
 -- off using 'supplyUnionCredits'.
+--
+-- As long as there is a union level, there is a non-zero debt. This makes it
+-- clear that 'supplyUnionCredits' should still be called to trigger migration,
+-- even if the merging tree itself has been completed. This becomes necessary
+-- when the tree has been completed by operations on another table via sharing.
 remainingUnionDebt :: LSM s -> ST s UnionDebt
 remainingUnionDebt (LSMHandle _ _ _conf lsmr) = do
     LSMContent _ _ ul <- readSTRef lsmr
     UnionDebt <$> case ul of
       NoUnion      -> pure 0
-      Union tree d -> checkedUnionDebt tree d
+      Union tree d -> (+1) <$> checkedUnionDebt tree d
 
 -- | Credits are used to pay off 'UnionDebt', completing a 'union' in the
 -- process.
@@ -1177,43 +1190,28 @@ newtype UnionCredits = UnionCredits Credit
 -- This function returns any surplus of union credits as /leftover/ credits when
 -- a union has finished. In particular, if the returned number of credits is
 -- non-negative, then the union is finished.
-supplyUnionCredits :: LSM s -> UnionCredits -> ST s UnionCredits
-supplyUnionCredits (LSMHandle _ scr conf lsmr) (UnionCredits credits)
+supplyUnionCredits :: Tracer (ST s) Event -> LSM s -> UnionCredits -> ST s UnionCredits
+supplyUnionCredits tr (LSMHandle tid scr conf lsmr) (UnionCredits credits)
   | credits <= 0 = pure (UnionCredits 0)
   | otherwise = do
-    content@(LSMContent _ _ ul) <- readSTRef lsmr
+    content@(LSMContent wb ls ul) <- readSTRef lsmr
     UnionCredits <$> case ul of
       NoUnion ->
         pure credits
       Union tree debtRef -> do
+        invariant conf content
+        sc <- readSTRef scr
         modifySTRef' scr (+1)
         _debt <- checkedUnionDebt tree debtRef  -- just to make sure it's checked
         c' <- supplyCreditsMergingTree credits tree
         debt' <- checkedUnionDebt tree debtRef
         when (debt' > 0) $
           assertST $ c' == 0  -- should have spent these credits
-        invariant conf content
+        (ls', ul') <- migrateUnionLevel (LevelEvent tid >$< tr) sc conf ls ul
+        let content' = LSMContent wb ls' ul'
+        invariant conf content'
+        writeSTRef lsmr content'
         pure c'
-
--- TODO: At some point the completed merging tree should to moved into the
--- regular levels, so it can be merged with other runs and last level merges can
--- happen again to drop deletes. Also, lookups then don't need to handle the
--- merging tree any more. There are two possible strategies:
---
--- 1. As soon as the merging tree completes, move the resulting run to the
---    regular levels. However, its size does generally not fit the last level,
---    which requires relaxing 'invariant' and adjusting 'increment'.
---
---    If the run is much larger than the resident and incoming runs of the last
---    level, it should also not be included into a merge yet, as that merge
---    would be expensive, but offer very little potential for compaction (the
---    run from the merging tree is already compacted after all). So it needs to
---    be bumped to the next level instead.
---
--- 2. Initially leave the completed run in the union level. Then every time a
---    new last level merge is created in 'increment', check if there is a
---    completed run in the union level with a size that fits the new merge. If
---    yes, move it over.
 
 -- | Like 'remainingDebtMergingTree', but additionally asserts that the debt
 -- never increases.
@@ -1224,6 +1222,52 @@ checkedUnionDebt tree debtRef = do
     assertST $ debt <= storedDebt
     writeSTRef debtRef debt
     pure debt
+
+-- | At some point the completed merging tree should become part of the regular
+-- levels, so it can be merged with other runs. Otherwise, we could never
+-- perform a last level merge, which is especially important for compaction, as
+-- it allows us to drop deletes. Also, lookups then don't need to consider the
+-- merging tree any more.
+--
+-- We can do this as soon as the tree is completed by appending a new regular
+-- level containing only the run that resulted from the tree merge. If the
+-- run is too large to fit into the level directly after the existing ones, we
+-- first add empty levels.
+migrateUnionLevel :: forall s. Tracer (ST s) (EventAt EventDetail)
+                  -> Counter -> LSMConfig -> Levels s -> UnionLevel s
+                  -> ST s (Levels s, UnionLevel s)
+migrateUnionLevel _ _ _ ls NoUnion = do
+    -- nothing to do
+    pure (ls, NoUnion)
+migrateUnionLevel tr sc conf ls ul@(Union t _) =
+    getCompletedMergingTree t >>= \case
+      Nothing ->
+        -- Still in progress, leave it.
+        pure (ls, ul)
+      Just r -> do
+        -- Before migration, there is usually a last regular (i.e. non-union)
+        -- level, which uses tiering. We could potentially add the completed
+        -- union (or rather the run it resulted in) directly to the resident
+        -- tiering runs of that last regular level, but that would clash with
+        -- some invariants. Instead, we always create a new last level, which
+        -- only makes a small difference, but keeps the invariants simpler.
+        --
+        -- Also note even empty runs get migrated. This doesn't violate any
+        -- invariants, as levelling levels can already contain empty runs.
+        -- Dropping the run would be more complicated since the previous level
+        -- then suddenly becomes the last one while potentially still containing
+        -- midlevel merges.
+        let levelNo = maximum
+              [ 2              -- First level is tiering, don't migrate there.
+              , length ls + 1  -- Must come after existing levels.
+              , runToLevelNumber LevelLevelling conf r
+                               -- Run must not be too large for the level.
+              ]
+        let emptyLevels = replicate (levelNo - 1 - length ls) EmptyLevel
+        let levels = ls ++ emptyLevels ++ [Level (Single r) []]
+        assertST $ length levels == levelNo
+        traceWith tr $ EventAt sc levelNo $ UnionLevelMigratedEvent r
+        pure (levels, NoUnion)
 
 -------------------------------------------------------------------------------
 -- Lookups
@@ -1835,6 +1879,12 @@ expectCompletedChildren (PendingMerge mt prs trees) = do
 expectCompletedMergingTree :: HasCallStack => MergingTree s -> ST s Run
 expectCompletedMergingTree = expectInvariant . isCompletedMergingTree
 
+getCompletedMergingTree :: MergingTree s -> ST s (Maybe Run)
+getCompletedMergingTree t =
+    evalInvariant (isCompletedMergingTree t) >>= \case
+      Left _  -> pure Nothing
+      Right r -> pure (Just r)
+
 -------------------------------------------------------------------------------
 -- Measurements
 --
@@ -1991,6 +2041,8 @@ data EventDetail =
         mergeSize   :: Int
       }
   | SingleRunCompletedEvent Run
+
+  | UnionLevelMigratedEvent Run
 
   | RunTooSmallForLevelEvent MergePolicyForLevel Run
   | LevelIsFullEvent MergePolicyForLevel

--- a/lsm-tree/src-prototypes/ScheduledMerges.hs
+++ b/lsm-tree/src-prototypes/ScheduledMerges.hs
@@ -1191,27 +1191,30 @@ newtype UnionCredits = UnionCredits Credit
 -- a union has finished. In particular, if the returned number of credits is
 -- non-negative, then the union is finished.
 supplyUnionCredits :: Tracer (ST s) Event -> LSM s -> UnionCredits -> ST s UnionCredits
-supplyUnionCredits tr (LSMHandle tid scr conf lsmr) (UnionCredits credits)
-  | credits <= 0 = pure (UnionCredits 0)
-  | otherwise = do
-    content@(LSMContent wb ls ul) <- readSTRef lsmr
-    UnionCredits <$> case ul of
-      NoUnion ->
-        pure credits
-      Union tree debtRef -> do
-        invariant conf content
-        sc <- readSTRef scr
-        modifySTRef' scr (+1)
-        _debt <- checkedUnionDebt tree debtRef  -- just to make sure it's checked
-        c' <- supplyCreditsMergingTree credits tree
-        debt' <- checkedUnionDebt tree debtRef
-        when (debt' > 0) $
-          assertST $ c' == 0  -- should have spent these credits
-        (ls', ul') <- migrateUnionLevel (LevelEvent tid >$< tr) sc conf ls ul
-        let content' = LSMContent wb ls' ul'
-        invariant conf content'
-        writeSTRef lsmr content'
-        pure c'
+supplyUnionCredits tr (LSMHandle tid scr conf lsmr) (UnionCredits credits) = do
+    traceWith tr $ SupplyUnionCreditsEvent tid credits
+    if credits <= 0
+      then
+        pure (UnionCredits 0)
+      else do
+        content@(LSMContent wb ls ul) <- readSTRef lsmr
+        UnionCredits <$> case ul of
+          NoUnion ->
+            pure credits
+          Union tree debtRef -> do
+            invariant conf content
+            sc <- readSTRef scr
+            modifySTRef' scr (+1)
+            _debt <- checkedUnionDebt tree debtRef  -- make sure it's checked
+            c' <- supplyCreditsMergingTree credits tree
+            debt' <- checkedUnionDebt tree debtRef
+            when (debt' > 0) $
+              assertST $ c' == 0  -- we should have spent these credits
+            (ls', ul') <- migrateUnionLevel (LevelEvent tid >$< tr) sc conf ls ul
+            let content' = LSMContent wb ls' ul'
+            invariant conf content'
+            writeSTRef lsmr content'
+            pure c'
 
 -- | Like 'remainingDebtMergingTree', but additionally asserts that the debt
 -- never increases.
@@ -2013,6 +2016,7 @@ data Event =
   | LookupEvent TableId Key
   | DuplicateEvent TableId TableId
   | UnionsEvent TableId [TableId]
+  | SupplyUnionCreditsEvent TableId Credit
   | LevelEvent TableId (EventAt EventDetail)
   deriving stock Show
 

--- a/lsm-tree/test-prototypes/Main.hs
+++ b/lsm-tree/test-prototypes/Main.hs
@@ -5,6 +5,7 @@ import           Test.Tasty
 import qualified Test.FormatPage
 import qualified Test.ScheduledMerges
 import qualified Test.ScheduledMerges.RunSizes
+import qualified Test.ScheduledMergesDL
 import qualified Test.ScheduledMergesQLS
 
 main :: IO ()
@@ -13,4 +14,5 @@ main = defaultMain $ testGroup "prototypes" [
     , Test.ScheduledMerges.tests
     , Test.ScheduledMerges.RunSizes.tests
     , Test.ScheduledMergesQLS.tests
+    , Test.ScheduledMergesDL.tests
     ]

--- a/lsm-tree/test-prototypes/Test/ScheduledMerges.hs
+++ b/lsm-tree/test-prototypes/Test/ScheduledMerges.hs
@@ -190,7 +190,7 @@ prop_union_complete conf nestedUnionData =
         rep <- dumpRepresentation t
         debt@(UnionDebt x) <- LSM.remainingUnionDebt t
 
-        leftovers <- LSM.supplyUnionCredits t (UnionCredits x)
+        leftovers <- LSM.supplyUnionCredits tr t (UnionCredits x)
 
         rep' <- dumpRepresentation t
         debt' <- LSM.remainingUnionDebt t
@@ -201,10 +201,10 @@ prop_union_complete conf nestedUnionData =
               -- (i.e. they have runs or at least a non-empty write buffer).
               -- Therefore there must be a merging tree.
               debt =/= UnionDebt 0
-              .&&. hasUnionWith (not . isCompleted) rep
+              .&&. hasUnionLevelWith (not . isCompleted) rep
           , QC.counterexample "after" $
               debt' === UnionDebt 0
-              .&&. hasUnionWith isCompleted rep'
+              .&&. hasNoUnionLevel rep'
           , QC.counterexample "leftovers" $
               leftovers >= 0
           ]
@@ -631,10 +631,16 @@ expectShape lsm expectedWb expectedLevels = do
         , "actual shape:   " <> show shape
         ]
 
-hasUnionWith :: (MTree Int -> Bool) -> Representation -> Property
-hasUnionWith p rep = do
+hasNoUnionLevel :: Representation -> Property
+hasNoUnionLevel rep = do
     let (_, _, shape) = representationShape rep
-    QC.counterexample "expected suitable Union" $
+    QC.counterexample "expected no union level" $
+      Nothing === shape
+
+hasUnionLevelWith :: (MTree Int -> Bool) -> Representation -> Property
+hasUnionLevelWith p rep = do
+    let (_, _, shape) = representationShape rep
+    QC.counterexample "expected suitable union level" $
       QC.counterexample (show shape) $
         case shape of
           Nothing -> False

--- a/lsm-tree/test-prototypes/Test/ScheduledMergesDL.hs
+++ b/lsm-tree/test-prototypes/Test/ScheduledMergesDL.hs
@@ -1,0 +1,47 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.ScheduledMergesDL (tests) where
+
+import           ScheduledMerges as LSM
+import           Test.ScheduledMergesQLS as QLS (Action (..), Model, prop_LSM)
+
+import           Test.QuickCheck (NonNegative (..), Property)
+import           Test.QuickCheck.DynamicLogic
+import           Test.QuickCheck.StateModel.Lockstep hiding (ModelOp)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests = testGroup "Test.ScheduledMergesDL" [
+      testProperty "prop_empty_union" prop_empty_union
+    ]
+
+instance DynLogicModel (Lockstep Model)
+
+prop_empty_union :: Property
+prop_empty_union = forAllDL dl_empty_union prop_LSM
+
+-- | Create a table with an empty run in the union level, then run arbitrary
+-- actions to see if all invariants still hold.
+dl_empty_union :: DL (Lockstep Model) ()
+dl_empty_union = do
+    -- Create a union level that will result in an empty run. This is easy to
+    -- achieve if the inputs to the union only contain deletes (which will get
+    -- removed in a last level merge, which the union merges are).
+    tInput <- action $ ANew conf
+    _ <- action $ ADelete (unsafeMkGVar tInput opIdentity) (Right (K 0))
+    tUnion <- action $ AUnions [unsafeMkGVar tInput opIdentity, unsafeMkGVar tInput opIdentity]
+
+    -- Perform some actions so tUnion gets regular levels as well.
+    anyActions_
+
+    -- Now complete the union.
+    _ <- action $ ASupplyUnion (unsafeMkGVar tUnion opIdentity) (NonNegative (UnionCredits 100))
+
+    anyActions_
+  where
+    conf =
+      LSMConfig
+        { configMaxWriteBufferSize = 2
+        , configSizeRatio = 2
+        }

--- a/lsm-tree/test-prototypes/Test/ScheduledMergesQLS.hs
+++ b/lsm-tree/test-prototypes/Test/ScheduledMergesQLS.hs
@@ -3,7 +3,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
-module Test.ScheduledMergesQLS (tests) where
+module Test.ScheduledMergesQLS (
+    tests
+  , Model
+  , prop_LSM
+  , Action (..)
+  ) where
 
 import           Control.Monad.Reader (ReaderT (..))
 import           Control.Monad.ST
@@ -404,7 +409,7 @@ runActionIO action lookUp = ReaderT $ \tidVar -> do
     AUnions vars        -> do
       tid <- incrTidVar tidVar
       stToIO $ unions tr tid (map lookUpVar vars)
-    ASupplyUnion var c  -> stToIO $ supplyUnionCredits (lookUpVar var) (getNonNegative c) >> pure ()
+    ASupplyUnion var c  -> stToIO $ supplyUnionCredits tr (lookUpVar var) (getNonNegative c) >> pure ()
     ADump      var      -> stToIO $ logicalValue (lookUpVar var)
   where
     lookUpVar :: ModelVar Model a -> a


### PR DESCRIPTION
When creating the union of multiple tables, we create a special union level containing a merging tree. Once the tree has been completed, i.e. merged into a single run, we want to get rid of the union level by migrating the run to the regular levels. The main motivation is that we want it to become part of a last level merge, so compaction can occur. Last level merges are especially useful for compaction, since they can drop all delete entries.

This PR demonstrates one of two approaches for migration (#822 being the other one). As soon as the merging tree gets completed through `supplyUnionCredits`, we migrate it to a new last regular level. Sometimes it would not fit directly after the existing levels, in which case we can insert a few empty levels.

An interesting case to consider it that a union can get completed by an operation on another table that contains a shared reference to the merging tree. Therefore, at the beginning of any operation, a completed but not yet migrated union might be present. To ensure unions can become part of merges as soon as possible, we also check for possible migrations when flushing the write buffer. It might be beneficial to do the same when doing lookups.