### PR TITLE
blockio: Use osx implementation on freebsd

### DIFF
--- a/blockio/blockio.cabal
+++ b/blockio/blockio.cabal
@@ -103,7 +103,7 @@ library
       other-modules: System.FS.BlockIO.Async
       build-depends: blockio-uring ^>=0.2
 
-  elif os(osx)
+  elif os(osx) || os(freebsd)
     hs-source-dirs: src-macos
     build-depends:  unix ^>=2.8.4
     other-modules:


### PR DESCRIPTION
`cabal test` passes.