### PR TITLE
Add SnapshotVersionMismatchError for snapshot version mismatches

### DIFF
--- a/lsm-tree/CHANGELOG.md
+++ b/lsm-tree/CHANGELOG.md
@@ -15,6 +15,10 @@
   `fallback` flag determines whether the import/export should fall back to
   copying if hard linking fails. If the `SnapshotMode` is `Copy extFS`, the
   `FsPath` is interpreted relative to the root of the `extFS` `HasFS` interface.
+* Opening a snapshot with an incompatible snapshot format version now throws
+  `SnapshotVersionMismatchError` instead of `SnapshotCorruptedError`. See
+  [issue #862](https://github.com/IntersectMBO/lsm-tree/issues/862) and [PR
+  #875](https://github.com/IntersectMBO/lsm-tree/pull/875).
 
 ### New features
 

--- a/lsm-tree/src-core/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -8,6 +8,11 @@ module Database.LSMTree.Internal.Snapshot.Codec (
   , prettySnapshotVersion
   , currentSnapshotVersion
   , allCompatibleSnapshotVersions
+    -- * Errors
+  , SnapshotVersionMismatchError (..)
+  , snapshotVersionFromWord
+  , checkVersionCompatibility
+  , decodeVersionHeader
     -- * Writing and reading files
   , writeFileSnapshotMetaData
   , readFileSnapshotMetaData
@@ -94,6 +99,44 @@ isCompatible otherVersion
   = Right ()
   | otherwise = Left "forward compatibility not supported"
 
+-- | Convert a raw version number to a known snapshot version.
+--
+-- Returns 'Nothing' for version numbers that are not known to this version of
+-- the library.
+snapshotVersionFromWord :: Word -> Maybe SnapshotVersion
+snapshotVersionFromWord 0 = Just V0
+snapshotVersionFromWord 1 = Just V1
+snapshotVersionFromWord 2 = Just V2
+snapshotVersionFromWord _ = Nothing
+
+-- | Check whether a raw version number found in snapshot metadata is
+-- compatible with the current snapshot version of the library.
+--
+-- Returns an explanation of the incompatibility if the version number is
+-- unknown to this version of the library, or known but incompatible.
+checkVersionCompatibility :: Word -> Either String SnapshotVersion
+checkVersionCompatibility versionNum =
+  case snapshotVersionFromWord versionNum of
+    Nothing ->
+      Left ("unknown snapshot format version number: " <> show versionNum)
+    Just version ->
+      version <$ isCompatible version
+
+-- | The snapshot metadata declares a snapshot format version that is
+-- incompatible with the current snapshot version of the library.
+data SnapshotVersionMismatchError
+    = ErrSnapshotVersionMismatch
+        -- | The version number found in the snapshot metadata. This is a raw
+        -- number because it may not correspond to any 'SnapshotVersion' that
+        -- is known to this version of the library.
+        !Word
+        -- | The current snapshot version of the library.
+        !SnapshotVersion
+        -- | An explanation of the incompatibility.
+        !String
+    deriving stock (Show, Eq)
+    deriving anyclass (Exception)
+
 {-------------------------------------------------------------------------------
   Writing and reading files
 -------------------------------------------------------------------------------}
@@ -138,6 +181,10 @@ encodeSnapshotMetaData = toLazyByteString . encode . Versioned
   #-}
 -- | Read from 'SnapshotMetaDataFile' and attempt to decode it to
 -- 'SnapshotMetaData'.
+--
+-- Throws a 'SnapshotVersionMismatchError' if the snapshot metadata declares a
+-- snapshot format version that is incompatible with the current snapshot
+-- version of the library.
 readFileSnapshotMetaData ::
      (MonadThrow m)
   => HasFS m h
@@ -156,10 +203,36 @@ readFileSnapshotMetaData hfs contentPath checksumPath = do
 
     expectChecksum hfs contentPath expectedChecksum actualChecksum
 
-    expectValidFile hfs contentPath FormatSnapshotMetaData (decodeSnapshotMetaData lbs)
+    -- Decode and check the version header before decoding the payload, so
+    -- that a version mismatch is reported as a 'SnapshotVersionMismatchError'
+    -- instead of a generic parse failure.
+    (rest, versionNum) <-
+      expectValidFile hfs contentPath FormatSnapshotMetaData (decodeVersionHeader lbs)
+    version <- case checkVersionCompatibility versionNum of
+      Right version -> pure version
+      Left errMsg   ->
+        throwIO (ErrSnapshotVersionMismatch versionNum currentSnapshotVersion errMsg)
+    expectValidFile hfs contentPath FormatSnapshotMetaData (decodeSnapshotMetaData version rest)
 
-decodeSnapshotMetaData :: ByteString -> Either String SnapshotMetaData
-decodeSnapshotMetaData lbs = bimap displayException (getVersioned . snd) (deserialiseFromBytes decode lbs)
+-- | Decode only the version header of versioned snapshot metadata: the
+-- 'Versioned' list wrapper and the version number. Returns the remaining,
+-- undecoded input, from which the metadata itself can be decoded using
+-- 'decodeSnapshotMetaData'.
+decodeVersionHeader :: ByteString -> Either String (ByteString, Word)
+decodeVersionHeader lbs =
+    first displayException (deserialiseFromBytes headerDecoder lbs)
+  where
+    headerDecoder = do
+      _ <- decodeListLenOf 2 -- 'Versioned' wrapper
+      _ <- decodeListLenOf 1 -- 'SnapshotVersion' wrapper
+      decodeWord
+
+-- | Decode 'SnapshotMetaData' using the versioned decoder for the given
+-- version. The input should be the remaining input as returned by
+-- 'decodeVersionHeader'.
+decodeSnapshotMetaData :: SnapshotVersion -> ByteString -> Either String SnapshotMetaData
+decodeSnapshotMetaData version rest =
+    bimap displayException snd (deserialiseFromBytes (decodeVersioned version) rest)
 
 {-------------------------------------------------------------------------------
   Encoding and decoding
@@ -223,11 +296,9 @@ instance Decode SnapshotVersion where
   decode = do
       _ <- decodeListLenOf 1
       ver <- decodeWord
-      case ver of
-        0 -> pure V0
-        1 -> pure V1
-        2 -> pure V2
-        _ -> fail ("Unknown snapshot format version number: " <>  show ver)
+      case snapshotVersionFromWord  ver of
+        Just version -> pure version
+        Nothing -> fail ("Unknown snapshot format version number: " <>  show ver)
 
 {-------------------------------------------------------------------------------
   Encoding and decoding: SnapshotMetaData

--- a/lsm-tree/src-core/Database/LSMTree/Internal/Unsafe.hs
+++ b/lsm-tree/src-core/Database/LSMTree/Internal/Unsafe.hs
@@ -23,6 +23,7 @@ module Database.LSMTree.Internal.Unsafe (
   , SnapshotExistsError (..)
   , SnapshotDoesNotExistError (..)
   , SnapshotCorruptedError (..)
+  , SnapshotVersionMismatchError (..)
   , SnapshotNotCompatibleError (..)
   , SnapshotImportDirDoesNotExistError (..)
   , SnapshotExportDirExistsError (..)

--- a/lsm-tree/src/Database/LSMTree.hs
+++ b/lsm-tree/src/Database/LSMTree.hs
@@ -183,6 +183,7 @@ module Database.LSMTree (
   SnapshotExistsError (..),
   SnapshotDoesNotExistError (..),
   SnapshotCorruptedError (..),
+  SnapshotVersionMismatchError (..),
   SnapshotNotCompatibleError (..),
   SnapshotImportDirDoesNotExistError (..),
   SnapshotExportDirExistsError (..),
@@ -260,7 +261,8 @@ import           Database.LSMTree.Internal.Unsafe (BlobRefInvalidError (..),
                      SnapshotDoesNotExistError (..), SnapshotExistsError (..),
                      SnapshotExportDirExistsError (..),
                      SnapshotImportDirDoesNotExistError (..), SnapshotMode (..),
-                     SnapshotNotCompatibleError (..), TableClosedError (..),
+                     SnapshotNotCompatibleError (..),
+                     SnapshotVersionMismatchError (..), TableClosedError (..),
                      TableCorruptedError (..), TableTooLargeError (..),
                      TableTrace, TableUnionNotCompatibleError (..),
                      UnionCredits (..), UnionDebt (..))
@@ -2633,6 +2635,8 @@ Throws the following exceptions:
     If the table is closed.
 ['SnapshotDoesNotExistError']
     If no snapshot with the given name exists.
+['SnapshotVersionMismatchError']:
+    If the snapshot was created with an incompatible snapshot format version.
 ['SnapshotCorruptedError']:
     If the snapshot data is corrupted.
 ['SnapshotNotCompatibleError']:
@@ -2718,6 +2722,8 @@ Throws the following exceptions:
     If the table is closed.
 ['SnapshotDoesNotExistError']
     If no snapshot with the given name exists.
+['SnapshotVersionMismatchError']:
+    If the snapshot was created with an incompatible snapshot format version.
 ['SnapshotCorruptedError']:
     If the snapshot data is corrupted.
 ['SnapshotNotCompatibleError']:

--- a/lsm-tree/src/Database/LSMTree/Simple.hs
+++ b/lsm-tree/src/Database/LSMTree/Simple.hs
@@ -151,6 +151,7 @@ module Database.LSMTree.Simple (
     SnapshotExistsError (..),
     SnapshotDoesNotExistError (..),
     SnapshotCorruptedError (..),
+    SnapshotVersionMismatchError (..),
     SnapshotNotCompatibleError (..),
     SnapshotImportDirDoesNotExistError (..),
     SnapshotExportDirExistsError (..),
@@ -178,7 +179,8 @@ import           Database.LSMTree (BloomFilterAlloc, CursorClosedError (..),
                      SnapshotCorruptedError (..),
                      SnapshotDoesNotExistError (..), SnapshotExistsError (..),
                      SnapshotLabel (..), SnapshotName,
-                     SnapshotNotCompatibleError (..), TableClosedError (..),
+                     SnapshotNotCompatibleError (..),
+                     SnapshotVersionMismatchError (..), TableClosedError (..),
                      TableConfig (..), TableConfigOverride (..),
                      TableCorruptedError (..), TableTooLargeError (..),
                      UnionCredits (..), UnionDebt (..), WriteBufferAlloc,
@@ -1437,6 +1439,8 @@ Throws the following exceptions:
     If the table is closed.
 ['SnapshotDoesNotExistError']
     If no snapshot with the given name exists.
+['SnapshotVersionMismatchError']:
+    If the snapshot was created with an incompatible snapshot format version.
 ['SnapshotCorruptedError']:
     If the snapshot data is corrupted.
 ['SnapshotNotCompatibleError']:
@@ -1483,6 +1487,8 @@ Throws the following exceptions:
     If no snapshot with the given name exists.
 ['SnapshotCorruptedError']:
     If the snapshot data is corrupted.
+['SnapshotVersionMismatchError']:
+    If the snapshot was created with an incompatible snapshot format version.
 ['SnapshotNotCompatibleError']:
     If the snapshot has a different label or is a different table type.
 -}

--- a/lsm-tree/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
+++ b/lsm-tree/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs
@@ -39,6 +39,17 @@ tests = testGroup "Test.Database.LSMTree.Internal.Snapshot.Codec" [
         , testProperty "roundtripCBOR" $ roundtripCBOR (Proxy @SnapshotVersion)
         , testProperty "roundtripFlatTerm" $ roundtripFlatTerm (Proxy @SnapshotVersion)
         ]
+     , testGroup "SnapshotVersionMismatchError" [
+          testProperty "unknown versions are incompatible" $ \(NonNegative n) ->
+            let versionNum = 3 + fromIntegral (n :: Int) in
+            case checkVersionCompatibility versionNum of
+              Left _  -> property True
+              Right v -> counterexample ("unexpectedly compatible: " <> show v) False
+        , testProperty "decodeVersionHeader agrees with encodeSnapshotMetaData" $ \metadata ->
+            case decodeVersionHeader (encodeSnapshotMetaData metadata) of
+              Left err     -> counterexample err False
+              Right (_, w) -> snapshotVersionFromWord w === Just currentSnapshotVersion
+        ]
     , testGroup "Versioned SnapshotMetaData" [
           testProperty "roundtripCBOR" $ roundtripCBOR (Proxy @(Versioned SnapshotMetaData))
         , testProperty "roundtripFlatTerm" $ roundtripFlatTerm (Proxy @(Versioned SnapshotMetaData))

--- a/lsm-tree/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
+++ b/lsm-tree/test/Test/Database/LSMTree/Internal/Snapshot/FS.hs
@@ -3,10 +3,14 @@
 -- | Tests for snapshots and their interaction with the file system
 module Test.Database.LSMTree.Internal.Snapshot.FS (tests) where
 
+import           Codec.CBOR.Encoding (encodeListLen, encodeWord)
+import           Codec.CBOR.Write (toLazyByteString)
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Tracer
 import           Data.Bifunctor (Bifunctor (..))
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
 import           Data.Word
 import           Database.LSMTree.Extras (showPowersOf10)
@@ -15,6 +19,7 @@ import qualified Database.LSMTree.Internal.BloomFilter as Bloom
 import           Database.LSMTree.Internal.Config
 import           Database.LSMTree.Internal.Config.Override
                      (noTableConfigOverride)
+import           Database.LSMTree.Internal.CRC32C
 import           Database.LSMTree.Internal.Entry
 import           Database.LSMTree.Internal.Paths
 import           Database.LSMTree.Internal.Serialise
@@ -39,6 +44,7 @@ tests = testGroup "Test.Database.LSMTree.Internal.Snapshot.FS" [
     , testProperty "prop_fault_fsRoundtripSnapshotMetaData"
         prop_fault_fsRoundtripSnapshotMetaData
     , testProperty "prop_flipSnapshotBit" prop_flipSnapshotBit
+    , testProperty "prop_versionMismatch" prop_versionMismatch
     ]
 
 -- | @readFileSnapshotMetaData . writeFileSnapshotMetaData = id@
@@ -228,3 +234,37 @@ prop_flipSnapshotBit (Positive (Small bufferSize)) es pickFileBit =
         openTableFromSnapshot noTableConfigOverride s snapName snapLabel resolve
 
     getConstructorName e = takeWhile (/= ' ') (show e)
+
+-- | Reading snapshot metadata that declares an unknown (future) snapshot
+-- format version fails with a 'SnapshotVersionMismatchError', not with a
+-- generic 'FileCorruptedError'.
+prop_versionMismatch :: NonNegative Int -> Property
+prop_versionMismatch (NonNegative n) =
+    ioProperty $
+    withTempIOHasFS "temp" $ \hfs -> do
+      -- Write a metadata file that declares a future format version. The
+      -- payload does not matter: the version is checked before the payload is
+      -- decoded.
+      let lbs = toLazyByteString $
+                   encodeListLen 2 -- 'Versioned' wrapper
+                <> encodeListLen 1 -- 'SnapshotVersion' wrapper
+                <> encodeWord versionNum
+      (_, checksum) <-
+        FS.withFile hfs contentPath (FS.WriteMode FS.MustBeNew) $ \h ->
+          hPutAllChunksCRC32C hfs h lbs initialCRC32C
+      let checksumFileName = ChecksumsFileName (BSC.pack "metadata")
+      writeChecksumsFile hfs checksumPath
+        (Map.singleton checksumFileName checksum)
+
+      result <-
+        try @_ @SnapshotVersionMismatchError $
+          readFileSnapshotMetaData hfs contentPath checksumPath
+      pure $ case result of
+        Left (ErrSnapshotVersionMismatch found current _) ->
+          found === versionNum .&&. current === currentSnapshotVersion
+        Right _ ->
+          counterexample "expected SnapshotVersionMismatchError" False
+  where
+    versionNum   = 3 + fromIntegral n
+    contentPath  = mkFsPath ["content"]
+    checksumPath = mkFsPath ["checksum"]


### PR DESCRIPTION
# Description
Resolves #862 and #864.

Right now a version mismatch comes out as a `SnapshotCorruptedError` wrapping `ErrFileFormatInvalid`, with the actual version buried in the message string. This adds a dedicated `SnapshotVersionMismatchError` so it can be caught separately from real corruption.

The awkward part is that the check happens inside a CBOR `Decoder`, where `fail :: String -> Decoder s a` is the only exit, so there's no way to throw a typed exception from in there. `readFileSnapshotMetaData` now decodes in two phases instead: read the version header, check compatibility, then decode the payload with the versioned decoder. `deserialiseFromBytes` returns the leftover bytes, so this doesn't cost a second parse over the file.
Note `isCompatible` can't return `Left` today — every constructor is in `allCompatibleSnapshotVersions` — so the only reachable mismatch is a snapshot from a *newer* library, which has no `SnapshotVersion` constructor here. Hence the found version is a raw `Word`. Checksum and parse failures still throw `SnapshotCorruptedError`.

This is breaking: code catching `SnapshotCorruptedError` for version mismatches will quietly stop catching them, and still compile.

Tests: 
compatibility-check and header-decoding properties in `lsm-tree/test/Test/Database/LSMTree/Internal/Snapshot/Codec.hs`; `prop_versionMismatch` in `lsm-tree/test/Test/Database/LSMTree/Internal/Snapshot` writes metadata with a future version and checks what comes back.

[link]( https://github.com/IntersectMBO/lsm-tree/issues/862)


# Checklist

- [x] Read our contribution guidelines at [CONTRIBUTING.md](https://github.com/IntersectMBO/lsm-tree/blob/main/CONTRIBUTING.md), and make sure that this PR complies with the guidelines.
- [x] cabal build all and cabal test all pass (GHC 9.6.7)
- [x] stylish-haskell 0.15.1.0 applied
<img width="948" height="958" alt="image" src="https://github.com/user-attachments/assets/12e3aa48-8b5b-40d2-af90-07e74d2045e5" />

