### PR TITLE
Support exporting and importing snapshots

### DIFF
--- a/blockio/src/System/FS/BlockIO/API.hs
+++ b/blockio/src/System/FS/BlockIO/API.hs
@@ -270,7 +270,7 @@ synchroniseDirectoryRecursive hfs hbio path = do
           synchroniseDirectory hbio path'
         else
           error $ printf
-            "listDirectoryRecursive: %s is not a file or directory"
+            "synchroniseDirectoryRecursive: %s is not a file or directory"
             (show path')
 
 {-------------------------------------------------------------------------------

--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -12,12 +12,36 @@
 
 ### New features
 
-None
+### Full API
+
+* Add a new `importSnapshot` function for importing snapshots from outside a
+  session into that session. See [PR
+  #835](https://github.com/IntersectMBO/lsm-tree/pull/835).
+* Add a new `SnapshotImportDirDoesNotExistError` exception, which can currently
+  only be thrown by thrown by `importSnapshot`. See [PR
+  #835](https://github.com/IntersectMBO/lsm-tree/pull/835).
+* Add a new `exportSnapshot` function for exporting snapshots from inside a
+  session to outside that session. See [PR
+  #835](https://github.com/IntersectMBO/lsm-tree/pull/835).
+* Add a new `SnapshotExportDirExistsError` exception, which can currently only
+  be thrown by thrown by `exportSnapshot`. See [PR
+  #835](https://github.com/IntersectMBO/lsm-tree/pull/835).
+* Add a new `withOpenMountedSessionIO` function, a variant of
+  `withOpenSessionIO` with more general control over where snapshots can be
+  exported to and imported from. See [PR
+  #835](https://github.com/IntersectMBO/lsm-tree/pull/835).
 
 ### Minor changes
 
 * Update to `fs-sim ^>=0.5`. See PR
   [#845](https://github.com/IntersectMBO/lsm-tree/pull/845).
+
+### Full API
+
+* Deprecate `withOpenSessionIO` in favour of `withOpenMountedSessionIO`.
+  `withOpenSessionIO` is generally unsafe to use with the new `importSnapshot`
+  and `exportSnapshot` functions. See [PR
+  #835](https://github.com/IntersectMBO/lsm-tree/pull/835).
 
 ### Bug fixes
 

--- a/lsm-tree/app/Database/LSMTree/Demo.hs
+++ b/lsm-tree/app/Database/LSMTree/Demo.hs
@@ -24,6 +24,7 @@ import           Data.Word (Word64)
 import           Database.LSMTree as LSMT
 import qualified System.Directory as IO (createDirectoryIfMissing,
                      doesDirectoryExist, removeDirectoryRecursive)
+import           System.FilePath ((</>))
 import qualified System.FS.API as FS
 import qualified System.FS.BlockIO.API as FS
 import qualified System.FS.BlockIO.IO as FS
@@ -41,8 +42,8 @@ import           System.IO.Unsafe (unsafePerformIO)
 -- functional requirement.
 demo :: Bool -> IO ()
 demo interactive = do
-  freshDirectory "_demo"
-  withOpenSessionIO tracer "_demo" $ \session -> do
+  freshDirectory ("_demo" </> "session")
+  withOpenMountedSessionIO tracer "_demo" (FS.mkFsPath ["session"]) $ \session -> do
     withTableWith config session  $ \(table :: Table IO K V B) -> do
       pause interactive -- [0]
 
@@ -141,8 +142,8 @@ demo interactive = do
          (LSMT.IOLike m, Typeable h)
       => FS.HasFS m h -> FS.HasBlockIO m h -> m ()
     simpleAction hasFS hasBlockIO = do
-      let sessionDir = FS.mkFsPath ["_demo"]
-      FS.createDirectoryIfMissing hasFS False sessionDir
+      let sessionDir = FS.mkFsPath ["_demo", "session"]
+      FS.createDirectoryIfMissing hasFS True sessionDir
       withOpenSession tracer hasFS hasBlockIO 17 sessionDir $ \session -> do
         withTableWith config session  $ \(table :: Table m K V B) -> do
           inserts table $ V.fromList [ (K i, V i, Just (B i)) | i <- [1 .. 10_000] ]
@@ -215,7 +216,7 @@ freshDirectory :: FilePath -> IO ()
 freshDirectory path = do
     b <- IO.doesDirectoryExist path
     when b $ IO.removeDirectoryRecursive path
-    IO.createDirectoryIfMissing False path
+    IO.createDirectoryIfMissing True path
 
 print' :: (Show a, MonadST m) => a -> m ()
 print' x = stToIO $ unsafeIOToST $ print x

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -742,6 +742,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.WriteBufferReader.FS
     Test.Database.LSMTree.Model.Table
     Test.Database.LSMTree.Resolve
+    Test.Database.LSMTree.Snapshots
     Test.Database.LSMTree.StateMachine
     Test.Database.LSMTree.StateMachine.DL
     Test.Database.LSMTree.StateMachine.Op
@@ -1172,6 +1173,7 @@ test-suite demo
     , blockio:sim
     , contra-tracer
     , directory
+    , filepath
     , fs-api
     , fs-sim
     , io-classes

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -574,6 +574,7 @@ library core
     Database.LSMTree.Internal.CRC32C
     Database.LSMTree.Internal.Cursor
     Database.LSMTree.Internal.Entry
+    Database.LSMTree.Internal.FS
     Database.LSMTree.Internal.IncomingRun
     Database.LSMTree.Internal.Index
     Database.LSMTree.Internal.Index.Compact

--- a/lsm-tree/src-core/Database/LSMTree/Internal/FS.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/FS.hs
@@ -1,0 +1,72 @@
+module Database.LSMTree.Internal.FS (
+    -- * Hard links
+    hardLink
+    -- * Copy file
+  , copyFile
+  ) where
+
+import           Control.ActionRegistry
+import           Control.Monad (void)
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Primitive (PrimMonad)
+
+import qualified System.FS.API as FS
+import           System.FS.API
+import qualified System.FS.API.Lazy as FSL
+import qualified System.FS.BlockIO.API as FS
+import           System.FS.BlockIO.API (HasBlockIO)
+
+{-------------------------------------------------------------------------------
+  Hard links
+-------------------------------------------------------------------------------}
+
+{-# SPECIALISE
+  hardLink ::
+       HasFS IO h
+    -> HasBlockIO IO h
+    -> ActionRegistry IO
+    -> FS.FsPath
+    -> FS.FsPath
+    -> IO ()
+  #-}
+-- | @'hardLink' hfs hbio reg sourcePath destinationPath@ creates a hard link from
+-- @sourcePath@ to @targetPath@.
+hardLink ::
+     (MonadMask m, PrimMonad m)
+  => HasFS m h
+  -> HasBlockIO m h
+  -> ActionRegistry m
+  -> FS.FsPath
+  -> FS.FsPath
+  -> m ()
+hardLink hfs hbio reg sourcePath destinationPath = do
+    withRollback_ reg
+      (FS.createHardLink hbio sourcePath destinationPath)
+      (FS.removeFile hfs destinationPath)
+
+{-------------------------------------------------------------------------------
+  Copy file
+-------------------------------------------------------------------------------}
+
+{-# SPECIALISE
+  copyFile ::
+       HasFS IO h
+    -> ActionRegistry IO
+    -> FS.FsPath
+    -> FS.FsPath
+    -> IO ()
+  #-}
+-- | @'copyFile' hfs reg source target@ copies the @source@ path to the @target@ path.
+copyFile ::
+     (MonadMask m, PrimMonad m)
+  => HasFS m h
+  -> ActionRegistry m
+  -> FS.FsPath
+  -> FS.FsPath
+  -> m ()
+copyFile hfs reg sourcePath destinationPath =
+    flip (withRollback_ reg) (FS.removeFile hfs destinationPath) $
+      FS.withFile hfs sourcePath FS.ReadMode $ \sourceHandle ->
+        FS.withFile hfs destinationPath (FS.WriteMode FS.MustBeNew) $ \targetHandle -> do
+          bs <- FSL.hGetAll hfs sourceHandle
+          void $ FSL.hPutAll hfs targetHandle bs

--- a/lsm-tree/src-core/Database/LSMTree/Internal/FS.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/FS.hs
@@ -1,12 +1,13 @@
 module Database.LSMTree.Internal.FS (
     -- * Hard links
     hardLink
+  , hardLinkDirectoryRecursive
     -- * Copy file
   , copyFile
   ) where
 
 import           Control.ActionRegistry
-import           Control.Monad (void)
+import           Control.Monad (forM_, void)
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Primitive (PrimMonad)
 
@@ -15,6 +16,7 @@ import           System.FS.API
 import qualified System.FS.API.Lazy as FSL
 import qualified System.FS.BlockIO.API as FS
 import           System.FS.BlockIO.API (HasBlockIO)
+import           Text.Printf (printf)
 
 {-------------------------------------------------------------------------------
   Hard links
@@ -30,7 +32,9 @@ import           System.FS.BlockIO.API (HasBlockIO)
     -> IO ()
   #-}
 -- | @'hardLink' hfs hbio reg sourcePath destinationPath@ creates a hard link from
--- @sourcePath@ to @targetPath@.
+-- @sourcePath@ to @destinationPath@.
+--
+-- Both the source path and destination path should be on the same disk volume.
 hardLink ::
      (MonadMask m, PrimMonad m)
   => HasFS m h
@@ -44,6 +48,46 @@ hardLink hfs hbio reg sourcePath destinationPath = do
       (FS.createHardLink hbio sourcePath destinationPath)
       (FS.removeFile hfs destinationPath)
 
+{-# SPECIALISE
+  hardLinkDirectoryRecursive ::
+       HasFS IO h
+    -> HasBlockIO IO h
+    -> ActionRegistry IO
+    -> FS.FsPath
+    -> FS.FsPath
+    -> IO ()
+  #-}
+-- | Recursively create hard links for all the directory contents of the source
+-- path at the destination path.
+--
+-- Both the source path and destination path should be on the same disk volume.
+hardLinkDirectoryRecursive ::
+     (MonadMask m, PrimMonad m)
+  => HasFS m h
+  -> HasBlockIO m h
+  -> ActionRegistry m
+     -- | Source path
+  -> FS.FsPath
+     -- | Destination path
+  -> FS.FsPath
+  -> m ()
+hardLinkDirectoryRecursive hfs hbio reg sourcePath destinationPath = do
+    entries <- FS.listDirectory hfs sourcePath
+    forM_ entries $ \entry -> do
+      let sourcePath' = sourcePath FS.</> FS.mkFsPath [entry]
+          destinationPath' = destinationPath FS.</> FS.mkFsPath [entry]
+      isFile <- FS.doesFileExist hfs sourcePath'
+      if isFile then
+        hardLink hfs hbio reg sourcePath' destinationPath'
+      else do
+        isDirectory <- FS.doesDirectoryExist hfs sourcePath'
+        if isDirectory then do
+          hardLinkDirectoryRecursive hfs hbio reg sourcePath' destinationPath'
+        else
+          error $ printf
+            "hardLinkDirectoryRecursive: %s is not a file or directory"
+            (show sourcePath')
+
 {-------------------------------------------------------------------------------
   Copy file
 -------------------------------------------------------------------------------}
@@ -56,7 +100,8 @@ hardLink hfs hbio reg sourcePath destinationPath = do
     -> FS.FsPath
     -> IO ()
   #-}
--- | @'copyFile' hfs reg source target@ copies the @source@ path to the @target@ path.
+-- | @'copyFile' hfs reg sourcePath destinationPath@ copies the file contents of
+-- @sourcePath@ to the @destinationPath@.
 copyFile ::
      (MonadMask m, PrimMonad m)
   => HasFS m h

--- a/lsm-tree/src-core/Database/LSMTree/Internal/Snapshot.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/Snapshot.hs
@@ -38,7 +38,6 @@ import           Control.ActionRegistry
 import           Control.Concurrent.Class.MonadMVar.Strict
 import           Control.Concurrent.Class.MonadSTM (MonadSTM)
 import           Control.DeepSeq (NFData (..))
-import           Control.Monad (void)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow (MonadMask, bracket,
                      bracketOnError)
@@ -52,6 +51,7 @@ import qualified Database.LSMTree.Internal.BloomFilter as Bloom
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.CRC32C (checkCRC)
 import qualified Database.LSMTree.Internal.CRC32C as CRC
+import qualified Database.LSMTree.Internal.FS as FS
 import           Database.LSMTree.Internal.IncomingRun
 import qualified Database.LSMTree.Internal.Merge as Merge
 import           Database.LSMTree.Internal.MergeSchedule
@@ -76,8 +76,6 @@ import qualified Database.LSMTree.Internal.WriteBufferReader as WBR
 import qualified Database.LSMTree.Internal.WriteBufferWriter as WBW
 import qualified System.FS.API as FS
 import           System.FS.API (HasFS, (<.>), (</>))
-import qualified System.FS.API.Lazy as FSL
-import qualified System.FS.BlockIO.API as FS
 import           System.FS.BlockIO.API (HasBlockIO)
 
 {-------------------------------------------------------------------------------
@@ -474,13 +472,13 @@ snapshotWriteBuffer hfs hbio activeUc snapUc reg activeDir snapDir wb wbb = do
   -- Hard link the write buffer and write buffer blobs to the snapshot directory.
   snapWriteBufferNumber <- uniqueToRunNumber <$> incrUniqCounter snapUc
   let snapWriteBufferPaths = WriteBufferFsPaths (getNamedSnapshotDir snapDir) snapWriteBufferNumber
-  hardLink hfs hbio reg
+  FS.hardLink hfs hbio reg
     (writeBufferKOpsPath activeWriteBufferPaths)
     (writeBufferKOpsPath snapWriteBufferPaths)
-  hardLink hfs hbio reg
+  FS.hardLink hfs hbio reg
     (writeBufferBlobPath activeWriteBufferPaths)
     (writeBufferBlobPath snapWriteBufferPaths)
-  hardLink hfs hbio reg
+  FS.hardLink hfs hbio reg
     (writeBufferChecksumsPath activeWriteBufferPaths)
     (writeBufferChecksumsPath snapWriteBufferPaths)
   pure snapWriteBufferPaths
@@ -522,7 +520,7 @@ openWriteBuffer reg resolve hfs hbio refCtx uc activeDir snapWriteBufferPaths = 
   activeWriteBufferNumber <- uniqueToInt <$> incrUniqCounter uc
   let activeWriteBufferBlobPath =
         getActiveDir activeDir </> FS.mkFsPath [show activeWriteBufferNumber] <.> "wbblobs"
-  copyFile hfs reg (writeBufferBlobPath snapWriteBufferPaths) activeWriteBufferBlobPath
+  FS.copyFile hfs reg (writeBufferBlobPath snapWriteBufferPaths) activeWriteBufferBlobPath
   writeBufferBlobs <-
     withRollback reg
       (WBB.open hfs refCtx activeWriteBufferBlobPath FS.AllowExisting)
@@ -768,56 +766,5 @@ hardLinkRunFiles ::
 hardLinkRunFiles hfs hbio reg sourceRunFsPaths targetRunFsPaths = do
     let sourcePaths = pathsForRunFiles sourceRunFsPaths
         targetPaths = pathsForRunFiles targetRunFsPaths
-    sequenceA_ (hardLink hfs hbio reg <$> sourcePaths <*> targetPaths)
-    hardLink hfs hbio reg (runChecksumsPath sourceRunFsPaths) (runChecksumsPath targetRunFsPaths)
-
-{-# SPECIALISE
-  hardLink ::
-       HasFS IO h
-    -> HasBlockIO IO h
-    -> ActionRegistry IO
-    -> FS.FsPath
-    -> FS.FsPath
-    -> IO ()
-  #-}
--- | @'hardLink' hfs hbio reg sourcePath targetPath@ creates a hard link from
--- @sourcePath@ to @targetPath@.
-hardLink ::
-     (MonadMask m, PrimMonad m)
-  => HasFS m h
-  -> HasBlockIO m h
-  -> ActionRegistry m
-  -> FS.FsPath
-  -> FS.FsPath
-  -> m ()
-hardLink hfs hbio reg sourcePath targetPath = do
-    withRollback_ reg
-      (FS.createHardLink hbio sourcePath targetPath)
-      (FS.removeFile hfs targetPath)
-
-{-------------------------------------------------------------------------------
-  Copy file
--------------------------------------------------------------------------------}
-
-{-# SPECIALISE
-  copyFile ::
-       HasFS IO h
-    -> ActionRegistry IO
-    -> FS.FsPath
-    -> FS.FsPath
-    -> IO ()
-  #-}
--- | @'copyFile' hfs reg source target@ copies the @source@ path to the @target@ path.
-copyFile ::
-     (MonadMask m, PrimMonad m)
-  => HasFS m h
-  -> ActionRegistry m
-  -> FS.FsPath
-  -> FS.FsPath
-  -> m ()
-copyFile hfs reg sourcePath targetPath =
-    flip (withRollback_ reg) (FS.removeFile hfs targetPath) $
-      FS.withFile hfs sourcePath FS.ReadMode $ \sourceHandle ->
-        FS.withFile hfs targetPath (FS.WriteMode FS.MustBeNew) $ \targetHandle -> do
-          bs <- FSL.hGetAll hfs sourceHandle
-          void $ FSL.hPutAll hfs targetHandle bs
+    sequenceA_ (FS.hardLink hfs hbio reg <$> sourcePaths <*> targetPaths)
+    FS.hardLink hfs hbio reg (runChecksumsPath sourceRunFsPaths) (runChecksumsPath targetRunFsPaths)

--- a/lsm-tree/src-core/Database/LSMTree/Internal/Unsafe.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/Unsafe.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE CPP       #-}
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- | This module brings together the internal parts to provide an API in terms
@@ -23,6 +24,8 @@ module Database.LSMTree.Internal.Unsafe (
   , SnapshotDoesNotExistError (..)
   , SnapshotCorruptedError (..)
   , SnapshotNotCompatibleError (..)
+  , SnapshotImportDirDoesNotExistError (..)
+  , SnapshotExportDirExistsError (..)
   , BlobRefInvalidError (..)
   , CursorClosedError (..)
   , FileFormat (..)
@@ -79,6 +82,8 @@ module Database.LSMTree.Internal.Unsafe (
   , deleteSnapshot
   , doesSnapshotExist
   , listSnapshots
+  , importSnapshot
+  , exportSnapshot
     -- * Multiple writable tables
   , duplicate
     -- * Table union
@@ -126,6 +131,7 @@ import           Database.LSMTree.Internal.CRC32C (FileCorruptedError (..),
                      FileFormat (..))
 import qualified Database.LSMTree.Internal.Cursor as Cursor
 import           Database.LSMTree.Internal.Entry (Entry)
+import qualified Database.LSMTree.Internal.FS as FS
 import           Database.LSMTree.Internal.IncomingRun (IncomingRun (..))
 import           Database.LSMTree.Internal.Lookup (TableCorruptedError (..),
                      lookupsIO, lookupsIOWithWriteBuffer)
@@ -242,6 +248,18 @@ data SessionTrace =
   | TraceDeletedSnapshot SnapshotName
     -- | We are listing snapshots.
   | TraceListSnapshots
+
+    -- | We are importing a snapshot. A 'TraceImportedSnapshot' message should
+    -- follow if successful.
+  | TraceImportSnapshot SnapshotName FsPath
+    -- | Importing a snapshot was successful.
+  | TraceImportedSnapshot SnapshotName
+
+    -- | We are exporting a snapshot. A 'TraceExportedSnapshot' message should
+    -- follow if successful.
+  | TraceExportSnapshot SnapshotName FsPath
+    -- | Exporting a snapshot was successful.
+  | TraceExportedSnapshot SnapshotName
 
     -- | We are retrieving blobs.
   | TraceRetrieveBlobs Int
@@ -1894,6 +1912,110 @@ listSnapshots sesh = do
             (Paths.getNamedSnapshotDir $ Paths.namedSnapshotDir root snap)
       if b then pure $ Just snap
             else pure $ Nothing
+
+-- | A snapshot was intended to be imported, but the source directory does not
+-- exist.
+data SnapshotImportDirDoesNotExistError
+    = SnapshotImportDirDoesNotExistError !FsPath
+    deriving stock (Show, Eq)
+    deriving anyclass (Exception)
+
+{-# SPECIALISE importSnapshot ::
+     Session IO h
+  -> SnapshotName
+  -> FsPath
+  -> IO () #-}
+-- |  See 'Database.LSMTree.importSnapshot'.
+importSnapshot ::
+     (MonadMask m, MonadSTM m, PrimMonad m)
+  => Session m h
+  -> SnapshotName
+  -> FsPath
+  -> m ()
+importSnapshot sesh snap sourcePath = do
+    traceWith sesh.sessionTracer $ TraceImportSnapshot snap sourcePath
+    withKeepSessionOpen sesh $ \seshEnv ->
+      withActionRegistry $ \reg -> do
+        let hfs = seshEnv.sessionHasFS
+            hbio = seshEnv.sessionHasBlockIO
+
+        -- Guard that the snapshot does not exist already
+        let snapDir = Paths.namedSnapshotDir (sessionRoot seshEnv) snap
+        snapshotExists <- doesSnapshotDirExist snap seshEnv
+        when snapshotExists $ throwIO (ErrSnapshotExists snap)
+
+        let destinationPath = Paths.getNamedSnapshotDir snapDir
+
+        sourceExists <- FS.doesDirectoryExist hfs sourcePath
+        unless sourceExists $ throwIO (SnapshotImportDirDoesNotExistError sourcePath)
+
+        -- we assume the snapshots directory already exists, so we just have
+        -- to create the directory for this specific snapshot.
+        withRollback_ reg
+          (FS.createDirectory hfs destinationPath)
+          (FS.removeDirectoryRecursive hfs destinationPath)
+
+        -- create hard links for all files in the destination directory
+        FS.hardLinkDirectoryRecursive hfs hbio reg sourcePath destinationPath
+
+        -- Make the destination directory and its contents durable
+        FS.synchroniseDirectoryRecursive hfs hbio destinationPath
+
+        -- Note: trace the success message only after all side effects have been
+        -- succesfully performed
+        delayedCommit reg $
+          traceWith sesh.sessionTracer $ TraceImportedSnapshot snap
+
+-- | A snapshot was intended to be exported, but the destination directory
+-- already exists.
+data SnapshotExportDirExistsError
+    = SnapshotExportDirExistsError !FsPath
+    deriving stock (Show, Eq)
+    deriving anyclass (Exception)
+
+{-# SPECIALISE exportSnapshot ::
+     Session IO h
+  -> SnapshotName
+  -> FsPath
+  -> IO () #-}
+-- |  See 'Database.LSMTree.exportSnapshot'.
+exportSnapshot ::
+     (MonadMask m, MonadSTM m, PrimMonad m)
+  => Session m h
+  -> SnapshotName
+  -> FsPath
+  -> m ()
+exportSnapshot sesh snap destinationPath = do
+    traceWith (sessionTracer sesh) $ TraceExportSnapshot snap destinationPath
+    withKeepSessionOpen sesh $ \seshEnv ->
+      withActionRegistry $ \reg -> do
+        let hfs = seshEnv.sessionHasFS
+            hbio = seshEnv.sessionHasBlockIO
+
+        -- Guard that the snapshot exists already
+        let snapDir = Paths.namedSnapshotDir (sessionRoot seshEnv) snap
+        snapshotExists <- doesSnapshotDirExist snap seshEnv
+        unless snapshotExists $ throwIO (ErrSnapshotDoesNotExist snap)
+
+        let sourcePath = Paths.getNamedSnapshotDir snapDir
+
+        destinationExists <- FS.doesDirectoryExist hfs destinationPath
+        when destinationExists $ throwIO (SnapshotExportDirExistsError sourcePath)
+
+        withRollback_ reg
+          (FS.createDirectoryIfMissing hfs True destinationPath)
+          (FS.removeDirectoryRecursive hfs destinationPath)
+
+        -- Create hard links for all files in the destination directory
+        FS.hardLinkDirectoryRecursive hfs hbio reg sourcePath destinationPath
+
+        -- Make the directory and its contents durable.
+        FS.synchroniseDirectoryRecursive hfs hbio destinationPath
+
+        -- Note: trace the success message only after all side effects have been
+        -- succesfully performed
+        delayedCommit reg $
+          traceWith sesh.sessionTracer $ TraceExportedSnapshot snap
 
 {-------------------------------------------------------------------------------
   Multiple writable tables

--- a/lsm-tree/src/Database/LSMTree.hs
+++ b/lsm-tree/src/Database/LSMTree.hs
@@ -20,6 +20,7 @@ module Database.LSMTree (
   Session,
   withOpenSession,
   withOpenSessionIO,
+  withOpenMountedSessionIO,
   withNewSession,
   withRestoreSession,
   openSession,
@@ -101,6 +102,8 @@ module Database.LSMTree (
   doesSnapshotExist,
   deleteSnapshot,
   listSnapshots,
+  importSnapshot,
+  exportSnapshot,
   SnapshotName,
   isValidSnapshotName,
   toSnapshotName,
@@ -178,6 +181,8 @@ module Database.LSMTree (
   SnapshotDoesNotExistError (..),
   SnapshotCorruptedError (..),
   SnapshotNotCompatibleError (..),
+  SnapshotImportDirDoesNotExistError (..),
+  SnapshotExportDirExistsError (..),
   BlobRefInvalidError (..),
   CursorClosedError (..),
   InvalidSnapshotNameError (..),
@@ -250,6 +255,8 @@ import           Database.LSMTree.Internal.Unsafe (BlobRefInvalidError (..),
                      SessionDirLockedError (..), SessionId (..),
                      SessionTrace (..), SnapshotCorruptedError (..),
                      SnapshotDoesNotExistError (..), SnapshotExistsError (..),
+                     SnapshotExportDirExistsError (..),
+                     SnapshotImportDirDoesNotExistError (..),
                      SnapshotNotCompatibleError (..), TableClosedError (..),
                      TableCorruptedError (..), TableTooLargeError (..),
                      TableTrace, TableUnionNotCompatibleError (..),
@@ -369,17 +376,28 @@ runs the example with access to an open 'Session' and a fresh 'Table'.
 >>> import           Data.Foldable (traverse_)
 >>> import qualified System.Directory as Dir
 >>> import           System.FilePath ((</>))
+>>> import           System.FS.API (FsPath, mkFsPath)
+>>> import qualified System.FS.API as FS
 >>> import           System.Process (getCurrentPid)
+
+>>> :{
+withTempDirectory :: String -> (FilePath -> IO a) -> IO a
+withTempDirectory name k = do
+    sysTmpDir <- Dir.getTemporaryDirectory
+    pid <- getCurrentPid
+    let tmpDir = sysTmpDir </> name </> show pid
+    let createTmpDir = Dir.createDirectoryIfMissing True tmpDir
+    let removeTmpDir = Dir.removeDirectoryRecursive tmpDir
+    bracket_ createTmpDir removeTmpDir $ k tmpDir
+:}
+
 >>> :{
 runExample :: (Session IO -> Table IO Key Value Blob -> IO a) -> IO a
-runExample action = do
-  tmpDir <- Dir.getTemporaryDirectory
-  pid <- getCurrentPid
-  let sessionDir = tmpDir </> "doctest_Database_LSMTree" </> show pid
-  let createSessionDir = Dir.createDirectoryIfMissing True sessionDir
-  let removeSessionDir = Dir.removeDirectoryRecursive sessionDir
-  bracket_ createSessionDir removeSessionDir $ do
-    LSMT.withOpenSessionIO mempty sessionDir $ \session -> do
+runExample action =
+  withTempDirectory "doctest_Database_LSMTree" $ \tmpDir -> do
+    let sessionPath = FS.mkFsPath ["session"]
+    Dir.createDirectoryIfMissing True (tmpDir </> "session")
+    LSMT.withOpenMountedSessionIO mempty tmpDir sessionPath $ \session -> do
       LSMT.withTable session $ \table ->
         action session table
 :}
@@ -396,6 +414,26 @@ Run an action with access to a session opened from a session directory.
 
 If the session directory is empty, a new session is created using the given salt.
 Otherwise, the session directory is restored as an existing session ignoring the given salt.
+
+As a feature, @lsm-tree@ uses abstract 'HasFS' and 'HasBlockIO' interfaces to
+abstract over interaction with the file system.
+These abstract interfaces can be instantiated with a real file system (for use in practice) or
+a simulated file system (for comprehensive testing).
+For more information about the interfaces and their instantiations, see the Haddock
+documentation of the @fs-api@, @fs-sim@, @blockio@ packages.
+
+The session directory is a relative 'FsPath' path that is interpreted relative to the /root/ of
+the given 'HasFS' and 'HasBlockio' interfaces.
+If the interaces are instantiated with the real file system, then the root is an
+(absolute or relative) file path.
+In this case, the root is also called the /mount point/ of the interface.
+If the interfaces are instantiated with a simulation, then the root is some abstract location.
+
+Any 'FsPath' paths used with the session after the session is created are also interpreted
+with respect to the root of these interfaces.
+'importSnapshot' and 'exportSnapshot' are currently the only two functions that take
+'FsPaths' as arguments.
+'FsPath's are subject to a number of constraints, which are mentioned in its Haddock documentation.
 
 If there are no open tables or cursors when the session terminates, then the disk I\/O complexity of this operation is \(O(1)\).
 Otherwise, 'closeTable' is called for each open table and 'closeCursor' is called for each open cursor.
@@ -426,6 +464,7 @@ Throws the following exceptions:
     HasFS IO HandleIO ->
     HasBlockIO IO HandleIO ->
     Salt ->
+    -- | The session directory
     FsPath ->
     (Session IO -> IO a) ->
     IO a
@@ -445,15 +484,52 @@ withOpenSession ::
 withOpenSession tracer hasFS hasBlockIO sessionSalt sessionDir action = do
   Internal.withOpenSession tracer hasFS hasBlockIO sessionSalt sessionDir (action . Session)
 
--- | Variant of 'withOpenSession' that is specialised to 'IO' using the real filesystem.
+{-# DEPRECATED withOpenSessionIO "withOpenSessionIO is not compatible with importSnapshot and exportSnapshot. Use withOpenMountedSessionIO instead." #-}
+{- |
+Variant of 'withOpenSession' that is specialised to 'IO' using the real filesystem.
+
+Any 'FsPath' paths used with the session after the session is created are interpreted
+with respect to the session directory.
+'importSnapshot' and 'exportSnapshot' are currently the only two functions that take
+'FsPaths' as arguments.
+'FsPath's are subject to a number of constraints, which are mentioned in its Haddock documentation.
+
+It is generally not advisable to use 'importSnapshot' and 'exportSnapshot' when the session is
+created using 'withOpenSessionIO'.
+Snapshots should only be exported to somewhere /outside/ the session directory, which is not possible
+when the session is created using 'withOpenSessionIO'.
+Use 'withOpenMountedSessionIO' or 'withOpenSession' instead.
+-}
 withOpenSessionIO ::
   Tracer IO LSMTreeTrace ->
+  -- | The session directory
   FilePath ->
   (Session IO -> IO a) ->
   IO a
-withOpenSessionIO tracer sessionDir action = do
-  let mountPoint = MountPoint sessionDir
-  let sessionDirFsPath = mkFsPath []
+withOpenSessionIO tracer sessionDir action =
+    withOpenMountedSessionIO tracer sessionDir (mkFsPath []) action
+
+{- |
+Variant of 'withOpenSession' that is specialised to 'IO' using the real filesystem.
+
+The session directory is an 'FsPath' path that is interpreted relative to the given mount point.
+Any 'FsPath' paths used with the session after the session is created are also interpreted
+with respect to the mount point.
+'importSnapshot' and 'exportSnapshot' are currently the only two functions that take
+'FsPaths' as arguments.
+'FsPath's are subject to a number of constraints, which are mentioned in its haddock documentation.
+-}
+withOpenMountedSessionIO ::
+  Tracer IO LSMTreeTrace ->
+  -- | The mount point
+  FilePath ->
+  -- | Session directory
+  FsPath ->
+  (Session IO -> IO a) ->
+  IO a
+withOpenMountedSessionIO tracer mountPointDir sessionDir action = do
+  let mountPoint = MountPoint mountPointDir
+  let sessionDirFsPath = sessionDir
   sessionSalt <- randomIO
   withIOHasBlockIO mountPoint defaultIOCtxParams $ \hasFS hasBlockIO ->
     withOpenSession tracer hasFS hasBlockIO sessionSalt sessionDirFsPath action
@@ -2809,6 +2885,149 @@ listSnapshots ::
   m [SnapshotName]
 listSnapshots (Session session) =
   Internal.listSnapshots session
+
+
+{- |
+Import a snapshot from an external directory.
+
+The source directory should exist.
+Snapshots should only be imported from a directory on the same volume as the session directory.
+
+Importing does not not check whether the external directory is a snapshot, and
+neither does importing verify the snapshot contents if it is a snapshot.
+Open the snapshot to verify that it is a snapshot and that it is not corrupted.
+
+The 'FsPath' path to the source directory is a relative path that is interpreted
+relative to a /root/ (sometimes also called a mount point).
+What the root is depends on which function was used to create the session.
+See 'withOpenSession', 'withOpenSessionIO', and 'withOpenMountedSessionIO' for more
+information about the root.
+
+It is generally not advisable to use 'importSnapshot' and 'exportSnapshot' when the session is
+created using 'withOpenSessionIO'.
+Snapshots should only be exported to somewhere /outside/ the session directory, which is not possible
+when the session is created using 'withOpenSessionIO'.
+Use 'withOpenMountedSessionIO' or 'withOpenSession' instead.
+
+>>> :{
+runExample $ \session table -> do
+  -- Save snapshot
+  LSMT.insert table 0 "Hello" Nothing
+  LSMT.insert table 1 "World" Nothing
+  LSMT.saveSnapshot "example" "Key Value Blob" table
+  -- Export then import snapshot
+  let exportDir = mkFsPath ["export"]
+  LSMT.exportSnapshot session "example" exportDir
+  LSMT.importSnapshot session "example_new" exportDir
+  -- Open the imported snapshot
+  LSMT.withTableFromSnapshot @_ @_ @Value
+    session "example_new" "Key Value Blob" $ \table' -> do
+      print =<< LSMT.lookup table 0
+      print =<< LSMT.lookup table 1
+:}
+Found (Value "Hello")
+Found (Value "World")
+
+The worst-case disk I\/O complexity of this operation depends on the merge policy of the table:
+
+['LazyLevelling']:
+    \(O(T \log_T \frac{n}{B})\).
+
+Throws the following exceptions:
+
+['SessionClosedError']:
+    If the session is closed.
+['SnapshotExistsError']:
+    If a snapshot with the same name already exists.
+['SnapshotImportDirDoesNotExistError']:
+    If the source directory for the to-be-imported snapshot does not exist.
+-}
+{-# SPECIALISE
+  importSnapshot ::
+    Session IO ->
+    SnapshotName ->
+    FsPath ->
+    IO ()
+  #-}
+importSnapshot ::
+  forall m.
+  (IOLike m) =>
+  Session m ->
+  SnapshotName ->
+  -- | Source directory
+  FsPath ->
+  m ()
+importSnapshot (Session session) =
+    Internal.importSnapshot session
+
+{- |
+Export a snapshot to an external directory.
+
+The destination directory should not exist already.
+Snapshots should only be exported to a directory on the same volume as the session directory.
+
+The 'FsPath' path to the destination directory is a relative path that is interpreted
+relative to a /root/.
+What the root is depends on which function was used to create the session.
+See 'withOpenSession', 'withOpenSessionIO', and 'withOpenMountedSessionIO' for more
+information about the root.
+
+It is generally not advisable to use 'importSnapshot' and 'exportSnapshot' when the session is
+created using 'withOpenSessionIO'.
+Snapshots should only be exported to somewhere /outside/ the session directory, which is not possible
+when the session is created using 'withOpenSessionIO'.
+Use 'withOpenMountedSessionIO' or 'withOpenSession' instead.
+
+>>> :{
+runExample $ \session table -> do
+  -- Save snapshot
+  LSMT.insert table 0 "Hello" Nothing
+  LSMT.insert table 1 "World" Nothing
+  LSMT.saveSnapshot "example" "Key Value Blob" table
+  -- Export then import snapshot
+  let exportDir = mkFsPath ["export"]
+  LSMT.exportSnapshot session "example" exportDir
+  LSMT.importSnapshot session "example_new" exportDir
+  -- Open the imported snapshot
+  LSMT.withTableFromSnapshot @_ @_ @Value
+    session "example_new" "Key Value Blob" $ \table' -> do
+      print =<< LSMT.lookup table 0
+      print =<< LSMT.lookup table 1
+:}
+Found (Value "Hello")
+Found (Value "World")
+
+The worst-case disk I\/O complexity of this operation depends on the merge policy of the table:
+
+['LazyLevelling']:
+    \(O(T \log_T \frac{n}{B})\).
+
+Throws the following exceptions:
+
+['SessionClosedError']:
+    If the session is closed.
+['SnapshotDoesNotExistError']:
+    If no snapshot with the given name exists.
+['SnapshotExportDirExistsError']:
+    If the destination directory for the to-be-exported snapshot already exists.
+-}
+{-# SPECIALISE
+  exportSnapshot ::
+    Session IO ->
+    SnapshotName ->
+    FsPath ->
+    IO ()
+  #-}
+exportSnapshot ::
+  forall m.
+  (IOLike m) =>
+  Session m ->
+  SnapshotName ->
+  -- | Destination directory
+  FsPath ->
+  m ()
+exportSnapshot (Session session) =
+    Internal.exportSnapshot session
 
 -- | Internal helper. Get 'resolveSerialised' at type 'ResolveSerialisedValue'.
 _getResolveSerialisedValue ::

--- a/lsm-tree/src/Database/LSMTree/Simple.hs
+++ b/lsm-tree/src/Database/LSMTree/Simple.hs
@@ -186,6 +186,7 @@ import qualified Database.LSMTree as LSMT
 import qualified Database.LSMTree.Internal.Types as LSMT
 import qualified Database.LSMTree.Internal.Unsafe as Internal
 import           Prelude hiding (lookup, take, takeWhile)
+import qualified System.FS.API as FS
 import           System.FS.API (MountPoint (..), mkFsPath)
 import           System.FS.BlockIO.API (HasBlockIO (..))
 import           System.FS.BlockIO.IO (defaultIOCtxParams, ioHasBlockIO)
@@ -426,7 +427,7 @@ withOpenSession ::
 withOpenSession dir action = do
     let tracer = mempty
     _convertSessionDirErrors dir $
-        LSMT.withOpenSessionIO tracer dir (action . Session)
+        LSMT.withOpenMountedSessionIO tracer dir (FS.mkFsPath []) (action . Session)
 
 {- |
 Open a session from a session directory.

--- a/lsm-tree/test/Main.hs
+++ b/lsm-tree/test/Main.hs
@@ -41,6 +41,7 @@ import qualified Test.Database.LSMTree.Internal.WriteBufferBlobs.FS
 import qualified Test.Database.LSMTree.Internal.WriteBufferReader.FS
 import qualified Test.Database.LSMTree.Model.Table
 import qualified Test.Database.LSMTree.Resolve
+import qualified Test.Database.LSMTree.Snapshots
 import qualified Test.Database.LSMTree.StateMachine
 import qualified Test.Database.LSMTree.StateMachine.DL
 import qualified Test.Database.LSMTree.Tracer.Golden
@@ -90,6 +91,7 @@ main = do
     , Test.Database.LSMTree.Internal.WriteBufferReader.FS.tests
     , Test.Database.LSMTree.Model.Table.tests
     , Test.Database.LSMTree.Resolve.tests
+    , Test.Database.LSMTree.Snapshots.tests
     , Test.Database.LSMTree.StateMachine.tests
     , Test.Database.LSMTree.StateMachine.DL.tests
     , Test.Database.LSMTree.Tracer.Golden.tests

--- a/lsm-tree/test/Test/Database/LSMTree/Snapshots.hs
+++ b/lsm-tree/test/Test/Database/LSMTree/Snapshots.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Database.LSMTree.Snapshots (tests) where
+
+import           Control.Tracer (nullTracer)
+import           Data.Monoid (Sum (Sum))
+import qualified Data.Vector as V
+import           Data.Void (Void)
+import           Data.Word (Word64)
+import           Database.LSMTree (ResolveValue, Salt, SerialiseKey,
+                     SerialiseValue, Table, TableConfig (confWriteBufferAlloc),
+                     WriteBufferAlloc (AllocNumEntries), defaultTableConfig,
+                     exportSnapshot, getValue, importSnapshot, inserts, lookups,
+                     saveSnapshot, withOpenSession, withTableFromSnapshot,
+                     withTableWith)
+
+import           Database.LSMTree.Extras (showRangesOf)
+import qualified System.FS.API as FS
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (Arbitrary, Property, Small (Small),
+                     checkCoverage, ioProperty, tabulate, testProperty, (===))
+import           Test.Util.FS (withTempIOHasBlockIO)
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Snapshots" [
+      testProperty "prop_exportImportSnapshot" prop_exportImportSnapshot
+    ]
+
+{-------------------------------------------------------------------------------
+  Snapshot import and export
+-------------------------------------------------------------------------------}
+
+newtype Key = Key Word64
+  deriving stock (Show, Eq, Ord)
+  deriving newtype SerialiseKey
+  deriving Arbitrary via Small Word64
+
+newtype Value = Value Word64
+  deriving stock (Show, Eq)
+  deriving newtype (SerialiseValue)
+  deriving ResolveValue via Sum Word64
+  deriving Arbitrary via Small Word64
+
+-- | Tables opened from imported snapshots behave the same as the original table
+-- that the snapshot was created for.
+--
+-- We test this by looking at the observable behaviour of the two tables. If
+-- lookups on both tables produce the same result, then they are logically
+-- equivalent.
+--
+-- Moreover, if importing or exporting were to corrupt the snapshots, then
+-- opening the snapshot would throw an error, which this test would catch.
+prop_exportImportSnapshot ::
+     V.Vector (Key, Value)
+  -> V.Vector Key
+  -> Property
+prop_exportImportSnapshot ins los =
+    checkCoverage $
+    ioProperty $
+    withTempIOHasBlockIO "prop_exportImportSnapshot" $ \hfs hbio -> do
+      FS.createDirectoryIfMissing hfs True sessionDir
+
+      -- Open a session and create a snapshot for some arbitrary table contents
+      withOpenSession nullTracer hfs hbio salt sessionDir $ \session ->
+        withTableWith conf session $ \(table1 :: Table IO Key Value Void) -> do
+          inserts table1 $ V.map (\(k, v) -> (k, v, Nothing)) ins
+          saveSnapshot "snap1" "KeyValueBlob" table1
+
+          -- Export then re-import the snapshot
+          exportSnapshot session "snap1" exportDir
+          importSnapshot session "snap2" exportDir
+
+          -- Open a table from the re-imported snapshot. Any corruption of the
+          -- snapshot would be identified here.
+          withTableFromSnapshot session "snap2" "KeyValueBlob" $ \(table2 :: Table IO Key Value Void) -> do
+
+            -- Check that lookups on both the original and re-imported table
+            -- match
+            lrs1 <- V.map getValue <$> lookups table1 los
+            lrs2 <- V.map getValue <$> lookups table2 los
+
+            pure $
+              tabulate "# of physical table entries" [ showRangesOf 5 $ V.length ins ] $
+              tabulate "# of lookups"                [ showRangesOf 5 $ V.length los ] $
+              tabulate "# of successful lookups"     [ showRangesOf 5 $ V.length $ V.catMaybes lrs1 ] $
+              tabulate "# of unsuccessful lookups"   [ showRangesOf 5 $ V.length $ V.filter (==Nothing) lrs1 ] $
+              lrs1 === lrs2
+  where
+    sessionDir = FS.mkFsPath ["session"]
+
+    -- | Directory for storing exported snapshots
+    exportDir = FS.mkFsPath ["export"]
+
+    salt :: Salt
+    salt = 17
+
+    conf :: TableConfig
+    conf = defaultTableConfig {
+        confWriteBufferAlloc = AllocNumEntries 3
+      }


### PR DESCRIPTION
Partially resolves #272 

This enables storing snapshots in directories other than the session directory. For now, exports are only supported for destination directories that are on the same disk volume.

This also does not yet support sharing snapshot directories between different sessions, as suggested in #272.


