### PR TITLE
Fix a typo in a bit-mask in `unpackRunIxKeyIx`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,8 @@ To publish a release for a package, follow the steps below:
 
 * Changelog checks (`CHANGELOG.md`):
   * Check that all user-facing changes have been recorded.
-  * Check that each changelog entry has a `BREAKING`, `NON-BREAKING`, or `PATCH`
-    level.
+  * Check that each changelog entry is in one of these sections: `Breaking
+    changes`, `New features`, `Minor changes`, or `Bug fixes`.
   * Check that each changelog entry links to a PR, if applicable.
   * Add or update the changelog's section header with the package version that
     is going to be released, and the date of the release. The version should be

--- a/blockio/CHANGELOG.md
+++ b/blockio/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Revision history for blockio
 
 ## Unreleased
-* PATCH: Support `io-classes ^>=1.9` and `^>=1.10`. See PR
+
+### Breaking changes
+
+None
+
+### New features
+
+None
+
+### Minor changes
+
+* Support `io-classes ^>=1.9` and `^>=1.10`. See PR
   [#819](https://github.com/IntersectMBO/lsm-tree/pull/819).
+
+### Bug fixes
+
+None
 
 ## 0.1.1.1 -- 2025-12-10
 

--- a/blockio/blockio.cabal
+++ b/blockio/blockio.cabal
@@ -64,6 +64,7 @@ common language
     DerivingStrategies
     DerivingVia
     LambdaCase
+    OverloadedRecordDot
 
 flag serialblockio
   description: Use serial HasBlockIO regardless of the operating system

--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -17,7 +17,9 @@ None
 
 ### Bug fixes
 
-None
+* Fix a bug where `lookups` with a large number of input keys would sometimes
+  return incorrect lookup results. See [PR
+  #841](https://github.com/IntersectMBO/lsm-tree/pull/841).
 
 ## 1.0.0.1 -- 2025-12-03
 

--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -2,8 +2,22 @@
 
 ## Unreleased
 
-* PATCH: Support `io-classes ^>=1.9` and `^>=1.10`. See PR [#819](https://github.com/IntersectMBO/lsm-tree/pull/819).
+### Breaking changes
 
+None
+
+### New features
+
+None
+
+### Minor changes
+
+* Support `io-classes ^>=1.9` and `^>=1.10`. See PR
+  [#819](https://github.com/IntersectMBO/lsm-tree/pull/819).
+
+### Bug fixes
+
+None
 
 ## 1.0.0.1 -- 2025-12-03
 

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -528,6 +528,7 @@ common language
     ExplicitNamespaces
     GADTs
     LambdaCase
+    OverloadedRecordDot
     RecordWildCards
     RoleAnnotations
     ViewPatterns

--- a/lsm-tree/src-core/Database/LSMTree/Internal/BloomFilter.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/BloomFilter.hs
@@ -89,7 +89,7 @@ packRunIxKeyIx r k =
 unpackRunIxKeyIx :: RunIxKeyIx -> (Int, Int)
 unpackRunIxKeyIx (MkRunIxKeyIx c) =
     ( fromIntegral (c `unsafeShiftR` 16)
-    , fromIntegral (c .&. 0xfff)
+    , fromIntegral (c .&. 0xffff)
     )
 {-# INLINE unpackRunIxKeyIx #-}
 

--- a/lsm-tree/test/Database/LSMTree/Model/Session.hs
+++ b/lsm-tree/test/Database/LSMTree/Model/Session.hs
@@ -598,7 +598,7 @@ saveSnapshot name label t@Table{..} = do
       })
 
 openTableFromSnapshot ::
-     forall k v b m.(
+     forall k v b m. (
        MonadState Model m
      , MonadError Err m
      , C k v b

--- a/lsm-tree/test/Test/Database/LSMTree/Internal/BloomFilter.hs
+++ b/lsm-tree/test/Test/Database/LSMTree/Internal/BloomFilter.hs
@@ -184,7 +184,9 @@ prop_bloomQueries (FPR fpr) filters keys =
 --
 -- There used to be a bug where this went wrong because of a typo in a bit-mask.
 -- This property test should ensure that we catch such mistakes in the future.
--- See PR #
+-- See PR #841 for more information.
+--
+-- <PR https://github.com/IntersectMBO/lsm-tree/pull/841>
 --
 prop_packUnpack_RunIxKeyIx :: Int_0xffff -> Int_0xffff -> Property
 prop_packUnpack_RunIxKeyIx r k =

--- a/lsm-tree/test/Test/Database/LSMTree/Internal/BloomFilter.hs
+++ b/lsm-tree/test/Test/Database/LSMTree/Internal/BloomFilter.hs
@@ -44,6 +44,8 @@ tests = testGroup "Database.LSMTree.Internal.BloomFilter"
         prop_total_deserialisation_whitebox
     , testProperty "bloomQueries (bulk)" $
         prop_bloomQueries
+    , testProperty "prop_packUnpack_RunIxKeyIx" prop_packUnpack_RunIxKeyIx
+    , testProperty "prop_packUnpack_RunIxKeyIx_limits" prop_packUnpack_RunIxKeyIx_limits
     ]
 
 testSalt :: Bloom.Salt
@@ -168,3 +170,48 @@ prop_bloomQueries (FPR fpr) filters keys =
        ===
         map (\(RunIxKeyIx rix kix) -> (rix, kix))
             (VP.toList (bloomQueries testSalt (V.fromList filters') (V.fromList keys')))
+
+{-------------------------------------------------------------------------------
+  RunIxKeyIx
+-------------------------------------------------------------------------------}
+
+-- | Test that 'RunIx' and 'KeyIx' roundtrip through the 'RunIxKeyIx' pattern
+-- synonym
+--
+-- More specifically, if we apply a 'RunIxKeyIx' pattern synonym to a pair of
+-- 'RunIx' and 'KeyIx', and then pattern match on it agains, then we would
+-- expect to get the same 'RunIx' and 'KeyIx' out as the ones we put in.
+--
+-- There used to be a bug where this went wrong because of a typo in a bit-mask.
+-- This property test should ensure that we catch such mistakes in the future.
+-- See PR #
+--
+prop_packUnpack_RunIxKeyIx :: Int_0xffff -> Int_0xffff -> Property
+prop_packUnpack_RunIxKeyIx r k =
+    case RunIxKeyIx r.unwrap k.unwrap of
+      RunIxKeyIx r' k' -> r.unwrap === r' .&&. k.unwrap === k'
+
+-- | A variant of 'prop_packUnpack_RunIxKeyIx' applied to 'RunIx' and 'KeyIx'
+-- that are close to their upper bounds.
+prop_packUnpack_RunIxKeyIx_limits :: Property
+prop_packUnpack_RunIxKeyIx_limits = conjoin [
+      prop_packUnpack_RunIxKeyIx 0xffff       0xffff
+    , prop_packUnpack_RunIxKeyIx (0xffff - 1) 0xffff
+    , prop_packUnpack_RunIxKeyIx 0xffff       (0xffff - 1)
+    , prop_packUnpack_RunIxKeyIx (0xffff - 1) (0xffff - 1)
+    ]
+
+-- | An Int in the inclusive range @(0, 0xffff)@
+newtype Int_0xffff = Int_0xffff { unwrap :: Int }
+  deriving stock (Show, Eq)
+  deriving newtype Num
+
+instance Arbitrary Int_0xffff where
+  arbitrary = Int_0xffff <$> chooseInt (0, 0xffff)
+  shrink x = [
+        Int_0xffff y
+      | y <- shrink x.unwrap
+      , 0 <= y
+      , y < 0xfff
+      ]
+


### PR DESCRIPTION
When calling `Database.LSMTree.lookups` with large-sized batches of keys, @jasagredo was seeing unexpected `NotFound` lookup results. The offending code is a typo in a bit-mask that we use while querying bloom filters. This typo effectively limited the number of bloom queries we could perform on a single run to `4096` (hexadecimal: `0xfff`),  while the limit should have been `65536` (hexadecimal: `0xffff`). So under high `lookups` workloads, this limit would be hit and hence the erroneous lookup results.