### PR TITLE
Support `blockio-uring ^>= 0.2`, drop support for `blockio-uring ^>= 0.1`

### DIFF
--- a/blockio/CHANGELOG.md
+++ b/blockio/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Breaking changes
 
-* Update to `fs-sim ^>=0.5`. See PR
-  [#845](https://github.com/IntersectMBO/lsm-tree/pull/845).
+* Update to `fs-sim ^>=0.5`. See [PR
+  #845](https://github.com/IntersectMBO/lsm-tree/pull/845).
+* `IOCtxParams` has a new record field for configuring the use of IOWAIT
+  metrics. Like the other configuration options, this option only applies on
+  Linux platforms. See [PR
+  #846](https://github.com/IntersectMBO/lsm-tree/pull/846). For more information
+  about the new option, see the documentation for `blockio-uring`.
 
 ### New features
 
@@ -13,7 +18,8 @@ None
 
 ### Minor changes
 
-None
+* Support `blockio-uring ^>= 0.2`, and drop support for `blockio-uring ^>= 0.1`.
+  See [PR #846](https://github.com/IntersectMBO/lsm-tree/pull/846)
 
 ### Bug fixes
 

--- a/blockio/blockio.cabal
+++ b/blockio/blockio.cabal
@@ -101,7 +101,7 @@ library
 
     if !flag(serialblockio)
       other-modules: System.FS.BlockIO.Async
-      build-depends: blockio-uring ^>=0.1
+      build-depends: blockio-uring ^>=0.2
 
   elif os(osx)
     hs-source-dirs: src-macos

--- a/blockio/src-linux/System/FS/BlockIO/Async.hs
+++ b/blockio/src-linux/System/FS/BlockIO/Async.hs
@@ -51,10 +51,11 @@ asyncHasBlockIO hSetNoCache hAdvise hAllocate tryLockFile hSynchronise synchroni
     }
 
 ctxParamsConv :: IOI.IOCtxParams -> I.IOCtxParams
-ctxParamsConv IOI.IOCtxParams{IOI.ioctxBatchSizeLimit, IOI.ioctxConcurrencyLimit} =
+ctxParamsConv IOI.IOCtxParams{IOI.ioctxBatchSizeLimit, IOI.ioctxConcurrencyLimit, IOI.ioctxIOWaitMetrics} =
     I.IOCtxParams {
         I.ioctxBatchSizeLimit   = ioctxBatchSizeLimit
       , I.ioctxConcurrencyLimit = ioctxConcurrencyLimit
+      , I.ioctxIOWaitMetrics    = ioctxIOWaitMetrics
       }
 
 submitIO ::

--- a/blockio/src/System/FS/BlockIO/IO/Internal.hs
+++ b/blockio/src/System/FS/BlockIO/IO/Internal.hs
@@ -42,18 +42,20 @@ import           System.IO.Error (ioeSetErrorString, mkIOError)
 --  them, see the @blockio-uring@ package.
 data IOCtxParams = IOCtxParams {
                      ioctxBatchSizeLimit   :: !Int,
-                     ioctxConcurrencyLimit :: !Int
+                     ioctxConcurrencyLimit :: !Int,
+                     ioctxIOWaitMetrics    :: !Bool
                    }
 
 instance NFData IOCtxParams where
-  rnf (IOCtxParams x y) = rnf x `seq` rnf y
+  rnf (IOCtxParams x y z) = rnf x `seq` rnf y `seq` rnf z
 
 -- | Default parameters. Some manual tuning of parameters might be required to
 -- achieve higher performance targets (see 'IOCtxParams').
 defaultIOCtxParams :: IOCtxParams
 defaultIOCtxParams = IOCtxParams {
       ioctxBatchSizeLimit   = 64,
-      ioctxConcurrencyLimit = 64 * 3
+      ioctxConcurrencyLimit = 64 * 3,
+      ioctxIOWaitMetrics    = True
     }
 
 {-------------------------------------------------------------------------------

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -1,7 +1,7 @@
 index-state:
   -- Bump this if you need newer packages from Hackage
-  -- current date: fs-sim-0.5.0.0
-  , hackage.haskell.org 2026-04-24T11:17:18Z
+  -- current date: blockio-uring-0.2.0.0
+  , hackage.haskell.org 2026-04-30T10:58:23Z
 
 packages:
   ./lsm-tree


### PR DESCRIPTION
Resolves #839