### PR TITLE
`CI`: configure mirrors for apt

### DIFF
--- a/.github/actions/fast-apt-mirror/action.yml
+++ b/.github/actions/fast-apt-mirror/action.yml
@@ -1,0 +1,17 @@
+name: "Configure Fast APT Mirror"
+description: "Configure Fast APT Mirror"
+runs:
+  using: composite
+  steps:
+    # Some mirrors for the Ubuntu software repositories, like Microsoft
+    # Azure-hosted ones, are sometimes unstable. This is a known issue (see links
+    # below). This can cause apt-get commands to be prohibitively slow, causing CI
+    # jobs to time out. We use fast-apt-mirror to pick suitable alternative
+    # mirrors.
+    #
+    # <https://github.com/actions/runner-images/issues?q=is%3Aissue+azure.archive.ubuntu.com>
+    # <https://github.com/actions/runner-images/issues/12949>
+    # <https://github.com/actions/runner-images/issues/7048>
+    - name: 🛠️ Configure Fast APT Mirror (Linux)
+      if: ${{ runner.os == 'Linux' }}
+      uses: vegardit/fast-apt-mirror.sh@v1

--- a/.github/workflows/check-release-builds.yml
+++ b/.github/workflows/check-release-builds.yml
@@ -78,6 +78,7 @@ jobs:
 
     - name: 🛠️ Setup system dependencies (Linux)
       if: ${{ runner.os == 'Linux' }}
+      timeout-minutes: 10
       run: sudo apt-get update && sudo apt-get -y install liburing-dev librocksdb-dev
       env:
         DEBIAN_FRONTEND: "noninteractive"

--- a/.github/workflows/check-release-builds.yml
+++ b/.github/workflows/check-release-builds.yml
@@ -60,6 +60,8 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v7
 
+    - uses: ./.github/actions/fast-apt-mirror
+
     - name: 🗄️ Print Job info
       run: |
         echo 'matrix.os: ${{ matrix.os }}'

--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -35,6 +35,8 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v7
 
+    - uses: ./.github/actions/fast-apt-mirror
+
     # We are currently only testing blockio because that is where the
     # FreeBSD-specific code lives, not in lsm-tree.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,8 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v7
 
+    - uses: ./.github/actions/fast-apt-mirror
+
     - name: 🗄️ Print Job info
       run: |
         echo 'matrix.os: ${{ matrix.os }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
 
     - name: 🛠️ Setup system dependencies (Linux)
       if: ${{ runner.os == 'Linux' }}
+      timeout-minutes: 10
       run: sudo apt-get update && sudo apt-get -y install liburing-dev librocksdb-dev
       env:
         DEBIAN_FRONTEND: "noninteractive"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,6 +42,8 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v7
 
+    - uses: ./.github/actions/fast-apt-mirror
+
     - name: 🛠️ Setup Haskell
       id: setup-haskell
       uses:  haskell-actions/setup@v2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -53,6 +53,7 @@ jobs:
 
     - name: 🛠️ Setup system dependencies (Linux)
       if: ${{ runner.os == 'Linux' }}
+      timeout-minutes: 10
       run: sudo apt-get update && sudo apt-get -y install liburing-dev librocksdb-dev
       env:
         DEBIAN_FRONTEND: "noninteractive"


### PR DESCRIPTION
Some mirrors for the Ubuntu software repositories, like Microsoft Azure-hosted ones, are sometimes unstable. This is a known issue. This can cause apt-get commands to be prohibitively slow, causing CI jobs to time out. We use fast-apt-mirror to pick suitable alternative mirrors.
