### PR TITLE
Support ghc-9.14

### DIFF
--- a/blockio/blockio.cabal
+++ b/blockio/blockio.cabal
@@ -84,10 +84,10 @@ library
     System.FS.BlockIO.Serial
 
   build-depends:
-    , base        >=4.16  && <4.22
+    , base        >=4.16  && <4.23
     , deepseq     ^>=1.4  || ^>=1.5
     , fs-api      ^>=0.4
-    , io-classes  ^>=1.6  || ^>=1.7 || ^>=1.8.0.1
+    , io-classes  ^>=1.6  || ^>=1.7 || ^>=1.8.0.1 || ^>=1.9
     , primitive   ^>=0.9
     , vector      ^>=0.13
 
@@ -144,12 +144,12 @@ library sim
   hs-source-dirs:  src-sim
   exposed-modules: System.FS.BlockIO.Sim
   build-depends:
-    , base                   >=4.16  && <4.22
+    , base                   >=4.16  && <4.23
     , blockio
     , bytestring             ^>=0.11 || ^>=0.12
     , fs-api                 ^>=0.4
     , fs-sim                 ^>=0.4
-    , io-classes             ^>=1.6  || ^>=1.7  || ^>=1.8.0.1
+    , io-classes             ^>=1.6  || ^>=1.7  || ^>=1.8.0.1 || ^>=1.9
     , io-classes:strict-stm
     , primitive              ^>=0.9
 

--- a/cabal.project.debug
+++ b/cabal.project.debug
@@ -38,3 +38,42 @@ if impl(ghc >=9.4.6 && <9.5 || >=9.6.3)
   package fs-sim
     ghc-options: -fcheck-prim-bounds
 
+-- Eariler versions fail to compile due to symbol name clash.
+constraints:
+  , nonempty-containers >= 0.3.2
+
+-- cabal-allow-newer
+if impl (ghc >= 9.14)
+  allow-newer:
+    , aeson:QuickCheck
+    , aeson:containers
+    , aeson:semialign
+    , aeson:template-haskell
+    , aeson:time
+    , binary-orphans:base
+    , blockio-uring:base
+    , boring:base
+    , cborg:base
+    , cborg:containers
+    , data-elevator:base
+    , fs-sim:QuickCheck
+    , indexed-traversable:base
+    , indexed-traversable:containers
+    , indexed-traversable-instances:base
+    , microstache:base
+    , microstache:containers
+    , nonempty-vector:base
+    , quickcheck-instances:QuickCheck
+    , quickcheck-instances:base
+    , quickcheck-instances:these
+    , quickcheck-instances:uuid-types
+    , safe-wild-cards:template-haskell
+    , semialign:base
+    , semialign:containers
+    , serialise:base
+    , serialise:containers
+    , text:base
+    , text:template-haskell
+    , these:base
+    , unix:time
+    , uuid-types:template-haskell

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -1,7 +1,7 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
   -- current date: release blockio-0.1.1.1
-  , hackage.haskell.org 2025-12-10T00:00:00Z
+  , hackage.haskell.org 2026-03-05T01:23:24Z
 
 packages:
   ./lsm-tree

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -513,6 +513,10 @@ common warnings
 
   ghc-options: -Werror=missing-deriving-strategies
 
+  -- In ghc-9.14 the `pattern` namespace specifier is deprecated.
+  if impl(ghc >=9.14)
+    ghc-options: -Wno-pattern-namespace-specifier
+
 common wno-x-partial
   if impl(ghc >=9.8)
     -- No errors for x-partial functions. We might remove this in the future if
@@ -533,7 +537,7 @@ common language
     ViewPatterns
 
 library
-  import:          language, warnings, wno-x-partial
+  import:          language, warnings
   hs-source-dirs:  src
   exposed-modules:
     Database.LSMTree
@@ -690,6 +694,12 @@ library extras
 
 test-suite lsm-tree-test
   import:          language, warnings, wno-x-partial
+
+  -- ghc-9.14 gives redundant constraint warnings on some constraints
+  -- that are needed for earlier compilers.
+  if impl(ghc >=9.14)
+    ghc-options: -Wno-redundant-constraints
+
   type:            exitcode-stdio-1.0
   hs-source-dirs:  test
   main-is:         Main.hs
@@ -851,7 +861,7 @@ benchmark lsm-tree-micro-bench
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded
 
 benchmark lsm-tree-bench-bloomfilter
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench/macro
   main-is:        lsm-tree-bench-bloomfilter.hs
@@ -868,7 +878,7 @@ benchmark lsm-tree-bench-bloomfilter
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded
 
 benchmark lsm-tree-bench-lookups
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench/macro
   main-is:        lsm-tree-bench-lookups.hs
@@ -891,7 +901,7 @@ benchmark lsm-tree-bench-lookups
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded
 
 library mcg
-  import:          language, warnings, wno-x-partial
+  import:          language, warnings
   visibility:      private
   hs-source-dirs:  src-mcg
   exposed-modules: MCG
@@ -900,7 +910,7 @@ library mcg
     , primes
 
 benchmark unions-bench
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench-unions
   main-is:        Main.hs
@@ -934,7 +944,7 @@ common measure-batch-latency
     cpp-options: -DMEASURE_BATCH_LATENCY
 
 benchmark utxo-bench
-  import:         language, warnings, wno-x-partial, measure-batch-latency
+  import:         language, warnings, measure-batch-latency, wno-x-partial
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench/macro
   main-is:        utxo-bench.hs
@@ -966,7 +976,7 @@ flag rocksdb
   manual:      False
 
 benchmark utxo-rocksdb-bench
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench/macro
   main-is:        utxo-rocksdb-bench.hs
@@ -1008,7 +1018,7 @@ library rocksdb
     , indexed-traversable
 
 library kmerge
-  import:          language, warnings, wno-x-partial
+  import:          language, warnings
   visibility:      private
   hs-source-dirs:  src-kmerge
   exposed-modules:
@@ -1058,7 +1068,7 @@ benchmark kmerge-bench
     , vector
 
 test-suite map-range-test
-  import:         language, warnings, wno-x-partial
+  import:         language, warnings
   type:           exitcode-stdio-1.0
   hs-source-dirs: test
   main-is:        map-range-test.hs
@@ -1172,8 +1182,7 @@ test-suite demo
     , fs-api
     , fs-sim
     , io-classes
-    -- Version 1.10 drops the flushEventLog method of MonadEventlog.
-    , io-sim < 1.10
+    , io-sim         <1.10
     , lsm-tree
     , primitive
     , vector

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -540,12 +540,12 @@ library
     Database.LSMTree.Simple
 
   build-depends:
-    , base                    >=4.16   && <4.22
+    , base                    >=4.16   && <4.23
     , blockio                 ^>=0.1
     , contra-tracer           ^>=0.1   || ^>=0.2
     , deepseq                 ^>=1.4   || ^>=1.5
     , fs-api                  ^>=0.4
-    , io-classes              ^>=1.6   || ^>=1.7 || ^>=1.8.0.1
+    , io-classes              ^>=1.6   || ^>=1.7 || ^>=1.8.0.1 || ^>=1.9
     , io-classes:strict-mvar
     , lsm-tree:control
     , lsm-tree:core
@@ -617,19 +617,19 @@ library core
     Database.LSMTree.Internal.WriteBufferWriter
 
   build-depends:
-    , base                    >=4.16      && <4.22
+    , base                    >=4.16      && <4.23
     , bitvec                  ^>=1.1
     , blockio                 ^>=0.1
     , bloomfilter-blocked     ^>=0.1
     , bytestring              ^>=0.11.4.0 || ^>=0.12.1.0
     , cborg                   ^>=0.2.10.0
-    , containers              ^>=0.6      || ^>=0.7
+    , containers              ^>=0.6      || ^>=0.7      || ^>=0.8
     , contra-tracer           ^>=0.1      || ^>=0.2
     , crc32c                  ^>=0.2.1
     , deepseq                 ^>=1.4      || ^>=1.5
     , filepath                ^>=1.4      || ^>=1.5
     , fs-api                  ^>=0.4
-    , io-classes              ^>=1.6      || ^>=1.7      || ^>=1.8.0.1
+    , io-classes              ^>=1.6      || ^>=1.7      || ^>=1.8.0.1 || ^>=1.9
     , io-classes:strict-mvar
     , lsm-tree:control
     , lsm-tree:kmerge
@@ -663,7 +663,7 @@ library extras
     Database.LSMTree.Extras.UTxO
 
   build-depends:
-    , base                    >=4.16 && <4.22
+    , base                    >=4.16 && <4.23
     , bitvec
     , blockio
     , bytestring
@@ -1026,7 +1026,7 @@ test-suite kmerge-test
   hs-source-dirs: test
   main-is:        kmerge-test.hs
   build-depends:
-    , base              >=4.16 && <4.22
+    , base              >=4.16 && <4.23
     , deepseq
     , heaps
     , lsm-tree:kmerge
@@ -1045,7 +1045,7 @@ benchmark kmerge-bench
   main-is:        kmerge-test.hs
   cpp-options:    -DKMERGE_BENCHMARKS
   build-depends:
-    , base              >=4.16 && <4.22
+    , base              >=4.16 && <4.23
     , deepseq
     , heaps
     , lsm-tree:kmerge
@@ -1063,7 +1063,7 @@ test-suite map-range-test
   hs-source-dirs: test
   main-is:        map-range-test.hs
   build-depends:
-    , base              >=4.16 && <4.22
+    , base              >=4.16 && <4.23
     , bytestring
     , containers
     , lsm-tree:core
@@ -1127,9 +1127,9 @@ library control
     Control.RefCount
 
   build-depends:
-    , base                   >=4.16 && <4.22
+    , base                   >=4.16 && <4.23
     , deepseq                ^>=1.4 || ^>=1.5
-    , io-classes             ^>=1.6 || ^>=1.7 || ^>=1.8.0.1
+    , io-classes             ^>=1.6 || ^>=1.7 || ^>=1.8.0.1 || ^>=1.9
     , io-classes:strict-stm
     , primitive              ^>=0.9
 
@@ -1172,7 +1172,8 @@ test-suite demo
     , fs-api
     , fs-sim
     , io-classes
-    , io-sim
+    -- Version 1.10 drops the flushEventLog method of MonadEventlog.
+    , io-sim < 1.10
     , lsm-tree
     , primitive
     , vector

--- a/scripts/format-cabal-fmt.sh
+++ b/scripts/format-cabal-fmt.sh
@@ -24,6 +24,7 @@ fi
 echo "Formatting Cabal source files with cabal-fmt version ${cabal_fmt_actual_version}"
 # shellcheck disable=SC2016
 if ! git ls-files --exclude-standard --no-deleted --deduplicate '*.cabal' | xargs -L 1 sh -c 'echo "$0" && cabal-fmt -c "$0" 2>/dev/null || (cabal-fmt -i "$0" && exit 1)'; then
+    git diff
     exit 1
 fi
 


### PR DESCRIPTION
# Description

Support ghc-9.14 exncluding adding it to CI.

The tests found a bug in the code which is only triggered when compiling with `ghc-9.14` due to changes in strictness analysis and optimisation behavior. Using Claude I have come up with a fix for that, but I am still validating that fix which will be in a later PR and I will then include `ghc-9.14` to CI.

# Checklist

- [x] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

