### PR TITLE
Support data-elevator 0.3.*

### DIFF
--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Revision history for `lsm-tree`
 
+## ?.?.?.? -- ????-??-??
+
+### Breaking changes
+
+None
+
+### New features
+
+None
+
+### Minor changes
+
+* Support `data-elevator-0.3`. See [issue #856](https://github.com/IntersectMBO/lsm-tree/issues/856) and [PR #857](https://github.com/IntersectMBO/lsm-tree/pull/857).
+
+### Bug fixes
+
+None
+
 ## 1.1.0.0 -- 2026-05-13
 
 ### Breaking changes

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -644,7 +644,7 @@ library core
 
   if impl(ghc >=9.4)
     other-modules: Database.LSMTree.Internal.StrictArray
-    build-depends: data-elevator ^>=0.1.0.2 || ^>=0.2
+    build-depends: data-elevator ^>=0.1.0.2 || ^>=0.2 || ^>=0.3
     cpp-options:   -DHAVE_STRICT_ARRAY
 
 library extras


### PR DESCRIPTION
# Description
Relaxes `data-elevator` bounds to allow `^>=0.3`.
- Updates `index-state` to a newer snapshot so `0.3.*` resolves.
- Tests: `cabal build all` and `cabal test all`.
(https://github.com/IntersectMBO/lsm-tree/issues/856)

# Checklist

- [x] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.
- [x] Tests passes

