### PR TITLE
Update to fs-sim 0.5.0.0

### DIFF
--- a/blockio/CHANGELOG.md
+++ b/blockio/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Revision history for blockio
 
+## Next version -- unreleased
+
+### Breaking changes
+
+* Update to `fs-sim ^>=0.5`. See PR
+  [#845](https://github.com/IntersectMBO/lsm-tree/pull/845).
+
+### New features
+
+None
+
+### Minor changes
+
+None
+
+### Bug fixes
+
+None
+
 ## 0.1.1.2 -- 2026-04-24
 
 ### Breaking changes

--- a/blockio/blockio.cabal
+++ b/blockio/blockio.cabal
@@ -149,7 +149,7 @@ library sim
     , blockio
     , bytestring             ^>=0.11 || ^>=0.12
     , fs-api                 ^>=0.4
-    , fs-sim                 ^>=0.4
+    , fs-sim                 ^>=0.4  || ^>=0.5
     , io-classes             ^>=1.6  || ^>=1.7  || ^>=1.8.0.1 || ^>=1.9 || ^>=1.10
     , io-classes:strict-stm
     , primitive              ^>=0.9

--- a/blockio/src-sim/System/FS/BlockIO/Sim.hs
+++ b/blockio/src-sim/System/FS/BlockIO/Sim.hs
@@ -207,7 +207,7 @@ simCreateHardLink hfs sourcePath targetPath =
 -- If you want to have access to the current state of the mocked file system,
 -- use 'simHasBlockIO' instead.
 runSimHasBlockIO ::
-     (MonadSTM m, PrimMonad m, MonadCatch m, MonadMVar m)
+     (MonadSTM m, PrimMonad m, MonadMask m, MonadMVar m)
   => MockFS
   -> (HasFS m HandleMock -> HasBlockIO m HandleMock -> m a)
   -> m (a, MockFS)
@@ -230,7 +230,7 @@ runSimHasBlockIO mockFS k = do
 -- If you want to have access to the current state of the mocked file system
 -- or stream of errors, use 'simErrorHasBlockIO' instead.
 runSimErrorHasBlockIO ::
-     (MonadSTM m, PrimMonad m, MonadCatch m, MonadMVar m)
+     (MonadSTM m, PrimMonad m, MonadMask m, MonadMVar m)
   => MockFS
   -> Errors
   -> (HasFS m HandleMock -> HasBlockIO m HandleMock -> m a)
@@ -256,7 +256,7 @@ runSimErrorHasBlockIO mockFS errs k = do
 -- the user by reading @mockFsVar@, but note that the user should not leave
 -- @mockFsVar@ empty.
 simHasBlockIO ::
-     (MonadCatch m, MonadMVar m, PrimMonad m, MonadSTM m)
+     (MonadMask m, MonadMVar m, PrimMonad m, MonadSTM m)
   => StrictTMVar m MockFS
   -> m (HasFS m HandleMock, HasBlockIO m HandleMock)
 simHasBlockIO var = do
@@ -273,7 +273,7 @@ simHasBlockIO var = do
 -- If you want to have access to the current state of the mocked file system,
 -- use 'simHasBlockIO' instead.
 simHasBlockIO' ::
-     (MonadCatch m, MonadMVar m, PrimMonad m, MonadSTM m)
+     (MonadMask m, MonadMVar m, PrimMonad m, MonadSTM m)
   => MockFS
   -> m (HasFS m HandleMock, HasBlockIO m HandleMock)
 simHasBlockIO' mockFS = do
@@ -293,7 +293,7 @@ simHasBlockIO' mockFS = do
 -- @errorsVar@. The current state of the stream of errors can be accessed by the
 -- user by reading @errorsVar@.
 simErrorHasBlockIO ::
-     forall m. (MonadCatch m, MonadMVar m, PrimMonad m, MonadSTM m)
+     forall m. (MonadMask m, MonadMVar m, PrimMonad m, MonadSTM m)
   => StrictTMVar m MockFS
   -> StrictTVar m Errors
   -> m (HasFS m HandleMock, HasBlockIO m HandleMock)
@@ -314,7 +314,7 @@ simErrorHasBlockIO fsVar errorsVar = do
 -- If you want to have access to the current state of the mocked file system
 -- or stream of errors, use 'simErrorHasBlockIO' instead.
 simErrorHasBlockIO' ::
-     (MonadCatch m, MonadMVar m, PrimMonad m, MonadSTM m)
+     (MonadMask m, MonadMVar m, PrimMonad m, MonadSTM m)
   => MockFS
   -> Errors
   -> m (HasFS m HandleMock, HasBlockIO m HandleMock)

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -1,7 +1,7 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  -- current date: release lsm-tree-1.0.0.2 and blockio-0.1.1.2
-  , hackage.haskell.org 2026-04-24T00:00:00Z
+  -- current date: fs-sim-0.5.0.0
+  , hackage.haskell.org 2026-04-24T11:17:18Z
 
 packages:
   ./lsm-tree

--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -16,7 +16,8 @@ None
 
 ### Minor changes
 
-None
+* Update to `fs-sim ^>=0.5`. See PR
+  [#845](https://github.com/IntersectMBO/lsm-tree/pull/845).
 
 ### Bug fixes
 

--- a/lsm-tree/test/Test/Util/FS.hs
+++ b/lsm-tree/test/Test/Util/FS.hs
@@ -55,7 +55,7 @@ import           Control.Concurrent.Class.MonadMVar
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Exception (assert)
 import           Control.Monad (void)
-import           Control.Monad.Class.MonadThrow (MonadCatch, MonadThrow)
+import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Monad.Primitive (PrimMonad)
 import           Data.Bit (MVector (..), flipBit)
@@ -108,7 +108,7 @@ withTempIOHasBlockIO path action = withSystemTempDirectory path $ \dir -> do
 
 {-# INLINABLE withSimHasFS #-}
 withSimHasFS ::
-     (MonadSTM m, MonadThrow m, PrimMonad m, Testable prop1, Testable prop2)
+     (MonadSTM m, MonadMask m, PrimMonad m, Testable prop1, Testable prop2)
   => (MockFS -> prop1)
   -> MockFS
   -> (  HasFS m HandleMock
@@ -125,7 +125,7 @@ withSimHasFS post fs k = do
 
 {-# INLINABLE withSimHasBlockIO #-}
 withSimHasBlockIO ::
-     (MonadMVar m, MonadSTM m, MonadCatch m, PrimMonad m, Testable prop1, Testable prop2)
+     (MonadMVar m, MonadSTM m, MonadMask m, PrimMonad m, Testable prop1, Testable prop2)
   => (MockFS -> prop1)
   -> MockFS
   -> (  HasFS m HandleMock
@@ -145,7 +145,7 @@ withSimHasBlockIO post fs k = do
 
 {-# INLINABLE withSimErrorHasFS #-}
 withSimErrorHasFS ::
-     (MonadSTM m, MonadThrow m, PrimMonad m, Testable prop1, Testable prop2)
+     (MonadSTM m, MonadMask m, PrimMonad m, Testable prop1, Testable prop2)
   => (MockFS -> prop1)
   -> MockFS
   -> Errors
@@ -165,7 +165,7 @@ withSimErrorHasFS post fs errs k = do
 
 {-# INLINABLE withSimErrorHasBlockIO #-}
 withSimErrorHasBlockIO ::
-     ( MonadSTM m, MonadCatch m, MonadMVar m, PrimMonad m
+     ( MonadSTM m, MonadMask m, MonadMVar m, PrimMonad m
      , Testable prop1, Testable prop2
      )
   => (MockFS -> prop1)

--- a/lsm-tree/test/Test/Util/FS/Error.hs
+++ b/lsm-tree/test/Test/Util/FS/Error.hs
@@ -107,7 +107,7 @@ countNoisyErrors = getSum . bfoldMapC @IsNoisy (Sum . length . Prelude.filter is
 
 -- | Like 'simErrorHasFSLogged', but also produces a simulated 'HasBlockIO'.
 simErrorHasBlockIOLogged ::
-     forall m. (MonadCatch m, MonadMVar m, PrimMonad m, MonadSTM m)
+     forall m. (MonadMask m, MonadMVar m, PrimMonad m, MonadSTM m)
   => StrictTMVar m MockFS
   -> StrictTVar m Errors
   -> StrictTVar m (HKD [])
@@ -123,7 +123,7 @@ simErrorHasBlockIOLogged fsVar errorsVar logVar = do
 -- Every time a 'HasFS' primitive is used and an error from 'Errors' is used, it
 -- will be logged in 'ErrorsLog'.
 simErrorHasFSLogged ::
-     forall m. (MonadSTM m, MonadThrow m, PrimMonad m)
+     forall m. (MonadSTM m, MonadMask m, PrimMonad m)
   => StrictTMVar m MockFS
   -> StrictTVar m Errors
   -> StrictTVar m ErrorsLog


### PR DESCRIPTION
# Description

`ouroboros-consensus` needs this new fs-sim version, which has breaking changes:

```
### Breaking

* Make `sim` operations exception safe by using `withMockFS`.
* Require `MonadMask` in `simHasFS`, `simHasFS'`, `runSimFS`.
```

# Checklist

- [ ] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

