### PR TITLE
Replace `exportSnapshot`/`importSnapshot` with variants that always copy

### DIFF
--- a/lsm-tree/lsm-tree.cabal
+++ b/lsm-tree/lsm-tree.cabal
@@ -633,6 +633,7 @@ library core
     , contra-tracer           ^>=0.1      || ^>=0.2
     , crc32c                  ^>=0.2.1
     , deepseq                 ^>=1.4      || ^>=1.5
+    , directory               ^>=1.3
     , filepath                ^>=1.4      || ^>=1.5
     , fs-api                  ^>=0.4
     , io-classes              ^>=1.6      || ^>=1.7      || ^>=1.8.0.1 || ^>=1.9 || ^>=1.10

--- a/lsm-tree/src-core/Database/LSMTree/Internal/FS.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/FS.hs
@@ -4,18 +4,27 @@ module Database.LSMTree.Internal.FS (
   , hardLinkDirectoryRecursive
     -- * Copy file
   , copyFile
+  , copyFileToDisk
+  , copyFileFromDisk
+  , copyDirectoryToDiskRecursive
+  , copyDirectoryFromDiskRecursive
   ) where
 
 import           Control.ActionRegistry
 import           Control.Monad (forM_, void)
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Primitive (PrimMonad)
+import           Control.Monad.Primitive (PrimBase, PrimMonad (..), RealWorld,
+                     ioToPrim, primToIO)
 
+import qualified Data.ByteString.Lazy as BSL
+import qualified System.Directory as Dir
+import qualified System.FilePath as FP
 import qualified System.FS.API as FS
 import           System.FS.API
 import qualified System.FS.API.Lazy as FSL
 import qualified System.FS.BlockIO.API as FS
 import           System.FS.BlockIO.API (HasBlockIO)
+import qualified System.IO as IO
 import           Text.Printf (printf)
 
 {-------------------------------------------------------------------------------
@@ -115,3 +124,126 @@ copyFile hfs reg sourcePath destinationPath =
         FS.withFile hfs destinationPath (FS.WriteMode FS.MustBeNew) $ \targetHandle -> do
           bs <- FSL.hGetAll hfs sourceHandle
           void $ FSL.hPutAll hfs targetHandle bs
+
+{-# SPECIALISE
+  copyFileToDisk ::
+       HasFS IO h
+    -> ActionRegistry IO
+    -> FS.FsPath
+    -> FilePath
+    -> IO ()
+  #-}
+-- | @'copyFileToDisk' hfs reg sourcePath destinationPath@ copies the file
+--   contents of @sourcePath@ to the on-disk filepath @destinationPath@.
+copyFileToDisk ::
+     (MonadMask m, PrimBase m, PrimState m ~ RealWorld)
+  => HasFS m h
+  -> ActionRegistry m
+  -> FS.FsPath
+  -> FilePath
+  -> m ()
+copyFileToDisk hfs reg sourcePath destinationPath =
+  flip (withRollback_ reg) (ioToPrim $ Dir.removeFile destinationPath) $
+    FS.withFile hfs sourcePath FS.ReadMode $ \sourceHandle -> do
+      ioToPrim . IO.withFile destinationPath IO.WriteMode $ \destinationHandle -> do
+        bs <- primToIO $ FSL.hGetAll hfs sourceHandle
+        BSL.hPut destinationHandle bs
+
+{-# SPECIALISE
+  copyFileFromDisk ::
+       HasFS IO h
+    -> ActionRegistry IO
+    -> FilePath
+    -> FS.FsPath
+    -> IO ()
+  #-}
+-- | @'copyFileFromDisk' hfs reg sourcePath destinationPath@ copies the file
+--   contents of @sourcePath@ to the on-disk filepath @destinationPath@.
+copyFileFromDisk ::
+     (MonadMask m, PrimBase m, PrimState m ~ RealWorld)
+  => HasFS m h
+  -> ActionRegistry m
+  -> FilePath
+  -> FS.FsPath
+  -> m ()
+copyFileFromDisk hfs reg sourcePath destinationPath =
+  flip (withRollback_ reg) (FS.removeFile hfs destinationPath) $
+    ioToPrim . IO.withFile sourcePath IO.ReadMode $ \sourceHandle -> do
+      primToIO . FS.withFile hfs destinationPath (FS.WriteMode FS.MustBeNew) $ \destinationHandle -> do
+        bs <- ioToPrim $ BSL.hGetContents sourceHandle
+        void $ FSL.hPutAll hfs destinationHandle bs
+
+{-# SPECIALISE
+  copyDirectoryToDiskRecursive ::
+       HasFS IO h
+    -> ActionRegistry IO
+    -> FS.FsPath
+    -> FilePath
+    -> IO ()
+  #-}
+-- | Recursively copy all the directory contents from the source
+-- path at the destination path.
+copyDirectoryToDiskRecursive ::
+  forall m h.
+     (MonadMask m, PrimBase m, PrimState m ~ RealWorld)
+  => HasFS m h
+  -> ActionRegistry m
+     -- | Source path
+  -> FS.FsPath
+     -- | Destination path
+  -> FilePath
+  -> m ()
+copyDirectoryToDiskRecursive hfs reg sourcePath destinationPath = do
+  entries <- FS.listDirectory hfs sourcePath
+  forM_ entries $ \entry -> do
+    let sourcePath' = sourcePath FS.</> FS.mkFsPath [entry]
+        destinationPath' = destinationPath FP.</> entry
+    isFile <- FS.doesFileExist hfs sourcePath'
+    if isFile then
+      copyFileToDisk hfs reg sourcePath' destinationPath'
+    else do
+      isDirectory <- FS.doesDirectoryExist hfs sourcePath'
+      if isDirectory then do
+        copyDirectoryToDiskRecursive hfs reg sourcePath' destinationPath'
+      else
+        error $ printf
+          "copyDirectoryToDiskRecursive: %s is not a file or directory"
+          (show sourcePath')
+
+
+{-# SPECIALISE
+  copyDirectoryFromDiskRecursive ::
+       HasFS IO h
+    -> ActionRegistry IO
+    -> FilePath
+    -> FS.FsPath
+    -> IO ()
+  #-}
+-- | Recursively copy all the directory contents from the source
+-- path at the destination path.
+copyDirectoryFromDiskRecursive ::
+  forall m h.
+     (MonadMask m, PrimBase m, PrimState m ~ RealWorld)
+  => HasFS m h
+  -> ActionRegistry m
+     -- | Destination path
+  -> FilePath
+     -- | Source path
+  -> FS.FsPath
+  -> m ()
+copyDirectoryFromDiskRecursive hfs reg sourcePath destinationPath = do
+  entries <- ioToPrim $ Dir.listDirectory sourcePath
+  forM_ entries $ \entry -> do
+    let sourcePath' = sourcePath FP.</> entry
+        destinationPath' = destinationPath FS.</> FS.mkFsPath [entry]
+    isFile <- ioToPrim $ Dir.doesFileExist sourcePath'
+    if isFile then
+      copyFileFromDisk hfs reg sourcePath' destinationPath'
+    else do
+      isDirectory <- ioToPrim $ Dir.doesDirectoryExist sourcePath'
+      if isDirectory then do
+        copyDirectoryFromDiskRecursive hfs reg sourcePath' destinationPath'
+      else
+        error $ printf
+          "copyDirectoryFromDiskRecursive: %s is not a file or directory"
+          (show sourcePath')

--- a/lsm-tree/src-core/Database/LSMTree/Internal/Unsafe.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/Unsafe.hs
@@ -82,8 +82,8 @@ module Database.LSMTree.Internal.Unsafe (
   , deleteSnapshot
   , doesSnapshotExist
   , listSnapshots
-  , importSnapshot
-  , exportSnapshot
+  , importSnapshotFromDisk
+  , exportSnapshotToDisk
     -- * Multiple writable tables
   , duplicate
     -- * Table union
@@ -161,6 +161,7 @@ import           Database.LSMTree.Internal.UniqCounter
 import qualified Database.LSMTree.Internal.Vector as V
 import qualified Database.LSMTree.Internal.WriteBuffer as WB
 import qualified Database.LSMTree.Internal.WriteBufferBlobs as WBB
+import qualified System.Directory as Dir
 import qualified System.FS.API as FS
 import           System.FS.API (FsError, FsErrorPath (..), FsPath, HasFS)
 import qualified System.FS.API.Lazy as FS
@@ -251,13 +252,13 @@ data SessionTrace =
 
     -- | We are importing a snapshot. A 'TraceImportedSnapshot' message should
     -- follow if successful.
-  | TraceImportSnapshot SnapshotName FsPath
+  | TraceImportSnapshot SnapshotName FilePath
     -- | Importing a snapshot was successful.
   | TraceImportedSnapshot SnapshotName
 
     -- | We are exporting a snapshot. A 'TraceExportedSnapshot' message should
     -- follow if successful.
-  | TraceExportSnapshot SnapshotName FsPath
+  | TraceExportSnapshot SnapshotName FilePath
     -- | Exporting a snapshot was successful.
   | TraceExportedSnapshot SnapshotName
 
@@ -1915,39 +1916,40 @@ listSnapshots sesh = do
 
 -- | A snapshot was intended to be imported, but the source directory does not
 -- exist.
-data SnapshotImportDirDoesNotExistError
-    = SnapshotImportDirDoesNotExistError !FsPath
+newtype SnapshotImportDirDoesNotExistError
+    = SnapshotImportDirDoesNotExistError FilePath
     deriving stock (Show, Eq)
     deriving anyclass (Exception)
 
-{-# SPECIALISE importSnapshot ::
+{-# SPECIALISE importSnapshotFromDisk ::
      Session IO h
   -> SnapshotName
-  -> FsPath
+  -> FilePath
   -> IO () #-}
--- |  See 'Database.LSMTree.importSnapshot'.
-importSnapshot ::
-     (MonadMask m, MonadSTM m, PrimMonad m)
+-- |  See 'Database.LSMTree.importSnapshotFromDisk'.
+importSnapshotFromDisk ::
+     (MonadMask m, MonadSTM m, PrimBase m, PrimState m ~ RealWorld)
   => Session m h
   -> SnapshotName
-  -> FsPath
+  -> FilePath
   -> m ()
-importSnapshot sesh snap sourcePath = do
+importSnapshotFromDisk sesh snap sourcePath = do
     traceWith sesh.sessionTracer $ TraceImportSnapshot snap sourcePath
     withKeepSessionOpen sesh $ \seshEnv ->
       withActionRegistry $ \reg -> do
         let hfs = seshEnv.sessionHasFS
             hbio = seshEnv.sessionHasBlockIO
 
-        -- Guard that the snapshot does not exist already
+        -- Guard that the internal snapshot does not exist already
         let snapDir = Paths.namedSnapshotDir (sessionRoot seshEnv) snap
         snapshotExists <- doesSnapshotDirExist snap seshEnv
         when snapshotExists $ throwIO (ErrSnapshotExists snap)
 
-        let destinationPath = Paths.getNamedSnapshotDir snapDir
-
-        sourceExists <- FS.doesDirectoryExist hfs sourcePath
+        -- Guard that the external snapshot exists
+        sourceExists <- ioToPrim $ Dir.doesDirectoryExist sourcePath
         unless sourceExists $ throwIO (SnapshotImportDirDoesNotExistError sourcePath)
+
+        let destinationPath = Paths.getNamedSnapshotDir snapDir
 
         -- we assume the snapshots directory already exists, so we just have
         -- to create the directory for this specific snapshot.
@@ -1955,8 +1957,8 @@ importSnapshot sesh snap sourcePath = do
           (FS.createDirectory hfs destinationPath)
           (FS.removeDirectoryRecursive hfs destinationPath)
 
-        -- create hard links for all files in the destination directory
-        FS.hardLinkDirectoryRecursive hfs hbio reg sourcePath destinationPath
+        -- copy all files from the source directory
+        FS.copyDirectoryFromDiskRecursive hfs reg sourcePath destinationPath
 
         -- Make the destination directory and its contents durable
         FS.synchroniseDirectoryRecursive hfs hbio destinationPath
@@ -1968,29 +1970,28 @@ importSnapshot sesh snap sourcePath = do
 
 -- | A snapshot was intended to be exported, but the destination directory
 -- already exists.
-data SnapshotExportDirExistsError
-    = SnapshotExportDirExistsError !FsPath
+newtype SnapshotExportDirExistsError
+    = SnapshotExportDirExistsError FilePath
     deriving stock (Show, Eq)
     deriving anyclass (Exception)
 
-{-# SPECIALISE exportSnapshot ::
+{-# SPECIALISE exportSnapshotToDisk ::
      Session IO h
   -> SnapshotName
-  -> FsPath
+  -> FilePath
   -> IO () #-}
--- |  See 'Database.LSMTree.exportSnapshot'.
-exportSnapshot ::
-     (MonadMask m, MonadSTM m, PrimMonad m)
+-- |  See 'Database.LSMTree.exportSnapshotToDisk'.
+exportSnapshotToDisk ::
+     (MonadMask m, MonadSTM m, PrimBase m, PrimState m ~ RealWorld)
   => Session m h
   -> SnapshotName
-  -> FsPath
+  -> FilePath
   -> m ()
-exportSnapshot sesh snap destinationPath = do
+exportSnapshotToDisk sesh snap destinationPath = do
     traceWith (sessionTracer sesh) $ TraceExportSnapshot snap destinationPath
     withKeepSessionOpen sesh $ \seshEnv ->
       withActionRegistry $ \reg -> do
         let hfs = seshEnv.sessionHasFS
-            hbio = seshEnv.sessionHasBlockIO
 
         -- Guard that the snapshot exists already
         let snapDir = Paths.namedSnapshotDir (sessionRoot seshEnv) snap
@@ -1999,18 +2000,16 @@ exportSnapshot sesh snap destinationPath = do
 
         let sourcePath = Paths.getNamedSnapshotDir snapDir
 
-        destinationExists <- FS.doesDirectoryExist hfs destinationPath
-        when destinationExists $ throwIO (SnapshotExportDirExistsError sourcePath)
+        -- Guard that the external snapshot does not exist
+        destinationExists <- ioToPrim $ Dir.doesDirectoryExist destinationPath
+        when destinationExists $ throwIO (SnapshotExportDirExistsError destinationPath)
 
         withRollback_ reg
-          (FS.createDirectoryIfMissing hfs True destinationPath)
-          (FS.removeDirectoryRecursive hfs destinationPath)
+          (ioToPrim $ Dir.createDirectoryIfMissing True destinationPath)
+          (ioToPrim $ Dir.removeDirectoryRecursive destinationPath)
 
-        -- Create hard links for all files in the destination directory
-        FS.hardLinkDirectoryRecursive hfs hbio reg sourcePath destinationPath
-
-        -- Make the directory and its contents durable.
-        FS.synchroniseDirectoryRecursive hfs hbio destinationPath
+        -- copy all files from the source directory
+        FS.copyDirectoryToDiskRecursive hfs reg sourcePath destinationPath
 
         -- Note: trace the success message only after all side effects have been
         -- succesfully performed

--- a/lsm-tree/src/Database/LSMTree.hs
+++ b/lsm-tree/src/Database/LSMTree.hs
@@ -484,21 +484,8 @@ withOpenSession ::
 withOpenSession tracer hasFS hasBlockIO sessionSalt sessionDir action = do
   Internal.withOpenSession tracer hasFS hasBlockIO sessionSalt sessionDir (action . Session)
 
-{-# DEPRECATED withOpenSessionIO "withOpenSessionIO is not compatible with importSnapshot and exportSnapshot. Use withOpenMountedSessionIO instead." #-}
 {- |
 Variant of 'withOpenSession' that is specialised to 'IO' using the real filesystem.
-
-Any 'FsPath' paths used with the session after the session is created are interpreted
-with respect to the session directory.
-'importSnapshot' and 'exportSnapshot' are currently the only two functions that take
-'FsPaths' as arguments.
-'FsPath's are subject to a number of constraints, which are mentioned in its Haddock documentation.
-
-It is generally not advisable to use 'importSnapshot' and 'exportSnapshot' when the session is
-created using 'withOpenSessionIO'.
-Snapshots should only be exported to somewhere /outside/ the session directory, which is not possible
-when the session is created using 'withOpenSessionIO'.
-Use 'withOpenMountedSessionIO' or 'withOpenSession' instead.
 -}
 withOpenSessionIO ::
   Tracer IO LSMTreeTrace ->

--- a/lsm-tree/src/Database/LSMTree.hs
+++ b/lsm-tree/src/Database/LSMTree.hs
@@ -102,8 +102,8 @@ module Database.LSMTree (
   doesSnapshotExist,
   deleteSnapshot,
   listSnapshots,
-  importSnapshot,
-  exportSnapshot,
+  importSnapshotFromDisk,
+  exportSnapshotToDisk,
   SnapshotName,
   isValidSnapshotName,
   toSnapshotName,
@@ -206,7 +206,7 @@ import           Control.Monad.Class.MonadAsync (MonadAsync)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow (MonadCatch (..), MonadEvaluate,
                      MonadMask, MonadThrow (..))
-import           Control.Monad.Primitive (PrimMonad)
+import           Control.Monad.Primitive (PrimBase, PrimMonad (..), RealWorld)
 import           Control.Tracer (Tracer)
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Coerce (coerce)
@@ -2882,26 +2882,14 @@ listSnapshots (Session session) =
 
 
 {- |
-Import a snapshot from an external directory.
+Import a snapshot from an on-disk directory.
 
 The source directory should exist.
-Snapshots should only be imported from a directory on the same volume as the session directory.
 
-Importing does not not check whether the external directory is a snapshot, and
-neither does importing verify the snapshot contents if it is a snapshot.
-Open the snapshot to verify that it is a snapshot and that it is not corrupted.
+Importing /always/ copies the external files.
 
-The 'FsPath' path to the source directory is a relative path that is interpreted
-relative to a /root/ (sometimes also called a mount point).
-What the root is depends on which function was used to create the session.
-See 'withOpenSession', 'withOpenSessionIO', and 'withOpenMountedSessionIO' for more
-information about the root.
-
-It is generally not advisable to use 'importSnapshot' and 'exportSnapshot' when the session is
-created using 'withOpenSessionIO'.
-Snapshots should only be exported to somewhere /outside/ the session directory, which is not possible
-when the session is created using 'withOpenSessionIO'.
-Use 'withOpenMountedSessionIO' or 'withOpenSession' instead.
+Importing does not check whether the source directory is a snapshot and does not verify the snapshot contents.
+To verify that the source directory is a valid snapshot, open the imported snapshot.
 
 >>> :{
 runExample $ \session table -> do
@@ -2910,9 +2898,9 @@ runExample $ \session table -> do
   LSMT.insert table 1 "World" Nothing
   LSMT.saveSnapshot "example" "Key Value Blob" table
   -- Export then import snapshot
-  let exportDir = mkFsPath ["export"]
-  LSMT.exportSnapshot session "example" exportDir
-  LSMT.importSnapshot session "example_new" exportDir
+  let exportDir = "export"
+  LSMT.exportSnapshotToDisk session "example" exportDir
+  LSMT.importSnapshotFromDisk session "example_new" exportDir
   -- Open the imported snapshot
   LSMT.withTableFromSnapshot @_ @_ @Value
     session "example_new" "Key Value Blob" $ \table' -> do
@@ -2937,40 +2925,27 @@ Throws the following exceptions:
     If the source directory for the to-be-imported snapshot does not exist.
 -}
 {-# SPECIALISE
-  importSnapshot ::
+  importSnapshotFromDisk ::
     Session IO ->
     SnapshotName ->
-    FsPath ->
+    FilePath ->
     IO ()
   #-}
-importSnapshot ::
+importSnapshotFromDisk ::
   forall m.
-  (IOLike m) =>
+  (IOLike m, PrimBase m, PrimState m ~ RealWorld) =>
   Session m ->
   SnapshotName ->
   -- | Source directory
-  FsPath ->
+  FilePath ->
   m ()
-importSnapshot (Session session) =
-    Internal.importSnapshot session
+importSnapshotFromDisk (Session session) =
+    Internal.importSnapshotFromDisk session
 
 {- |
 Export a snapshot to an external directory.
 
 The destination directory should not exist already.
-Snapshots should only be exported to a directory on the same volume as the session directory.
-
-The 'FsPath' path to the destination directory is a relative path that is interpreted
-relative to a /root/.
-What the root is depends on which function was used to create the session.
-See 'withOpenSession', 'withOpenSessionIO', and 'withOpenMountedSessionIO' for more
-information about the root.
-
-It is generally not advisable to use 'importSnapshot' and 'exportSnapshot' when the session is
-created using 'withOpenSessionIO'.
-Snapshots should only be exported to somewhere /outside/ the session directory, which is not possible
-when the session is created using 'withOpenSessionIO'.
-Use 'withOpenMountedSessionIO' or 'withOpenSession' instead.
 
 >>> :{
 runExample $ \session table -> do
@@ -2979,9 +2954,9 @@ runExample $ \session table -> do
   LSMT.insert table 1 "World" Nothing
   LSMT.saveSnapshot "example" "Key Value Blob" table
   -- Export then import snapshot
-  let exportDir = mkFsPath ["export"]
-  LSMT.exportSnapshot session "example" exportDir
-  LSMT.importSnapshot session "example_new" exportDir
+  let exportDir = "export"
+  LSMT.exportSnapshotToDisk session "example" exportDir
+  LSMT.importSnapshotFromDisk session "example_new" exportDir
   -- Open the imported snapshot
   LSMT.withTableFromSnapshot @_ @_ @Value
     session "example_new" "Key Value Blob" $ \table' -> do
@@ -3006,22 +2981,22 @@ Throws the following exceptions:
     If the destination directory for the to-be-exported snapshot already exists.
 -}
 {-# SPECIALISE
-  exportSnapshot ::
+  exportSnapshotToDisk ::
     Session IO ->
     SnapshotName ->
-    FsPath ->
+    FilePath ->
     IO ()
   #-}
-exportSnapshot ::
+exportSnapshotToDisk ::
   forall m.
-  (IOLike m) =>
+  (IOLike m, PrimBase m, PrimState m ~ RealWorld) =>
   Session m ->
   SnapshotName ->
   -- | Destination directory
-  FsPath ->
+  FilePath ->
   m ()
-exportSnapshot (Session session) =
-    Internal.exportSnapshot session
+exportSnapshotToDisk (Session session) =
+    Internal.exportSnapshotToDisk session
 
 -- | Internal helper. Get 'resolveSerialised' at type 'ResolveSerialisedValue'.
 _getResolveSerialisedValue ::

--- a/lsm-tree/test/Test/Database/LSMTree/Snapshots.hs
+++ b/lsm-tree/test/Test/Database/LSMTree/Snapshots.hs
@@ -10,12 +10,14 @@ import           Data.Word (Word64)
 import           Database.LSMTree (ResolveValue, Salt, SerialiseKey,
                      SerialiseValue, Table, TableConfig (confWriteBufferAlloc),
                      WriteBufferAlloc (AllocNumEntries), defaultTableConfig,
-                     exportSnapshot, getValue, importSnapshot, inserts, lookups,
-                     saveSnapshot, withOpenSession, withTableFromSnapshot,
-                     withTableWith)
+                     exportSnapshotToDisk, getValue, importSnapshotFromDisk,
+                     inserts, lookups, saveSnapshot, withOpenSession,
+                     withTableFromSnapshot, withTableWith)
 
 import           Database.LSMTree.Extras (showRangesOf)
+import qualified System.FilePath as FP
 import qualified System.FS.API as FS
+import           System.IO.Temp (withSystemTempDirectory)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (Arbitrary, Property, Small (Small),
                      checkCoverage, ioProperty, tabulate, testProperty, (===))
@@ -57,6 +59,7 @@ prop_exportImportSnapshot ::
 prop_exportImportSnapshot ins los =
     checkCoverage $
     ioProperty $
+    withSystemTempDirectory "prop_exportImportSnapshot" $ \tmp -> do
     withTempIOHasBlockIO "prop_exportImportSnapshot" $ \hfs hbio -> do
       FS.createDirectoryIfMissing hfs True sessionDir
 
@@ -67,8 +70,9 @@ prop_exportImportSnapshot ins los =
           saveSnapshot "snap1" "KeyValueBlob" table1
 
           -- Export then re-import the snapshot
-          exportSnapshot session "snap1" exportDir
-          importSnapshot session "snap2" exportDir
+          let exportDir = tmp FP.</> "export"
+          exportSnapshotToDisk session "snap1" exportDir
+          importSnapshotFromDisk session "snap2" exportDir
 
           -- Open a table from the re-imported snapshot. Any corruption of the
           -- snapshot would be identified here.
@@ -87,9 +91,6 @@ prop_exportImportSnapshot ins los =
               lrs1 === lrs2
   where
     sessionDir = FS.mkFsPath ["session"]
-
-    -- | Directory for storing exported snapshots
-    exportDir = FS.mkFsPath ["export"]
 
     salt :: Salt
     salt = 17


### PR DESCRIPTION
# Description

This PR addresses #853. After discussion with @dcoutts, we concluded that the import/export functions should _never_ hard link, since (1) these operations do not need to be as quick as possible and (2) hard linking opens the database up to accidental corruption if the external link to the snapshot is modified. This PR reverts the deprecation of `withOpenSessionIO` and replaces `importSnapshot` and `exportSnapshot` with `importSnapshotFromDisk` and `exportSnapshotToDisk` which accept `FilePath` arguments and copy the snapshot from/to disk.

If that's desirable, I can reintroduce the old `importSnapshot`/`exportSnapshot` functions as deprecated-but-present functions and make this a non-breaking change, but that _would_ lead to an annoying proliferation of error types.
