### PR TITLE
Support `random` version 1.2.0

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -78,3 +78,29 @@
     lhs: "Test.QuickCheck.withMaxSuccess"
     rhs: "withNumTests_compat"
 - ignore: { name: "Use withNumTests_compat", within: "Test.Util.QC.Compat" }
+
+### splitGen compatibility
+- error:
+    name: "Use splitGen_compat"
+    lhs: "System.Random.splitGen"
+    rhs: "splitGen_compat"
+- error:
+    name: "Use splitGen_compat"
+    lhs: "System.Random.Stateful.splitGen"
+    rhs: "splitGen_compat"
+- error:
+    name: "Use splitGen_compat"
+    lhs: "System.Random.split"
+    rhs: "splitGen_compat"
+- error:
+    name: "Use splitGen_compat"
+    lhs: "System.Random.Stateful.split"
+    rhs: "splitGen_compat"
+- ignore: { name: "Use splitGen_compat", within: "Database.LSMTree.Extras.Random" }
+
+### uniform compatibility
+- error:
+    name: "Use uniform_compat"
+    lhs: "System.Random.uniform"
+    rhs: "uniform_compat"
+- ignore: { name: "Use uniform_compat", within: "Database.LSMTree.Extras.Random" }

--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -18,6 +18,8 @@ None
 * Support `ghc-9.14`. See [issue
   #813](https://github.com/IntersectMBO/lsm-tree/issues/813) and [PR
   #859](https://github.com/IntersectMBO/lsm-tree/pull/859).
+* Drop support for `random < 1.2`. See [PR
+  #865](https://github.com/IntersectMBO/lsm-tree/pull/865).
 
 ### Bug fixes
 

--- a/lsm-tree/bench-unions/Bench/Unions.hs
+++ b/lsm-tree/bench-unions/Bench/Unions.hs
@@ -159,13 +159,13 @@ makeKey seed =
     case P.runPrimArray $ do
            v <- P.newPrimArray 5
            let g0 = Random.mkStdGen (fromIntegral seed)
-           let (!w0, !g1) = Random.uniform g0
+           let (!w0, !g1) = Random.uniform_compat g0
            P.writePrimArray v 0 w0
-           let (!w1, !g2) = Random.uniform g1
+           let (!w1, !g2) = Random.uniform_compat g1
            P.writePrimArray v 1 w1
-           let (!w2, !g3) = Random.uniform g2
+           let (!w2, !g3) = Random.uniform_compat g2
            P.writePrimArray v 2 w2
-           let (!w3, _g4) = Random.uniform g3
+           let (!w3, _g4) = Random.uniform_compat g3
            P.writePrimArray v 3 w3
            P.writePrimArray v 4 0x3d3d3d3d3d3d3d3d -- ========
            case v of
@@ -461,7 +461,7 @@ deriveSetupRNGs :: GlobalOpts -> Int -> NonEmpty Random.StdGen
 deriveSetupRNGs gOpts amount =
     let  -- g1 is reserved for the run command
         (_g1, !g2) = deriveInitialForkedRNGs gOpts
-    in  NE.fromList $ take amount $ List.unfoldr (Just . Random.splitGen) g2
+    in  NE.fromList $ take amount $ List.unfoldr (Just . Random.splitGen_compat) g2
 
 deriveRunRNG :: GlobalOpts -> Random.StdGen
 deriveRunRNG gOpts =
@@ -470,7 +470,7 @@ deriveRunRNG gOpts =
     in  g1
 
 deriveInitialForkedRNGs :: GlobalOpts -> (Random.StdGen, Random.StdGen)
-deriveInitialForkedRNGs = Random.splitGen . Random.mkStdGen . seed
+deriveInitialForkedRNGs = Random.splitGen_compat . Random.mkStdGen . seed
 
 -------------------------------------------------------------------------------
 -- Batch generation

--- a/lsm-tree/bench/macro/lsm-tree-bench-bloomfilter.hs
+++ b/lsm-tree/bench/macro/lsm-tree-bench-bloomfilter.hs
@@ -24,6 +24,8 @@ import           System.Random
 import           Text.Printf (printf)
 
 import           Database.LSMTree.Extras.Orphans ()
+import           Database.LSMTree.Extras.Random (splitGen_compat,
+                     uniform_compat)
 import           Database.LSMTree.Internal.Assertions (fromIntegralChecked)
 import qualified Database.LSMTree.Internal.BloomFilter as Bloom
 import           Database.LSMTree.Internal.Serialise (SerialisedKey,
@@ -236,7 +238,7 @@ elemManyEnv filterSizes rng0 =
          when (i .&. 0xFFFF == 0) (unsafeIOToST $ putStr ".")
          -- insert n elements into filter b
          let k :: Word256
-             (!k, !rng') = uniform rng
+             (!k, !rng') = uniform_compat rng
          Bloom.insert mb (serialiseKey k)
          pure rng'
       )
@@ -257,9 +259,9 @@ benchInBatches !b !rng0 !action =
     go !rng !n
       | n <= 0    = ()
       | otherwise =
-        let (!rng'', !rng') = splitGen rng
+        let (!rng'', !rng') = splitGen_compat rng
             ks  :: VP.Vector Word256
-            !ks  = VP.unfoldrExactN b uniform rng'
+            !ks  = VP.unfoldrExactN b uniform_compat rng'
             ks' :: V.Vector SerialisedKey
             !ks' = V.map serialiseKey (V.convert ks)
         in action ks' `seq` go rng'' (n-b)

--- a/lsm-tree/bench/macro/lsm-tree-bench-lookups.hs
+++ b/lsm-tree/bench/macro/lsm-tree-bench-lookups.hs
@@ -20,6 +20,7 @@ import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Unboxed.Mutable as VUM
 import           Database.LSMTree.Extras.Orphans ()
+import           Database.LSMTree.Extras.Random (uniform_compat)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Arena (ArenaManager, newArenaManager,
                      withArena)
@@ -404,7 +405,7 @@ genLookupBatch !rng0 !n0
           !res <- V.unsafeFreeze mres
           pure (res, rng)
       | otherwise = do
-          let (!k, !rng') = uniform @UTxOKey @StdGen rng
+          let (!k, !rng') = uniform_compat @UTxOKey @StdGen rng
               !sk = serialiseKey k
           VM.write mres i $! sk
           go rng' (i+1) mres
@@ -548,7 +549,7 @@ vectorOfUniforms !vec !g0 = do
       | i == n-1 = pure g
       | otherwise = do
           when (i .&. 0xFFFF == 0) (unsafeIOToPrim $ putStr ".")
-          let (!x, !g') = uniform g
+          let (!x, !g') = uniform_compat g
           VGM.unsafeWrite vec i x
           loop (i+1) g'
 

--- a/lsm-tree/bench/macro/utxo-bench.hs
+++ b/lsm-tree/bench/macro/utxo-bench.hs
@@ -79,6 +79,7 @@ import           Database.LSMTree.Extras (groupsOfN)
 -- We should be able to write this benchmark
 -- using only use public lsm-tree interface
 import qualified Database.LSMTree as LSM
+import qualified Database.LSMTree.Extras.Random as Random
 
 -------------------------------------------------------------------------------
 -- Table configuration
@@ -114,13 +115,13 @@ makeKey seed =
     case P.runPrimArray $ do
            v <- P.newPrimArray 5
            let g0 = Random.mkStdGen (fromIntegral seed)
-           let (!w0, !g1) = Random.uniform g0
+           let (!w0, !g1) = Random.uniform_compat g0
            P.writePrimArray v 0 w0
-           let (!w1, !g2) = Random.uniform g1
+           let (!w1, !g2) = Random.uniform_compat g1
            P.writePrimArray v 1 w1
-           let (!w2, !g3) = Random.uniform g2
+           let (!w2, !g3) = Random.uniform_compat g2
            P.writePrimArray v 2 w2
-           let (!w3, _g4) = Random.uniform g3
+           let (!w3, _g4) = Random.uniform_compat g3
            P.writePrimArray v 3 w3
            P.writePrimArray v 4 0x3d3d3d3d3d3d3d3d -- ========
            case v of

--- a/lsm-tree/bench/micro/Bench/Database/LSMTree.hs
+++ b/lsm-tree/bench/micro/Bench/Database/LSMTree.hs
@@ -17,6 +17,7 @@ import           Data.Word
 import           Database.LSMTree hiding (withTable)
 import           Database.LSMTree.Extras
 import           Database.LSMTree.Extras.Orphans ()
+import           Database.LSMTree.Extras.Random (uniform_compat)
 import           Database.LSMTree.Internal.Assertions (fromIntegralChecked)
 import qualified Database.LSMTree.Internal.RawBytes as RB
 import           GHC.Generics (Generic)
@@ -116,7 +117,7 @@ benchLargeValueVsSmallValueBlob =
 
       customRandomEntries :: Int -> V.Vector (K, Word64, ShortByteString)
       customRandomEntries n = V.unfoldrExactN n f (mkStdGen 17)
-        where f !g = let (!k, !g') = uniform g
+        where f !g = let (!k, !g') = uniform_compat g
                     in  ((k, v, b), g')
               -- The exact value does not matter much, so we pick an arbitrary
               -- hardcoded one.
@@ -207,7 +208,7 @@ benchCursorScanVsRangeLookupScan =
 
       customRandomEntries :: Int -> V.Vector (K, V2, Maybe B2)
       customRandomEntries n = V.unfoldrExactN n f (mkStdGen 17)
-        where f !g = let (!k, !g') = uniform g
+        where f !g = let (!k, !g') = uniform_compat g
                     in  ((k, v, Nothing), g')
               -- The exact value does not matter much, so we pick an arbitrary
               -- hardcoded one.
@@ -257,7 +258,7 @@ benchInsertBatches =
 
       randomInserts :: Int -> V.Vector (K, V2, Maybe Void)
       randomInserts n = V.unfoldrExactN n f (mkStdGen 17)
-        where f !g = let (!k, !g') = uniform g
+        where f !g = let (!k, !g') = uniform_compat g
                     in  ((k, v, Nothing), g')
               -- The exact value does not matter much, so we pick an arbitrary
               -- hardcoded one.
@@ -414,7 +415,7 @@ benchLookupInsertsVsLookupUpserts =
 -- | Random keys, default values @1@
 randomEntries :: Int -> V.Vector (K, V3)
 randomEntries n = V.unfoldrExactN n f (mkStdGen 17)
-  where f !g = let (!k, !g') = uniform g
+  where f !g = let (!k, !g') = uniform_compat g
                in  ((k, 1), g')
 
 -- | Like 'randomEntries', but also returns groups of size 'm'

--- a/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/BloomFilter.hs
+++ b/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/BloomFilter.hs
@@ -57,8 +57,8 @@ elemEnv ::
   -> IO (Bloom SerialisedKey, [SerialisedKey])
 elemEnv fpr nbloom nelemsPositive nelemsNegative = do
     let g = mkStdGen 100
-        (g1, g') = R.splitGen g
-        (g2, g3) = R.splitGen g'
+        (g1, g') = splitGen_compat g
+        (g2, g3) = splitGen_compat g'
 
     let (xs, ys1) = splitAt nbloom
                   $ uniformWithoutReplacement    @UTxOKey g1  (nbloom + nelemsNegative)

--- a/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -16,8 +16,8 @@ import           Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import           Database.LSMTree.Extras.Orphans ()
 import           Database.LSMTree.Extras.Random (frequency, randomByteStringR,
-                     sampleUniformWithReplacement, shuffle,
-                     uniformWithoutReplacement)
+                     sampleUniformWithReplacement, shuffle, splitGen_compat,
+                     uniformWithoutReplacement, uniform_compat)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Arena (ArenaManager, closeArena,
                      newArena, newArenaManager, withArena)
@@ -248,9 +248,9 @@ lookupsEnv ::
         , V.Vector SerialisedKey
         )
 lookupsEnv g nentries npos nneg = do
-    let  (g1, g')  = R.splitGen g
-         (g2, g'') = R.splitGen g'
-         (g3, g4)  = R.splitGen g''
+    let  (g1, g')  = splitGen_compat g
+         (g2, g'') = splitGen_compat g'
+         (g3, g4)  = splitGen_compat g''
     let (keys, negLookups) = splitAt nentries
                            $ uniformWithoutReplacement @UTxOKey g1 (nentries + nneg)
         posLookups         = sampleUniformWithReplacement g2 npos keys
@@ -267,14 +267,14 @@ lookupsEnv g nentries npos nneg = do
 
 randomEntry :: StdGen -> (Entry UTxOValue ByteString, StdGen)
 randomEntry g = frequency [
-      (20, \g' -> let (!v, !g'') = uniform g' in (Insert v, g''))
-    , (1,  \g' -> let (!v, !g'') = uniform g'
+      (20, \g' -> let (!v, !g'') = uniform_compat g' in (Insert v, g''))
+    , (1,  \g' -> let (!v, !g'') = uniform_compat g'
                       -- The size of the blobs doesn't matter for the benchmark,
                       -- as it only deals with the blob references. So we make
                       -- them tiny to not slow down the setup.
                       (!b, !g''') = randomByteStringR (0, 100) g''
                   in  (InsertWithBlob v b, g'''))
-    , (2,  \g' -> let (!v, !g'') = uniform g' in (Upsert v, g''))
+    , (2,  \g' -> let (!v, !g'') = uniform_compat g' in (Upsert v, g''))
     , (2,  \g' -> (Delete, g'))
     ] g
 

--- a/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
+++ b/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/Merge.hs
@@ -36,8 +36,7 @@ import qualified System.FS.BlockIO.API as FS
 import qualified System.FS.BlockIO.IO as FS
 import qualified System.FS.IO as FS
 import           System.IO.Temp
-import qualified System.Random as R
-import           System.Random (StdGen, mkStdGen, uniform, uniformR)
+import           System.Random (StdGen, mkStdGen, uniformR)
 
 benchmarks :: Benchmark
 benchmarks = bgroup "Bench.Database.LSMTree.Internal.Merge" [
@@ -345,22 +344,22 @@ defaultConfig = Config {
 
 configWord64 :: Config
 configWord64 = defaultConfig {
-    randomKey    = first serialiseKey . uniform @Word64 @_
-  , randomValue  = first serialiseValue . uniform @Word64 @_
+    randomKey    = first serialiseKey . R.uniform_compat @Word64 @_
+  , randomValue  = first serialiseValue . R.uniform_compat @Word64 @_
   , randomBlob   = first serialiseBlob . R.randomByteStringR (0, 0x2000)  -- up to 8 kB
   }
 
 configUTxO :: Config
 configUTxO = defaultConfig {
-    randomKey    = first serialiseKey . uniform @UTxOKey @_
-  , randomValue  = first serialiseValue . uniform @UTxOValue @_
+    randomKey    = first serialiseKey . R.uniform_compat @UTxOKey @_
+  , randomValue  = first serialiseValue . R.uniform_compat @UTxOValue @_
   }
 
 configUTxOStaking :: Config
 configUTxOStaking = defaultConfig {
     fmupserts    = 1
-  , randomKey    = first serialiseKey . uniform @UTxOKey @_
-  , randomValue  = first serialiseValue . uniform @Word64 @_
+  , randomKey    = first serialiseKey . R.uniform_compat @UTxOKey @_
+  , randomValue  = first serialiseValue . R.uniform_compat @Word64 @_
   , mergeResolve = Just (onDeserialisedValues ((+) @Word64))
   }
 
@@ -410,7 +409,7 @@ randomRuns hasFS hasBlockIO refCtx config@Config {..} rng0 = do
         zipWith
           (randomRunData config)
           nentries
-          (List.unfoldr (Just . R.splitGen) rng0)
+          (List.unfoldr (Just . R.splitGen_compat) rng0)
 
 -- | Generate keys and entries to insert into the write buffer.
 -- They are already serialised to exclude the cost from the benchmark.
@@ -425,7 +424,7 @@ randomRunData Config {..} runentries g0 =
       (R.withoutReplacement g1 runentries randomKey)
       (R.withReplacement g2 runentries randomEntry)
   where
-    (g1, g2) = R.splitGen g0
+    (g1, g2) = R.splitGen_compat g0
 
     randomEntry :: Rnd (Entry SerialisedValue SerialisedBlob)
     randomEntry = R.frequency

--- a/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/Serialise.hs
+++ b/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/Serialise.hs
@@ -3,13 +3,14 @@ module Bench.Database.LSMTree.Internal.Serialise (
   ) where
 
 import           Criterion.Main
+import           Database.LSMTree.Extras.Random (uniform_compat)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.Serialise.Class
 import           System.Random
 
 benchmarks :: Benchmark
 benchmarks = bgroup "Bench.Database.LSMTree.Internal.Serialise" [
-      env (pure $ fst $ uniform (mkStdGen 12)) $ \(k :: UTxOKey) ->
+      env (pure $ fst $ uniform_compat (mkStdGen 12)) $ \(k :: UTxOKey) ->
         bgroup "UTxOKey" [
             bench "serialiseKey" $ whnf serialiseKey k
           , bench "serialiseKeyRoundtrip" $ whnf serialiseKeyRoundtrip k

--- a/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/lsm-tree/bench/micro/Bench/Database/LSMTree/Internal/WriteBuffer.hs
@@ -10,14 +10,15 @@ import qualified Data.List as List
 import           Data.Maybe (fromMaybe, isJust, isNothing)
 import           Data.Word (Word64)
 import           Database.LSMTree.Extras.Orphans ()
-import           Database.LSMTree.Extras.Random (frequency, randomByteStringR)
+import           Database.LSMTree.Extras.Random (frequency, randomByteStringR,
+                     uniform_compat)
 import           Database.LSMTree.Extras.UTxO
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Serialise
 import           Database.LSMTree.Internal.WriteBuffer (WriteBuffer)
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
-import           System.Random (StdGen, mkStdGen, uniform)
+import           System.Random (StdGen, mkStdGen)
 
 benchmarks :: Benchmark
 benchmarks = bgroup "Bench.Database.LSMTree.Internal.WriteBuffer" [
@@ -168,14 +169,14 @@ defaultConfig = Config {
 
 configWord64 :: Config
 configWord64 = defaultConfig {
-    randomKey    = first serialiseKey . uniform @Word64 @_
-  , randomValue  = first serialiseValue . uniform @Word64 @_
+    randomKey    = first serialiseKey . uniform_compat @Word64 @_
+  , randomValue  = first serialiseValue . uniform_compat @Word64 @_
   }
 
 configUTxO :: Config
 configUTxO = defaultConfig {
-    randomKey    = first serialiseKey . uniform @UTxOKey @_
-  , randomValue  = first serialiseValue . uniform @UTxOValue @_
+    randomKey    = first serialiseKey . uniform_compat @UTxOKey @_
+  , randomValue  = first serialiseValue . uniform_compat @UTxOValue @_
   }
 
 envInputKOps :: Config -> InputKOps
@@ -219,6 +220,6 @@ randomKOps Config {..} = take nentries . List.unfoldr (Just . randomKOp) .
 
 randomBlobSpan :: Rnd BlobSpan
 randomBlobSpan !g =
-  let (off, !g')  = uniform g
-      (len, !g'') = uniform g'
+  let (off, !g')  = uniform_compat g
+      (len, !g'') = uniform_compat g'
   in (BlobSpan off len, g'')

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -802,7 +802,7 @@ test-suite lsm-tree-test
     , quickcheck-dynamic
     , quickcheck-instances
     , quickcheck-lockstep     >=0.8
-    , random                  ^>=1.3
+    , random
     , safe-wild-cards
     , semialign
     , split
@@ -852,7 +852,7 @@ benchmark lsm-tree-micro-bench
     , lsm-tree:core
     , lsm-tree:extras
     , QuickCheck
-    , random               ^>=1.3
+    , random
     , temporary
     , vector
 
@@ -868,7 +868,7 @@ benchmark lsm-tree-bench-bloomfilter
     , bloomfilter-blocked
     , lsm-tree:core
     , lsm-tree:extras
-    , random               ^>=1.3
+    , random
     , time
     , vector
     , wide-word
@@ -891,7 +891,7 @@ benchmark lsm-tree-bench-lookups
     , lsm-tree:core
     , lsm-tree:extras
     , primitive
-    , random               ^>=1.3
+    , random
     , time
     , vector
     , vector-algorithms
@@ -925,7 +925,7 @@ benchmark unions-bench
     , mtl
     , optparse-applicative
     , primitive
-    , random                ^>=1.3
+    , random
     , vector
 
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded

--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -555,7 +555,7 @@ library
     , lsm-tree:control
     , lsm-tree:core
     , primitive               ^>=0.9
-    , random                  ^>=1.0   || ^>=1.1 || ^>=1.2     || ^>=1.3
+    , random                  ^>=1.2   || ^>=1.3
     , text                    ^>=2.1.1
     , vector                  ^>=0.13
 
@@ -802,7 +802,7 @@ test-suite lsm-tree-test
     , quickcheck-dynamic
     , quickcheck-instances
     , quickcheck-lockstep     >=0.8
-    , random
+    , random                  ^>=1.3
     , safe-wild-cards
     , semialign
     , split
@@ -852,7 +852,7 @@ benchmark lsm-tree-micro-bench
     , lsm-tree:core
     , lsm-tree:extras
     , QuickCheck
-    , random
+    , random               ^>=1.3
     , temporary
     , vector
 
@@ -868,7 +868,7 @@ benchmark lsm-tree-bench-bloomfilter
     , bloomfilter-blocked
     , lsm-tree:core
     , lsm-tree:extras
-    , random
+    , random               ^>=1.3
     , time
     , vector
     , wide-word
@@ -891,7 +891,7 @@ benchmark lsm-tree-bench-lookups
     , lsm-tree:core
     , lsm-tree:extras
     , primitive
-    , random
+    , random               ^>=1.3
     , time
     , vector
     , vector-algorithms
@@ -925,7 +925,7 @@ benchmark unions-bench
     , mtl
     , optparse-applicative
     , primitive
-    , random
+    , random                ^>=1.3
     , vector
 
   ghc-options:    -rtsopts -with-rtsopts=-T -threaded

--- a/lsm-tree/src-extras/Database/LSMTree/Extras/Random.hs
+++ b/lsm-tree/src-extras/Database/LSMTree/Extras/Random.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP          #-}
 
 module Database.LSMTree.Extras.Random (
     -- * Sampling from uniform distributions
@@ -38,8 +39,7 @@ sampleUniformWithoutReplacement :: Ord a => StdGen -> Int -> [a] -> [a]
 sampleUniformWithoutReplacement rng0 n (Set.fromList -> xs0)
   | n > Set.size xs0 =
       error $
-        printf "sampleUniformWithoutReplacement: n > length xs0 for n=%d, \
-               \ length xs0=%d"
+        printf "sampleUniformWithoutReplacement: n > length xs0 for n=%d, length xs0=%d"
                n
                (Set.size xs0)
   | otherwise =
@@ -115,6 +115,13 @@ shuffle xs g =
 -- | Generates a random bytestring. Its length is uniformly distributed within
 -- the provided range.
 randomByteStringR :: (Int, Int) -> StdGen -> (BS.ByteString, StdGen)
+#if MIN_VERSION_random(1,3,0)
 randomByteStringR range g =
     let (!l, !g')  = uniformR range g
     in  R.uniformByteString l g'
+#else
+-- MIN_VERSION_random(1,2,0)
+randomByteStringR range g =
+    let (!l, !g')  = uniformR range g
+    in  R.genByteString l g'
+#endif

--- a/lsm-tree/src-extras/Database/LSMTree/Extras/Random.hs
+++ b/lsm-tree/src-extras/Database/LSMTree/Extras/Random.hs
@@ -15,6 +15,9 @@ module Database.LSMTree.Extras.Random (
   , shuffle
     -- * Generators for specific data types
   , randomByteStringR
+    -- * Compatibility
+  , splitGen_compat
+  , uniform_compat
   ) where
 
 import qualified Data.ByteString as BS
@@ -22,7 +25,7 @@ import           Data.List (sortBy, unfoldr)
 import           Data.Ord (comparing)
 import qualified Data.Set as Set
 import qualified System.Random as R
-import           System.Random (StdGen, Uniform, uniform, uniformR)
+import           System.Random (StdGen, Uniform, uniformR)
 import           Text.Printf (printf)
 
 {-------------------------------------------------------------------------------
@@ -30,10 +33,10 @@ import           Text.Printf (printf)
 -------------------------------------------------------------------------------}
 
 uniformWithoutReplacement :: (Ord a, Uniform a) => StdGen -> Int -> [a]
-uniformWithoutReplacement rng n = withoutReplacement rng n uniform
+uniformWithoutReplacement rng n = withoutReplacement rng n uniform_compat
 
 uniformWithReplacement :: Uniform a => StdGen -> Int -> [a]
-uniformWithReplacement rng n = withReplacement rng n uniform
+uniformWithReplacement rng n = withReplacement rng n uniform_compat
 
 sampleUniformWithoutReplacement :: Ord a => StdGen -> Int -> [a] -> [a]
 sampleUniformWithoutReplacement rng0 n (Set.fromList -> xs0)
@@ -125,3 +128,29 @@ randomByteStringR range g =
     let (!l, !g')  = uniformR range g
     in  R.genByteString l g'
 #endif
+
+{-------------------------------------------------------------------------------
+  Compatibility
+-------------------------------------------------------------------------------}
+
+-- | Alternative to @splitGen@ that is also compatible with versions of
+-- random<1.3
+--
+-- Uses @split@ on @random<1.3@, and @splitGen@ on @random>=1.3@. The former
+-- function is deprecated on @random>=1.3@.
+splitGen_compat :: StdGen -> (StdGen, StdGen)
+#if MIN_VERSION_random(1,3,0)
+splitGen_compat = R.splitGen
+#else
+splitGen_compat = R.split
+#endif
+
+-- | Alternative to @uniform@ that is also compatible with versions of
+-- random<1.3
+--
+-- The order of type variables is different on random<1.3 and random>=1.3. This
+-- is inconvenient for type application, so we use this compatibility function
+-- to ensure that the type variables always have the same ordering.
+uniform_compat :: (Uniform a, R.RandomGen g) => g -> (a, g)
+uniform_compat = R.uniform
+

--- a/lsm-tree/test/Test/Database/LSMTree/Internal/RunBloomFilterAlloc.hs
+++ b/lsm-tree/test/Test/Database/LSMTree/Internal/RunBloomFilterAlloc.hs
@@ -36,7 +36,7 @@ import           Database.LSMTree.Extras.Random
 import qualified Database.LSMTree.Internal.Entry as LSMT
 import           Database.LSMTree.Internal.RunAcc (RunBloomFilterAlloc (..),
                      newMBloom)
-import           System.Random hiding (Seed)
+import           System.Random (StdGen, Uniform, mkStdGen)
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck


### PR DESCRIPTION
# Description

Currently, `lsm-tree` declares support with `random` versions `>=1.0 && <1.4`. However, the `extras` library, the benchmarks, and the tests only compile with `random` versions `>=1.3 && <1.4`. Moreover, `lsm-tree` declares support for GHC versions `>=9.2 && <9.14` in its `tested-with` field, but the last GHC version supported by `random-1.2.0` is GHC 9.0.

Unfortunately, nixpkgs is stuck at `random.1.2.1.3` for the time being, and upgrading its random version is a nightmare.

This PR adds genuine support for `random` versions `>=1.2 && <1.4` to the main and extras libraries, updates their version bounds, and adds appropriate bounds to the benchmarks and tests. (It should be possible to support `random-1.2.0` in the tests and benchmarks as well, but would require so much more CPP, so I've opted not to bother.)

# Checklist

- [X] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.

